### PR TITLE
Support an environment variable for the runtime log path.

### DIFF
--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -4,7 +4,7 @@ module ParallelTests
       # --- usually overwritten by other runners
 
       def self.runtime_log
-        'tmp/parallel_runtime_test.log'
+        ENV['PARALLEL_TEST_RUNTIME_LOG'] || 'tmp/parallel_runtime_test.log'
       end
 
       def self.test_suffix


### PR DESCRIPTION
Some test suites may want to use the runtime log optimization, without
needing to run the entire test suite in one run. However, doing that
causes problems because each part overwrites the runtime log with
different test timings. This commit supports setting an environment
variable to control where the file is saved. One simply needs to set
that variable before running the tests.

For example, we have tasks like this defined.

``` Ruby
namespace :parallel do
  desc "Run tests in the separate traditional unit,functional,integration runs"
  task "suite" do
    Rake::Task['parallel:units'].invoke
    Rake::Task['parallel:functionals'].invoke
    Rake::Task['parallel:integration'].invoke
  end

  desc "Run all tests in test/unit using parallel_test"
  task "units" do
    ENV['PARALLEL_TEST_RUNTIME_LOG'] = 'tmp/units_parallel_runtime_test.log'
    Rake::Task['parallel:test'].reenable
    Rake::Task['parallel:test'].invoke('^test/unit')
  end

  desc "Run all tests in test/functional using parallel_test"
  task "functionals" do
    ENV['PARALLEL_TEST_RUNTIME_LOG'] = 'tmp/functionals_parallel_runtime_test.log'
    Rake::Task['parallel:test'].reenable
    Rake::Task['parallel:test'].invoke('^test/functional')
  end

  desc "Run all tests in test/integration using parallel_test"
  task "integration" do
    ENV['PARALLEL_TEST_RUNTIME_LOG'] = 'tmp/integration_parallel_runtime_test.log'
    Rake::Task['parallel:test'].reenable
    Rake::Task['parallel:test'].invoke('^test/integration')
  end
end
```
