### PR TITLE
Suppressed pending spec output from creating runtime imbalances between processes

### DIFF
--- a/lib/parallel_specs/spec_runtime_logger.rb
+++ b/lib/parallel_specs/spec_runtime_logger.rb
@@ -18,6 +18,7 @@ class ParallelSpecs::SpecRuntimeLogger < ParallelSpecs::SpecLoggerBase
   def dump_summary(*args);end
   def dump_failures(*args);end
   def dump_failure(*args);end
+  def dump_pending(*args);end
 
   def start_dump(*args)
     return unless ENV['TEST_ENV_NUMBER'] #only record when running in parallel


### PR DESCRIPTION
Suppressed pending spec output from being included in the parallel_profile.log.  The line number in pending output were being interpreted as recorded test times, causing a runtime imbalance between processes.

For instance, the following was being included in the parallel_profile.log:

```
Recruitment survey_response_count for identified surveys should return 0 when no one has applied (Not Yet Implemented)
/Users/mgarrick/recruit/spec/models/recruitment_spec.rb:1109
```

Note the line number will be interpreted as a runtime duration by parallel_tests.
