### PR TITLE
Remove rspec 1 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ group :development do
   gem 'rspec', '>=2.4'
   gem 'cucumber'
   gem 'rake'
+  gem 'parallel'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ PLATFORMS
 
 DEPENDENCIES
   cucumber
+  parallel
   parallel_tests!
   rake
   rspec (>= 2.4)

--- a/lib/parallel_tests/rspec/failures_logger.rb
+++ b/lib/parallel_tests/rspec/failures_logger.rb
@@ -2,18 +2,8 @@ require 'parallel_tests/rspec/logger_base'
 require 'parallel_tests/rspec/runner'
 
 class ParallelTests::RSpec::FailuresLogger < ParallelTests::RSpec::LoggerBase
-  # RSpec 1: does not keep track of failures, so we do
   def example_failed(example, *args)
-    if RSPEC_1
-      @failed_examples ||= []
-      @failed_examples << example
-    else
-      super
-    end
-  end
-
-  # RSpec 1: dumps 1 failed spec
-  def dump_failure(*args)
+    super
   end
 
   # RSpec 2: dumps all failed specs
@@ -22,23 +12,8 @@ class ParallelTests::RSpec::FailuresLogger < ParallelTests::RSpec::LoggerBase
 
   def dump_summary(*args)
     lock_output do
-      if RSPEC_1
-        dump_commands_to_rerun_failed_examples_rspec_1
-      else
-        dump_commands_to_rerun_failed_examples
-      end
+      dump_commands_to_rerun_failed_examples
     end
     @output.flush
-  end
-
-  private
-
-  def dump_commands_to_rerun_failed_examples_rspec_1
-    (@failed_examples||[]).each do |example|
-      file, line = example.location.to_s.split(':')
-      next unless file and line
-      file.gsub!(%r(^.*?/spec/), './spec/')
-      @output.puts "#{ParallelTests::RSpec::Runner.executable} #{file}:#{line} # #{example.description}"
-    end
   end
 end

--- a/lib/parallel_tests/rspec/logger_base.rb
+++ b/lib/parallel_tests/rspec/logger_base.rb
@@ -14,7 +14,6 @@ end
 ParallelTests::RSpec::LoggerBaseBase = base
 
 class ParallelTests::RSpec::LoggerBase < ParallelTests::RSpec::LoggerBaseBase
-  RSPEC_1 = !defined?(RSpec::Core::Formatters::BaseTextFormatter) # do not test for Spec, this will trigger deprecation warning in rspec 2
 
   def initialize(*args)
     super

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -13,7 +13,7 @@ module ParallelTests
         cmd = if ParallelTests.bundler_enabled?
           "bundle exec rspec"
         else
-          system "rspec --version > /dev/null 2>&1"
+          "rspec" if system "rspec --version > /dev/null 2>&1"
         end
         cmd or raise("Can't find executable rspec")
       end

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -10,7 +10,11 @@ module ParallelTests
       end
 
       def self.executable
-        cmd = system "rspec --version > /dev/null 2>&1"
+        cmd = if ParallelTests.bundler_enabled?
+          "bundle exec rspec"
+        else
+          system "rspec --version > /dev/null 2>&1"
+        end
         cmd or raise("Can't find executable rspec")
       end
 

--- a/spec/parallel_tests/rspec/failure_logger_spec.rb
+++ b/spec/parallel_tests/rspec/failure_logger_spec.rb
@@ -17,10 +17,6 @@ describe ParallelTests::RSpec::FailuresLogger do
     @logger = ParallelTests::RSpec::FailuresLogger.new(@output)
   end
 
-  after do
-    silence_warnings{ ParallelTests::RSpec::LoggerBase::RSPEC_1 = false }
-  end
-
   def clean_output
     @output.output.join("\n").gsub(/\e\[\d+m/,'')
   end
@@ -37,7 +33,6 @@ describe ParallelTests::RSpec::FailuresLogger do
   end
 
   it "should invoke spec for rspec 1" do
-    silence_warnings{ ParallelTests::RSpec::LoggerBase::RSPEC_1 = true }
     ParallelTests.stub!(:bundler_enabled?).and_return true
     ParallelTests::RSpec::Runner.stub!(:run).with("bundle show rspec").and_return "/foo/bar/rspec-1.0.2"
     @logger.example_failed @example1


### PR DESCRIPTION
Do not merge yet, needs code review.

I removed references of rspec1 wherever I could find them. Unfortunately I wasn't able to run the tests, is there something specific I should do to run the tests suite? I was just trying with:

```
rspec spec/
```

Anyway, this should at least show the reduced complexity and code improvement of removing support for rspec1. Hope it helps, let me know if I've missed something.
