### PR TITLE
Limit to load files by pattern

### DIFF
--- a/bin/parallel_test
+++ b/bin/parallel_test
@@ -18,6 +18,7 @@ Options are:
 BANNER
   opts.on("-n [PROCESSES]", Integer, "How many processes to use, default: available CPUs"){|n| options[:count] = n }
   opts.on("-p", '--path [PATH]', "run tests inside this path only"){|path| options[:path_prefix] = path }
+  opts.on("-P", '--pattern [PATTERN]', "limit files loaded to those matching this pattern."){|path| options[:pattern] = path }
   opts.on("--no-sort", "do not sort files before running them"){ |no_sort| options[:no_sort] = no_sort }
   opts.on("-m [FLOAT]", "--multiply-processes [FLOAT]", Float, "use given number as a multiplier of processes to run"){ |multiply| options[:multiply] = multiply }
   opts.on("-r", '--root [PATH]', "execute test commands from this path"){|path| options[:root] = path }
@@ -63,7 +64,7 @@ else
   tests_folder = File.join(task, options[:path_prefix].to_s)
   tests_folder = File.join(options[:root], tests_folder) unless options[:root].to_s.empty?
 
-  groups = klass.tests_in_groups(options[:files] || tests_folder, num_processes, :no_sort => options[:no_sort])
+  groups = klass.tests_in_groups(options[:files] || tests_folder, num_processes, :no_sort => options[:no_sort], :pattern => options[:pattern])
   num_processes = groups.size
 
   #adjust processes to groups

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -43,12 +43,13 @@ namespace :parallel do
 
   ['test', 'spec', 'features'].each do |type|
     desc "run #{type} in parallel with parallel:#{type}[num_cpus]"
-    task type, :count, :path_prefix, :options do |t,args|
+    task type, :count, :path_prefix, :options, :patterns do |t,args|
       $LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), '..'))
       require "parallel_tests"
-      count, prefix, options = ParallelTests.parse_rake_args(args)
+      count, prefix, options, patterns = ParallelTests.parse_rake_args(args)
       executable = File.join(File.dirname(__FILE__), '..', '..', 'bin', 'parallel_test')
-      command = "#{executable} --type #{type} -n #{count} -p '#{prefix}' -r '#{Rails.root}' -o '#{options}'"
+      patterns = "-P '#{patterns}'" if patterns
+      command = "#{executable} --type #{type} -n #{count} -p '#{prefix}' -r '#{Rails.root}' -o '#{options}' #{patterns}"
       abort unless system(command) # allow to chain tasks e.g. rake parallel:spec parallel:features
     end
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -108,4 +108,14 @@ describe 'CLI' do
     result = run_specs(:add => "--test-options ' --version'", :processes => 2)
     result.should =~ /\d+\.\d+\.\d+.*\d+\.\d+\.\d+/m # prints version twice
   end
+
+  it 'can run with test patterns' do
+    write 'test1_spec.rb', 'describe("it"){it("should"){puts "TEST1"}}'
+    write 'test2_spec.rb', 'describe("it"){it("should"){puts "TEST2"}}'
+    write 'test3_spec.rb', 'describe("it"){it("should"){puts "TEST3"}}'
+    result = run_specs(:add => "-P '**/test1_spec.rb,**/test2_spec.rb'")
+    result.should include('TEST1')
+    result.should include('TEST2')
+    result.should_not include('TEST3')
+  end
 end

--- a/spec/parallel_tests_spec.rb
+++ b/spec/parallel_tests_spec.rb
@@ -6,22 +6,27 @@ describe ParallelTests do
   describe :parse_rake_args do
     it "should return the count" do
       args = {:count => 2}
-      ParallelTests.parse_rake_args(args).should == [2, '', ""]
+      ParallelTests.parse_rake_args(args).should == [2, '', "", '']
     end
 
     it "should default to the prefix" do
       args = {:count => "models"}
-      ParallelTests.parse_rake_args(args).should == [Parallel.processor_count, "models", ""]
+      ParallelTests.parse_rake_args(args).should == [Parallel.processor_count, "models", "", '']
     end
 
     it "should return the count and prefix" do
       args = {:count => 2, :path_prefix => "models"}
-      ParallelTests.parse_rake_args(args).should == [2, "models", ""]
+      ParallelTests.parse_rake_args(args).should == [2, "models", "", '']
     end
 
     it "should return the count, prefix, and options" do
       args = {:count => 2, :path_prefix => "plain", :options => "-p default" }
-      ParallelTests.parse_rake_args(args).should == [2, "plain", "-p default"]
+      ParallelTests.parse_rake_args(args).should == [2, "plain", "-p default", '']
+    end
+
+    it "should return the count, prefix, options, and patterns" do
+      args = {:count => 2, :path_prefix => "plain", :options => "-p default", :patterns => "**/**/*_spec.rb" }
+      ParallelTests.parse_rake_args(args).should == [2, "plain", "-p default", "**/**/*_spec.rb"]
     end
   end
 


### PR DESCRIPTION
Hi

I'm running specs through a symbolic link, however, the following code doesn't match a symbolic directory.

``` ruby
Dir["#{root}**/**/*#{self.test_suffix}"]
```

I need to specify the pattern as follows:

``` ruby
Dir["#{root}*/**/*#{self.test_suffix}"]
```

Then I add the -P option. This is how the rspec pattern option works. 

I hope this is helpful.
