### PR TITLE
SpecSummaryLogger and SpecFailuresLogger

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-Speedup Test::Unit + RSpec + Cucumber by running parallel on multiple CPUs(or cores).
+Speedup Test::Unit + RSpec + Cucumber by running parallel on multiple CPUs (or cores).
 
 Setup for Rails
 ===============
@@ -59,6 +59,7 @@ OR as plugin
     ...
 
 Test just a subfolder (e.g. use one integration server per subfolder)
+
     rake parallel:test[models]
     rake parallel:test[something/else]
 
@@ -76,10 +77,14 @@ Example output
 
     Took 29.925333 seconds
 
-Even process runtimes (for specs only)
+Spec Loggers
+===================
+
+Even process runtimes
 -----------------
 
-Log test runtime to give each process the same test runtime.<br/>
+Log test runtime to give each process the same test runtime.
+
 Add to your `spec/parallel_spec.opts` (or `spec/spec.opts`) :
 
     RSpec 1.x:
@@ -90,6 +95,36 @@ Add to your `spec/parallel_spec.opts` (or `spec/spec.opts`) :
       --format progress
       --format ParallelSpecs::SpecRuntimeLogger --out tmp/parallel_profile.log
 
+SpecSummaryLogger
+--------------------
+
+This logger stops the different processes overwriting each other's output.
+
+Add the following to your `spec/parallel_spec.opts` (or `spec/spec.opts`) :
+
+    RSpec 1.x:
+      --format progress
+      --format ParallelSpecs::SpecSummaryLogger:tmp/spec_summary.log
+    RSpec >= 2.2:
+      --format progress
+      --format ParallelSpecs::SpecSummaryLogger --out tmp/spec_summary.log
+
+SpecFailuresLogger
+-----------------------
+
+This logger produces command lines for running any failing examples.
+
+E.g.
+
+    spec /path/to/my_spec.rb -e "should do something"
+
+Add the following to your `spec/parallel_spec.opts` (or `spec/spec.opts`) :
+
+    RSpec 1.x:
+      --format ParallelSpecs::SpecFailuresLogger:tmp/failing_specs.log
+    RSpec >= 2.2:
+      --format ParallelSpecs::SpecFailuresLogger --out tmp/failing_specs.log
+
 Setup for non-rails
 ===================
     sudo gem install parallel_tests
@@ -98,9 +133,11 @@ Setup for non-rails
     # [Optional] use ENV['TEST_ENV_NUMBER'] inside your tests to select separate db/memcache/etc.
 
 [optional] Only run selected files & folders:
+
     parallel_test test/bar test/baz/xxx_text.rb
 
 Options are:
+
     -n [PROCESSES]                   How many processes to use, default: available CPUs
     -p, --path [PATH]                run tests inside this path only
         --no-sort                    do not sort files before running them
@@ -114,6 +151,7 @@ Options are:
     -h, --help                       Show this.
 
 You can run any kind of code with -e / --execute
+
     parallel_test -n 5 -e 'ruby -e "puts %[hello from process #{ENV[:TEST_ENV_NUMBER.to_s].inspect}]"'
     hello from process "2"
     hello from process ""

--- a/lib/parallel_specs/spec_failures_logger.rb
+++ b/lib/parallel_specs/spec_failures_logger.rb
@@ -1,0 +1,25 @@
+require 'parallel_specs'
+require File.join(File.dirname(__FILE__), 'spec_logger_base')
+
+class ParallelSpecs::SpecFailuresLogger < ParallelSpecs::SpecLoggerBase
+  def initialize(options, output=nil)
+    super
+    @failed_examples = []
+  end
+
+  def example_failed(example, count, failure)
+    @failed_examples << example
+  end
+
+  def dump_failure(*args)
+    lock_output do
+      @failed_examples.each.with_index do | example, i |
+        spec_file = example.location.scan(/^[^:]+/)[0]
+        spec_file.gsub!(%r(^.*?/spec/), './spec/')
+        @output.puts "#{ParallelSpecs.executable} #{spec_file} -e \"#{example.description}\""
+      end
+    end
+    @output.flush
+  end
+
+end

--- a/lib/parallel_specs/spec_logger_base.rb
+++ b/lib/parallel_specs/spec_logger_base.rb
@@ -1,0 +1,72 @@
+require 'parallel_specs'
+
+begin
+  require 'rspec/core/formatters/progress_formatter'
+  base = RSpec::Core::Formatters::ProgressFormatter
+rescue LoadError
+  require 'spec/runner/formatter/progress_bar_formatter'
+  base = Spec::Runner::Formatter::BaseTextFormatter
+end
+ParallelSpecs::SpecLoggerBaseBase = base
+
+class ParallelSpecs::SpecLoggerBase < ParallelSpecs::SpecLoggerBaseBase
+  def initialize(options, output=nil)
+    output ||= options # rspec 2 has output as first argument
+
+    if String === output
+      FileUtils.mkdir_p(File.dirname(output))
+      File.open(output, 'w'){} # overwrite previous results
+      @output = File.open(output, 'a')
+    elsif File === output
+      output.close # close file opened with 'w'
+      @output = File.open(output.path, 'a')
+    else
+      @output = output
+    end
+
+    @failed_examples = [] # only needed for rspec 2
+  end
+
+  def example_started(*args)
+  end
+
+  def example_passed(example)
+  end
+
+  def example_pending(*args)
+  end
+
+  def example_failed(*args)
+  end
+
+  def start_dump(*args)
+  end
+
+  def dump_summary(*args)
+  end
+
+  def dump_pending(*args)
+  end
+
+  def dump_failure(*args)
+  end
+
+  #stolen from Rspec
+  def close
+    @output.close  if (IO === @output) & (@output != $stdout)
+  end
+
+  # do not let multiple processes get in each others way
+  def lock_output
+    if File === @output
+      begin
+        @output.flock File::LOCK_EX
+        yield
+      ensure
+        @output.flock File::LOCK_UN
+      end
+    else
+      yield
+    end
+  end
+end

--- a/lib/parallel_specs/spec_runtime_logger.rb
+++ b/lib/parallel_specs/spec_runtime_logger.rb
@@ -1,31 +1,10 @@
 require 'parallel_specs'
+require File.join(File.dirname(__FILE__), 'spec_logger_base')
 
-begin
-  require 'rspec/core/formatters/progress_formatter'
-  base = RSpec::Core::Formatters::ProgressFormatter
-rescue LoadError
-  require 'spec/runner/formatter/progress_bar_formatter'
-  base = Spec::Runner::Formatter::BaseTextFormatter
-end
-ParallelSpecs::SpecRuntimeLoggerBase = base
-
-class ParallelSpecs::SpecRuntimeLogger < ParallelSpecs::SpecRuntimeLoggerBase
+class ParallelSpecs::SpecRuntimeLogger < ParallelSpecs::SpecLoggerBase
   def initialize(options, output=nil)
-    output ||= options # rspec 2 has output as first argument
-
-    if String === output
-      FileUtils.mkdir_p(File.dirname(output))
-      File.open(output, 'w'){} # overwrite previous results
-      @output = File.open(output, 'a')
-    elsif File === output
-      output.close # close file opened with 'w'
-      @output = File.open(output.path, 'a')
-    else
-      @output = output
-    end
-
+    super
     @example_times = Hash.new(0)
-    @failed_examples = [] # only needed for rspec 2
   end
 
   def example_started(*args)
@@ -46,39 +25,4 @@ class ParallelSpecs::SpecRuntimeLogger < ParallelSpecs::SpecRuntimeLoggerBase
     @output.flush
   end
 
-  # stubs so that rspec doe not crash
-
-  def example_pending(*args)
-  end
-
-  def example_failed(*args)
-  end
-
-  def dump_summary(*args)
-  end
-
-  def dump_pending(*args)
-  end
-
-  def dump_failure(*args)
-  end
-
-  #stolen from Rspec
-  def close
-    @output.close  if (IO === @output) & (@output != $stdout)
-  end
-
-  # do not let multiple processes get in each others way
-  def lock_output
-    if File === @output
-      begin
-        @output.flock File::LOCK_EX
-        yield
-      ensure
-        @output.flock File::LOCK_UN
-      end
-    else
-      yield
-    end
-  end
 end

--- a/lib/parallel_specs/spec_summary_logger.rb
+++ b/lib/parallel_specs/spec_summary_logger.rb
@@ -1,0 +1,47 @@
+require 'parallel_specs'
+require File.join(File.dirname(__FILE__), 'spec_logger_base')
+
+class ParallelSpecs::SpecSummaryLogger < ParallelSpecs::SpecLoggerBase
+  def initialize(options, output=nil)
+    super
+    @passed_examples = []
+    @pending_examples = []
+    @failed_examples = []
+  end
+
+  def example_passed(example)
+    @passed_examples << example
+  end
+
+  def example_pending(*args)
+    @pending_examples << args
+  end
+
+  def example_failed(example, count, failure)
+    @failed_examples << failure
+  end
+
+  def dump_summary(duration, example_count, failure_count, pending_count)
+    lock_output do
+      @output.puts "#{ @passed_examples.size } examples passed"
+    end
+    @output.flush
+  end
+
+  def dump_failure(*args)
+    lock_output do
+      @output.puts "#{ @failed_examples.size } examples failed:"
+      @failed_examples.each.with_index do | failure, i |
+        @output.puts "#{ i + 1 })"
+        @output.puts failure.header
+        @output.puts failure.exception.to_s
+        failure.exception.backtrace.each do | caller |
+          @output.puts caller
+        end
+        @output.puts ''
+      end
+    end
+    @output.flush
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,8 +54,12 @@ def test_tests_in_groups(klass, folder, suffix)
       end
 
       @log = klass.runtime_log
-      `mkdir #{File.dirname(@log)}`
+      `mkdir -p #{File.dirname(@log)}`
       `rm -f #{@log}`
+    end
+
+    after :all do
+      `rm -f #{klass.runtime_log}`
     end
 
     it "groups when given an array of files" do


### PR DESCRIPTION
Hello,

I've squashed my commits into one in order to make a single pull request.

Rationale:
The motivation behind the addition of the loggers is that I work on a project with many thousands of specs, so one change sometimes causes a lot of breakage, and the current gem garbles the output.

SpecFailuresLogger should be handy as it lists failing specs in an executable form so you can fix them one by one before re-running the whole suite.

SpecSummaryLogger simply lists output as per non-parallel rspec execution, but avoids any scrambling due to parallel processes.

Regards,
Joe
