### PR TITLE
Fix wrong reference to moved ParallelCucumber::RuntimeLogger

### DIFF
--- a/lib/parallel_tests/cucumber/runner.rb
+++ b/lib/parallel_tests/cucumber/runner.rb
@@ -5,7 +5,7 @@ module ParallelTests
     class Runner < ParallelTests::Test::Runner
       def self.run_tests(test_files, process_number, options)
         color = ($stdout.tty? ? 'AUTOTEST=1 ; export AUTOTEST ;' : '')#display color when we are in a terminal
-        runtime_logging = " --format ParallelCucumber::RuntimeLogger --out #{runtime_log}"
+        runtime_logging = " --format ParallelTests::Cucumber::RuntimeLogger --out #{runtime_log}"
         cmd = "#{color} #{executable}"
         cmd << runtime_logging if File.directory?(File.dirname(runtime_log))
         cmd << " #{options[:test_options]} #{test_files*' '}"


### PR DESCRIPTION
There is a bug in Cucumber runner after recent move everything to ParallelTests namespace.
