### PR TITLE
colorize fail message (e.g. "Cucumbers failed")

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -34,7 +34,7 @@ module ParallelTest
         report_results runner, test_results
       end
 
-      abort "#{lib.capitalize}s Failed" if any_test_failed?(test_results)
+      abort final_fail_message(lib) if any_test_failed?(test_results)
     end
 
     def self.run_tests(runner, group, process_number, options)
@@ -133,6 +133,16 @@ TEXT
       yield
       puts ""
       puts "Took #{Time.now - start} seconds"
+    end
+
+    def self.final_fail_message(lib)
+      fail_message = "#{lib.capitalize}s Failed"
+      fail_message = "\e[31m#{fail_message}\e[0m" if use_colors?
+      fail_message
+    end
+
+    def self.use_colors?
+      $stdout.tty?
     end
   end
 end

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -21,4 +21,16 @@ describe ParallelTest::CLI do
       call(["--non-parallel"]).should == defaults.merge(:non_parallel => true)
     end
   end
+
+  describe ".final_fail_message" do
+    it 'returns a plain fail message if colors are nor supported' do
+      ParallelTest::CLI.stub(:use_colors? => false, :lib => "Test")
+      ParallelTest::CLI.send(:final_fail_message).should ==  "Tests Failed"
+    end
+
+    it 'returns a colorized fail message if colors are supported' do
+      ParallelTest::CLI.stub(:use_colors? => true, :lib => "Test")
+      ParallelTest::CLI.send(:final_fail_message).should == "\e[31mTests Failed\e[0m"
+    end
+  end
 end


### PR DESCRIPTION
In order to notify a user of failing tests this commit colors the test suite fail message in red.
