### PR TITLE
Silence output of successful parallel:prepare calls

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -40,7 +40,7 @@ namespace :parallel do
   # just load the schema (good for integration server <-> no development db)
   desc "load dumped schema for test databases via db:schema:load --> parallel:load_schema[num_cpus]"
   task :load_schema, :count do |t,args|
-    run_in_parallel("rake db:schema:load_silently RAILS_ENV=#{rails_env}", args)
+    run_in_parallel("rake db:schema:silence db:schema:load RAILS_ENV=#{rails_env}", args)
   end
 
   desc "load the seed data from db/seeds.rb via db:seed --> parallel:seed[num_cpus]"
@@ -68,9 +68,8 @@ end
 
 namespace :db do
   namespace :schema do
-    task :load_silently => :environment do
+    task :silence => :environment do
       ActiveRecord::Schema.verbose = false
-      Rake::Task['db:schema:load'].invoke
     end
   end
 end


### PR DESCRIPTION
The commit [Make DB tasks respect RAILS_ENV ](https://github.com/grosser/parallel_tests/commit/12e982cfe5271ce0f8c7d0f0b1b76e0ed6364eea) has made the output of `rake parallel:prepare` very verbose, as it recreates all tables for all test databases with a lot of logging output. Also the output is not very readable, because many processes print to the same terminal in parallel.

The reason for this is that in order to respect the RAILS_ENV we now call `db:schema:load` instead of `db:test:load`. The latter eventually calls the former, but calls `ActiveRecord::Schema.verbose = false` before.

This pull request again silences the output of successful `rake parallel:prepare` runs while still respecting the RAILS_ENV.
