### PR TITLE
Add the --symlinks option to enable traversing symbolic links while finding tests

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -100,6 +100,7 @@ TEXT
         opts.on("--chunk-timeout [TIMEOUT]", "timeout before re-printing the output of a child-process") { |timeout| options[:chunk_timeout] = timeout.to_f }
         opts.on('-v', '--version', 'Show Version') { puts ParallelTests::VERSION; exit }
         opts.on("-h", "--help", "Show this.") { puts opts; exit }
+        opts.on('--symlinks', 'Traverse symbolic links to find test files') { options[:symlinks] = true }
       end.parse!(argv)
 
       raise "--group-by found and --single-process are not supported" if options[:group_by] == :found and options[:single_process]

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -121,7 +121,7 @@ module ParallelTests
       def self.find_tests(tests, options={})
         (tests||[]).map do |file_or_folder|
           if File.directory?(file_or_folder)
-            files = files_in_folder(file_or_folder)
+            files = files_in_folder(file_or_folder, options)
             files.grep(/#{Regexp.escape test_suffix}$/).grep(options[:pattern]||//)
           else
             file_or_folder
@@ -129,10 +129,14 @@ module ParallelTests
         end.flatten.uniq
       end
 
-      def self.files_in_folder(folder)
+      def self.files_in_folder(folder, options={})
         # follow one symlink and direct children
         # http://stackoverflow.com/questions/357754/can-i-traverse-symlinked-directories-in-ruby-with-a-glob
-        Dir[File.join(folder, "**{,/*/**}/*")].uniq
+        if options[:symlinks]
+          Dir[File.join(folder, "**{,/*/**}/*")].uniq
+        else
+          Dir[File.join(folder, "**/*")].uniq
+        end
       end
     end
   end

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -145,9 +145,18 @@ EOF
     it "finds test files nested in symlinked folders" do
       with_files(['a/a_test.rb','b/b_test.rb']) do |root|
         `ln -s #{root}/a #{root}/b/link`
-        call(["#{root}/b"]).sort.should == [
+        call(["#{root}/b"], :symlinks => true).sort.should == [
           "#{root}/b/b_test.rb",
           "#{root}/b/link/a_test.rb",
+        ]
+      end
+    end
+
+    it "finds test files but ignores those in symlinked folders" do
+      with_files(['a/a_test.rb','b/b_test.rb']) do |root|
+        `ln -s #{root}/a #{root}/b/link`
+        call(["#{root}/b"]).sort.should == [
+          "#{root}/b/b_test.rb",
         ]
       end
     end


### PR DESCRIPTION
Fixes #124
