### PR TITLE
this commit fixes #87, 

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -49,7 +49,7 @@ namespace :parallel do
       count, pattern, options = ParallelTests.parse_rake_args(args)
       executable = File.join(File.dirname(__FILE__), '..', '..', 'bin', 'parallel_test')
       command = "#{executable} --type #{type} -n #{count} -p '#{pattern}' -r '#{Rails.root}' -o '#{options}'"
-      abort unless system(command) # allow to chain tasks e.g. rake parallel:spec parallel:features
+      next unless system(command) # allow to chain tasks e.g. rake parallel:spec parallel:features
     end
   end
 end


### PR DESCRIPTION
allow the parallel:test, parallel:spec and parallel:features tasks to be easily wrapped
