### PR TITLE
Group tests by directories

### DIFF
--- a/bin/parallel_test
+++ b/bin/parallel_test
@@ -18,6 +18,7 @@ Options are:
 BANNER
   opts.on("-n [PROCESSES]", Integer, "How many processes to use, default: available CPUs"){|n| options[:count] = n }
   opts.on("-p", '--pattern [PATTERN]', "run tests matching this pattern"){|pattern| options[:pattern] = pattern }
+  opts.on("-g", '--group_by_directories [DIR1,DIR2]', "group tests by directories specified. non matching tests go in a group of their own"){|groups| options[:directories_to_group_by] = groups.split(',') }
   opts.on("--no-sort", "do not sort files before running them"){ |no_sort| options[:no_sort] = no_sort }
   opts.on("-m [FLOAT]", "--multiply-processes [FLOAT]", Float, "use given number as a multiplier of processes to run"){ |multiply| options[:multiply] = multiply }
   opts.on("-r", '--root [PATH]', "execute test commands from this path"){|path| options[:root] = path }
@@ -63,7 +64,7 @@ else
   tests_folder = task
   tests_folder = File.join(options[:root], tests_folder) unless options[:root].to_s.empty?
 
-  groups = klass.tests_in_groups(options[:files] || tests_folder, num_processes, :no_sort => options[:no_sort], :pattern => options[:pattern])
+  groups = klass.tests_in_groups(options[:files] || tests_folder, num_processes, :no_sort => options[:no_sort], :pattern => options[:pattern], :directories_to_group_by => options[:directories_to_group_by])
   num_processes = groups.size
 
   #adjust processes to groups

--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -29,6 +29,8 @@ class ParallelTests
     tests = find_tests(root, options)
     if options[:no_sort] == true
       Grouper.in_groups(tests, num_groups)
+    elsif options[:directories_to_group_by]
+      Grouper.by_directories tests, root, options[:directories_to_group_by]
     else
       tests = with_runtime_info(tests)
       Grouper.in_even_groups_by_size(tests, num_groups)

--- a/lib/parallel_tests/grouper.rb
+++ b/lib/parallel_tests/grouper.rb
@@ -27,5 +27,16 @@ class ParallelTests
     def self.smallest_first(files)
       files.sort_by{|item, size| size }.reverse
     end
+
+    def self.by_directories items, root, directories_to_group_by
+      directory_groups = items.group_by do | item |
+        group_name = 'non_matching'
+        directories_to_group_by.each do | dir |
+          group_name = dir if item.start_with?("#{root}/#{dir}")
+        end
+        group_name
+      end
+      directory_groups.values
+    end
   end
 end


### PR DESCRIPTION
Introduced '--group_by_directories [DIR1,DIR2]' option to the command line.

This option allows the user to group tests within directories to be run on the same process/thread.

All tests that don't match any of the passed in directories are run in a "non_matching" group of their own
