### PR TITLE
Parallel tests runtime logger

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -81,7 +81,7 @@ Example output
 
     Took 29.925333 seconds
 
-Spec Loggers
+Loggers
 ===================
 
 Even process runtimes
@@ -89,7 +89,7 @@ Even process runtimes
 
 Log test runtime to give each process the same runtime.
 
-Add to your `spec/parallel_spec.opts` (or `spec/spec.opts`) :
+Rspec: Add to your `spec/parallel_spec.opts` (or `spec/spec.opts`) :
 
     RSpec 1.x:
       --format progress
@@ -99,6 +99,10 @@ Add to your `spec/parallel_spec.opts` (or `spec/spec.opts`) :
       If installed as plugin: -I vendor/plugins/parallel_tests/lib
       --format progress
       --format ParallelSpecs::SpecRuntimeLogger --out tmp/parallel_profile.log
+
+Test::Unit:  Add to your `test_helper.rb`:
+    require 'parallel_tests/runtime_logger'
+
 
 SpecSummaryLogger
 --------------------
@@ -189,7 +193,6 @@ TIPS
  - [Capybara setup](https://github.com/grosser/parallel_tests/wiki)
  - [Sphinx setup](https://github.com/grosser/parallel_tests/wiki)
  - [Capistrano setup](https://github.com/grosser/parallel_tests/wiki/Remotely-with-capistrano) let your tests run on a big box instead of your laptop
- - [Test::Unit runtime logger](https://gist.github.com/1333414) some basic plumbing done (needs some love and a pull-request)
  - [SQL schema format] use :ruby schema format to get faster parallel:prepare`
  - [ActiveRecord] if you do not have `db:abort_if_pending_migrations` add this to your Rakefile: `task('db:abort_if_pending_migrations'){}`
  - `export PARALLEL_TEST_PROCESSORS=X` in your environment and parallel_tests will use this number of processors by default
@@ -228,6 +231,7 @@ inspired by [pivotal labs](http://pivotallabs.com/users/miked/blog/articles/849-
  - [Doug Barth](https://github.com/dougbarth)
  - [Geoffrey Hichborn](https://github.com/phene)
  - [Trae Robrock](https://github.com/trobrock)
+ - [Sean Walbran](https://github.com/seanwalbran)
 
 [Michael Grosser](http://grosser.it)<br/>
 michael@grosser.it<br/>

--- a/spec/parallel_tests/runtime_logger_spec.rb
+++ b/spec/parallel_tests/runtime_logger_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe ParallelTests::RuntimeLogger do
+
+  describe :writing do
+    it "overwrites the runtime_log file on first log invocation" do
+      class FakeTest
+      end
+      test = FakeTest.new
+      time = Time.now
+      File.open(ParallelTests.runtime_log, 'w'){ |f| f.puts("FooBar") }
+      ParallelTests::RuntimeLogger.send(:class_variable_set,:@@has_started, false)
+      ParallelTests::RuntimeLogger.log(test, time, Time.at(time.to_f+2.00))
+      result = File.read(ParallelTests.runtime_log)
+      result.should_not include('FooBar')
+      result.should include('test/fake_test.rb:2.00')
+    end
+
+    it "appends to the runtime_log file after first log invocation" do
+      class FakeTest
+      end
+      test = FakeTest.new
+      class OtherFakeTest
+      end
+      other_test = OtherFakeTest.new
+
+      time = Time.now
+      File.open(ParallelTests.runtime_log, 'w'){ |f| f.puts("FooBar") }
+      ParallelTests::RuntimeLogger.send(:class_variable_set,:@@has_started, false)
+      ParallelTests::RuntimeLogger.log(test, time, Time.at(time.to_f+2.00))
+      ParallelTests::RuntimeLogger.log(other_test, time, Time.at(time.to_f+2.00))
+      result = File.read(ParallelTests.runtime_log)
+      result.should_not include('FooBar')
+      result.should include('test/fake_test.rb:2.00')
+      result.should include('test/other_fake_test.rb:2.00')
+    end
+
+  end
+
+  describe :formatting do
+    it "formats results for simple test names" do
+      class FakeTest
+      end
+      test = FakeTest.new
+      time = Time.now
+      ParallelTests::RuntimeLogger.message(test, time, Time.at(time.to_f+2.00)).should == 'test/fake_test.rb:2.00'
+    end
+
+    it "formats results for complex test names" do
+      class AVeryComplex
+        class FakeTest
+        end
+      end
+      test = AVeryComplex::FakeTest.new
+      time = Time.now
+      ParallelTests::RuntimeLogger.message(test, time, Time.at(time.to_f+2.00)).should == 'test/a_very_complex/fake_test.rb:2.00'
+    end
+
+    it "guesses subdirectory structure for rails test classes" do
+      module Rails
+      end
+      class ActionController
+        class TestCase
+        end
+      end
+      class FakeControllerTest < ActionController::TestCase
+      end
+      test = FakeControllerTest.new
+      time = Time.now
+      ParallelTests::RuntimeLogger.message(test, time, Time.at(time.to_f+2.00)).should == 'test/functional/fake_controller_test.rb:2.00'
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require 'parallel_specs'
 require 'parallel_specs/spec_runtime_logger'
 require 'parallel_specs/spec_summary_logger'
 require 'parallel_cucumber'
+require 'parallel_tests/runtime_logger'
 
 OutputLogger = Struct.new(:output) do
   attr_reader :flock, :flush


### PR DESCRIPTION
Add a runtime logger for Test::Unit.  (See also discussion under earlier, now-closed PR #70.)
