### PR TITLE
Support PARALLEL_PROCESSOR_COUNT env var in parallel:test

### DIFF
--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -15,7 +15,7 @@ class ParallelTests
     # parallel:spec[,models,options]
     count = args.shift if args.first.to_s =~ /^\d*$/
     num_processes = count.to_i unless count.to_s.empty?
-    num_processes ||= ENV['PARALLEL_PROCESSOR_COUNT'].to_i if ENV['PARALLEL_PROCESSOR_COUNT']
+    num_processes ||= ENV['PARALLEL_TEST_PROCESSORS'].to_i if ENV['PARALLEL_TEST_PROCESSORS']
     num_processes ||= Parallel.processor_count
 
     pattern = args.shift

--- a/spec/parallel_tests_spec.rb
+++ b/spec/parallel_tests_spec.rb
@@ -24,13 +24,13 @@ describe ParallelTests do
       ParallelTests.parse_rake_args(args).should == [2, "plain", "-p default"]
     end
 
-    it "should use the PARALLEL_PROCESSOR_COUNT env var for processor_count if set" do
-      ENV['PARALLEL_PROCESSOR_COUNT'] = '28'
+    it "should use the PARALLEL_TEST_PROCESSORS env var for processor_count if set" do
+      ENV['PARALLEL_TEST_PROCESSORS'] = '28'
       ParallelTests.parse_rake_args({}).should == [28, '', '']
     end
 
-    it "should use count over PARALLEL_PROCESSOR_COUNT env var" do
-      ENV['PARALLEL_PROCESSOR_COUNT'] = '28'
+    it "should use count over PARALLEL_TEST_PROCESSORS env var" do
+      ENV['PARALLEL_TEST_PROCESSORS'] = '28'
       args = {:count => 2}
       ParallelTests.parse_rake_args(args).should == [2, '', ""]
     end


### PR DESCRIPTION
This env var can be set by the user to limit the number of workers that
are spawned. You might use this approach to globally limit all parallel
runs to 2 workers on an 8 core machine because testing with 8 cores has
been shown to have diminishing returns.
