### PR TITLE
Add method ParallelTests.root_dir

### DIFF
--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -165,4 +165,9 @@ class ParallelTests
       files.map{|f| "#{root}/#{f}" }
     end
   end
+
+  # @return [Pathname] path to root directory of the gem.
+  def self.root_dir
+    Pathname.new(__FILE__) + "../../"
+  end
 end

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -1,7 +1,7 @@
 namespace :parallel do
   def run_in_parallel(cmd, options)
     count = "-n #{options[:count]}" if options[:count]
-    executable = File.join(File.dirname(__FILE__), '..', '..', 'bin', 'parallel_test')
+    executable = ParallelTests.root_dir + "bin/parallel_test"
     command = "#{executable} --exec '#{cmd}' #{count} #{'--non-parallel' if options[:non_parallel]}"
     abort unless system(command)
   end
@@ -47,7 +47,7 @@ namespace :parallel do
       $LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), '..'))
       require "parallel_tests"
       count, pattern, options = ParallelTests.parse_rake_args(args)
-      executable = File.join(File.dirname(__FILE__), '..', '..', 'bin', 'parallel_test')
+      executable = ParallelTests.root_dir + "bin/parallel_test"
       command = "#{executable} --type #{type} -n #{count} -p '#{pattern}' -r '#{Rails.root}' -o '#{options}'"
       abort unless system(command) # allow to chain tasks e.g. rake parallel:spec parallel:features
     end


### PR DESCRIPTION
I'd like to redefine `parallel:spec` task in my application so I need a way to get path executable file.

Actually I'm testing rails engine with dummy application. I can't use ParallelTests as it is since all tasks `parallel:*` become `app:parallel:*` and it breaks task dependencies.
