### PR TITLE
fix cucumber summary

### DIFF
--- a/lib/parallel_tests/cucumber/runner.rb
+++ b/lib/parallel_tests/cucumber/runner.rb
@@ -39,7 +39,32 @@ module ParallelTests
       end
 
       def self.line_is_result?(line)
-        line =~ /^\d+ (steps|scenarios)/
+        line =~ /^\d+ (steps?|scenarios?)/
+      end
+
+      def self.summarize_results(results)
+        sort_order = %w[scenario step failed undefined skipped pending passed]
+
+        %w[scenario step].map do |group|
+          all_group_results = results.select{|v| v =~ /^\d+ #{group}s?/}
+          next if all_group_results.empty?
+
+          sums = sum_up_results(all_group_results)
+
+          group_results = sums.map do |word, number|
+            "#{number} #{word}"
+          end
+
+          # sort results like cucumber does it
+          group_results = group_results.sort do |a, b|
+            (sort_order.index{|order_item| a.include?(order_item) } || sort_order.size)  <=> (sort_order.index{|order_item| b.include?(order_item) } || sort_order.size)
+          end
+
+          # pluralize group results
+          group_results[0] += 's' if sums[group] > 1
+          "#{group_results[0]} (#{group_results[1..-1].join(", ")})"
+
+        end.compact.join("\n")
       end
 
       def self.cucumber_opts(given)

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -60,16 +60,21 @@ module ParallelTests
       end
 
       def self.summarize_results(results)
+        sums = sum_up_results(results)
+        sums.sort.map{|word, number|  "#{number} #{word}#{'s' if number != 1}" }.join(', ')
+      end
+
+      protected
+
+      def self.sum_up_results(results)
         results = results.join(' ').gsub(/s\b/,'') # combine and singularize results
         counts = results.scan(/(\d+) (\w+)/)
         sums = counts.inject(Hash.new(0)) do |sum, (number, word)|
           sum[word] += number.to_i
           sum
         end
-        sums.sort.map{|word, number|  "#{number} #{word}#{'s' if number != 1}" }.join(', ')
+        sums
       end
-
-      protected
 
       # read output of the process and print in in chucks
       def self.fetch_output(process, options)


### PR DESCRIPTION
Currently scenario and step results are combined which is wrong.
Sums for scenario results and step results have to be treated separately to get correct numbers.

This commit fixes the sums as well as displaying them like cucumber does.
