### PR TITLE
rspec2 now handles -O like rspec1 did

### DIFF
--- a/lib/parallel_specs.rb
+++ b/lib/parallel_specs.rb
@@ -42,12 +42,7 @@ class ParallelSpecs < ParallelTests
   def self.spec_opts(rspec_version)
     options_file = ['spec/parallel_spec.opts', 'spec/spec.opts'].detect{|f| File.file?(f) }
     return unless options_file
-    if rspec_version == 2
-      # does not handle -O, so we inline the options
-      File.read(options_file).tr("\n", ' ')
-    else
-      "-O #{options_file}"
-    end
+    "-O #{options_file}"
   end
 
   def self.test_suffix

--- a/spec/parallel_specs_spec.rb
+++ b/spec/parallel_specs_spec.rb
@@ -108,14 +108,13 @@ describe ParallelSpecs do
       ParallelSpecs.run_tests(['xxx'],1,'')
     end
 
-    it "uses inline options with rspec2" do
+    it "uses -O spec/parallel_spec.opts with rspec2" do
       File.should_receive(:file?).with('spec/parallel_spec.opts').and_return true
-      File.should_receive(:read).with('spec/parallel_spec.opts').and_return "--foo\n--bar\n"
 
       ParallelSpecs.stub!(:bundler_enabled?).and_return true
-      ParallelSpecs.stub!(:run).with("bundle show rspec").and_return "/foo/bar/rspec-2.0.2"
+      ParallelSpecs.stub!(:run).with("bundle show rspec").and_return "/foo/bar/rspec-2.4.2"
 
-      ParallelSpecs.should_receive(:open).with{|x,y| x =~ %r{rspec\s+ --tty --foo --bar}}.and_return mocked_process
+      ParallelSpecs.should_receive(:open).with{|x,y| x =~ %r{rspec\s+ --tty -O spec/parallel_spec.opts}}.and_return mocked_process
       ParallelSpecs.run_tests(['xxx'],1,'')
     end
 


### PR DESCRIPTION
To me this is slightly more convenient - one less codepath in parallel_tests, and when rspec reads a .opts file it passes it through yaml (I'm using this to mate parallel_tests with spork, running multiple spork instances)
