### PR TITLE
Added /usr/bin/env prefix to base ruby call in parallel_tests.rb

### DIFF
--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -30,7 +30,7 @@ class ParallelTests
 
   def self.run_tests(test_files, process_number, options)
     require_list = test_files.map { |filename| "\"#{filename}\"" }.join(",")
-    cmd = "ruby -Itest #{options[:test_options]} -e '[#{require_list}].each {|f| require f }'"
+    cmd = "/usr/bin/env ruby -Itest #{options[:test_options]} -e '[#{require_list}].each {|f| require f }'"
     execute_command(cmd, process_number, options)
   end
 


### PR DESCRIPTION
Added /usr/bin/env prefix to base ruby call in parallel_tests.rb - helps with Ruby EE. Had to do this locally on our CI server to make sure it was calling the correct ruby.
