### PR TITLE
Check for migrations before running tests

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -43,7 +43,7 @@ namespace :parallel do
 
   ['test', 'spec', 'features'].each do |type|
     desc "run #{type} in parallel with parallel:#{type}[num_cpus]"
-    task type, :count, :pattern, :options do |t,args|
+    task type, [:count, :pattern, :options] => 'db:abort_if_pending_migrations' do |t,args|
       $LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), '..'))
       require "parallel_tests"
       count, pattern, options = ParallelTests.parse_rake_args(args)


### PR DESCRIPTION
The normal test/spec helpers check for pending migrations before running tests, but it doesn't seem like parallel:test does, is this possible?
