### PR TITLE
use $stdout instead of STDOUT for easier redirecting

### DIFF
--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -92,16 +92,16 @@ class ParallelTests
       now = Time.now.to_f
       buffer << char
       if flushed + timeout < now
-        print buffer
-        STDOUT.flush
+        $stdout.print buffer
+        $stdout.flush
         buffer = ''
         flushed = now
       end
     end
 
     # print the remainder
-    print buffer
-    STDOUT.flush
+    $stdout.print buffer
+    $stdout.flush
 
     all
   end


### PR DESCRIPTION
this makes it easier to redirect to a separate log file for each process:

```
$stdout = open('my_log_file', 'w')
```

instead of

```
silence_warnings { const_set(:STDOUT, open('my_log_file', 'w')) }  
```
