### PR TITLE
Added rake task for dropping test databases (wraps rake db:drop)

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -11,6 +11,11 @@ namespace :parallel do
     run_in_parallel('rake db:create RAILS_ENV=test', args)
   end
 
+  desc "drop test databases via db:drop --> parallel:drop[num_cpus]"
+  task :drop, :count do |t,args|
+     run_in_parallel('rake db:drop RAILS_ENV=test', args)
+  end
+
   desc "update test databases by dumping and loading --> parallel:prepare[num_cpus]"
   task(:prepare, [:count] => 'db:abort_if_pending_migrations') do |t,args|
     if ActiveRecord::Base.schema_format == :ruby


### PR DESCRIPTION
In our continuous integration build script we like to start from a completely fresh database as rails doesn't always deal well with our complex postgres schema.

So we run...
rake parallel:drop
rake parallel:create
rake parallel:migrate

I didn't update the README as I wasn't sure if that was appropriate

Cheers
PS: This gem has provided our team with the biggest productivity gain in months.
