### PR TITLE
Test relative paths when using runtime info

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 $LOAD_PATH << File.expand_path("../lib", File.dirname(__FILE__))
 
-FAKE_RAILS_ROOT = '/tmp/pspecs/fixtures'
+FAKE_RAILS_ROOT = './tmp/pspecs/fixtures'
 
 require 'tempfile'
 require 'parallel_tests'


### PR DESCRIPTION
Added to ensure runtime logs are mapped correctly. 
See: d212845e3797fb26060ed1a93afa7b79193cb7a5
