### PR TITLE
Add support for loading a file with additional options for cucumber

### DIFF
--- a/lib/parallel_tests/cucumber/runner.rb
+++ b/lib/parallel_tests/cucumber/runner.rb
@@ -6,6 +6,7 @@ module ParallelTests
       def self.run_tests(test_files, process_number, options)
         color = ($stdout.tty? ? 'AUTOTEST=1 ; export AUTOTEST ;' : '')#display color when we are in a terminal
         runtime_logging = " --format ParallelTests::Cucumber::RuntimeLogger --out #{runtime_log}"
+        options[:test_options] = options[:test_options].nil? ? cucumber_opts : "#{options[:test_options]} #{cucumber_opts}".strip
         cmd = "#{color} #{executable}"
         cmd << runtime_logging if File.directory?(File.dirname(runtime_log))
         cmd << " #{options[:test_options]} #{test_files*' '}"
@@ -36,6 +37,14 @@ module ParallelTests
 
       def self.line_is_result?(line)
         line =~ /^\d+ (steps|scenarios)/
+      end
+
+      def self.cucumber_opts
+        if File.exists?('.cucumber_parallel')
+          File.read('.cucumber_parallel').strip
+        else
+          ''
+        end
       end
     end
   end

--- a/spec/parallel_tests/cucumber/runner_spec.rb
+++ b/spec/parallel_tests/cucumber/runner_spec.rb
@@ -52,6 +52,28 @@ describe ParallelTests::Cucumber do
       ParallelTests::Cucumber::Runner.should_receive(:open).with{|x,y| x =~ %r{script/cucumber .* -p default}}.and_return mocked_process
       call(['xxx'],1,:test_options => '-p default')
     end
+
+    it "uses the contents of a .cucumber_parallel file as options" do
+      file_contents = '-f progress'
+      ParallelTests::Cucumber::Runner.should_receive(:open).with{|x,y| x =~ %r{script/cucumber .* #{file_contents}}}.and_return mocked_process
+      File.should_receive(:exists?).with('.cucumber_parallel').and_return true
+      File.should_receive(:read).with('.cucumber_parallel').and_return file_contents
+      call(['xxx'],1,{})
+    end
+
+    it "doesn't use the contents of a .cucumber_parallel file when it's not available" do
+      ParallelTests::Cucumber::Runner.should_receive(:open).with{|x,y| x =~ %r{script/cucumber .*}}.and_return mocked_process
+      File.should_receive(:exists?).with('.cucumber_parallel').and_return false
+      call(['xxx'],1,{})
+    end
+
+    it "merges the contents of a .cucumber_parallel file with the current test options" do
+      file_contents = '-f progress'
+      ParallelTests::Cucumber::Runner.should_receive(:open).with{|x,y| x =~ %r{script/cucumber .* -p default #{file_contents}}}.and_return mocked_process
+      File.should_receive(:exists?).with('.cucumber_parallel').and_return true
+      File.should_receive(:read).with('.cucumber_parallel').and_return file_contents
+      call(['xxx'],1,:test_options => '-p default')
+    end
   end
 
   describe :find_results do


### PR DESCRIPTION
Added support for loading a .cucumber_parallel or a features/parallel_cucumber.opts file that includes some additional options to pass to cucumber.

Useful if you want to maintain the default profile when running the rake cucumber task but if you want to specify another profile if you're running with parallel tests.
It can also be used if you want to change the format of the output if you're using parallel tests, comes in handy if you want to force parallel tests to use the progress format while keeping the pretty format in your default profile.

Cheers,
