### PR TITLE
FIx spec loggers to handle rspec formatter changes

### DIFF
--- a/lib/parallel_specs/spec_failures_logger.rb
+++ b/lib/parallel_specs/spec_failures_logger.rb
@@ -6,7 +6,7 @@ class ParallelSpecs::SpecFailuresLogger < ParallelSpecs::SpecLoggerBase
     @failed_examples = []
   end
 
-  def example_failed(example, count, failure)
+  def example_failed(example, *args)
     @failed_examples << example
   end
 

--- a/lib/parallel_specs/spec_summary_logger.rb
+++ b/lib/parallel_specs/spec_summary_logger.rb
@@ -12,12 +12,12 @@ class ParallelSpecs::SpecSummaryLogger < ParallelSpecs::SpecLoggerBase
     @passed_examples << example
   end
 
-  def example_pending(*args)
-    @pending_examples << args
+  def example_pending(example, *args)
+    @pending_examples << example
   end
 
-  def example_failed(example, count, failure)
-    @failed_examples << failure
+  def example_failed(example, *args)
+    @failed_examples << example
   end
 
   def dump_summary(duration, example_count, failure_count, pending_count)
@@ -29,16 +29,23 @@ class ParallelSpecs::SpecSummaryLogger < ParallelSpecs::SpecLoggerBase
 
   def dump_failure(*args)
     lock_output do
-      @output.puts "#{ @failed_examples.size } examples failed:"
-      @failed_examples.each.with_index do | failure, i |
-        @output.puts "#{ i + 1 })"
-        @output.puts failure.header
-        @output.puts failure.exception.to_s
-        failure.exception.backtrace.each do | caller |
-          @output.puts caller
-        end
-        @output.puts ''
+      @failed_examples.each.with_index do | example, i |
+        spec_file = example.location.scan(/^[^:]+/)[0]
+        spec_file.gsub!(%r(^.*?/spec/), './spec/')
+        @output.puts "#{ParallelSpecs.executable} #{spec_file} -e \"#{example.description}\""
       end
+      
+      
+      # @output.puts "#{ @failed_examples.size } examples failed:"
+      # @failed_examples.each.with_index do | failure, i |
+      #   @output.puts "#{ i + 1 })"
+      #   @output.puts failure.header
+      #   @output.puts failure.exception.to_s
+      #   failure.exception.backtrace.each do | caller |
+      #     @output.puts caller
+      #   end
+      #   @output.puts ''
+      # end
     end
     @output.flush
   end

--- a/spec/parallel_specs_spec.rb
+++ b/spec/parallel_specs_spec.rb
@@ -186,11 +186,11 @@ EOF
       end
 
       it "should print a summary of failing examples" do
-        @logger.example_failed( nil, nil, @failure1 )
+        @logger.example_failed( @example1 )
 
         @logger.dump_failure
 
-        @output.output.should == ["1 examples failed:", "1)", "header", "exception", "/path/to/error/line:33", ""]
+        @output.output.should == ["bundle exec rspec ./spec/path/to/example -e \"should do stuff\""]
       end
     end
 


### PR DESCRIPTION
Most of the changelog comes from here: https://github.com/bbuchalter/parallel_tests/commit/23841549b4a9fe5c725533ec3f1a1423cb68bb31

with a few other modifications and spec fixes 
