### PR TITLE
Make DB tasks respect RAILS_ENV

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -5,7 +5,7 @@ namespace :parallel do
     command = "#{executable} --exec '#{cmd}' #{count} #{'--non-parallel' if options[:non_parallel]}"
     abort unless system(command)
   end
-  
+
   desc "create test databases via db:create --> parallel:create[num_cpus]"
   task :create, :count do |t,args|
     rails_env = ENV['RAILS_ENV'] || 'test'


### PR DESCRIPTION
This pull request enables you to run DB related tasks in parallel for environments other than test, e.g. cucumber.

We use this on our CI box to load the schema in parallel into the cucumber databases.
