### PR TITLE
Support all possible locations for cucumber.yml for loading additional options

### DIFF
--- a/lib/parallel_tests/cucumber/runner.rb
+++ b/lib/parallel_tests/cucumber/runner.rb
@@ -71,7 +71,7 @@ module ParallelTests
       end
 
       def self.profile_from_config
-        config = 'config/cucumber.yml'
+        config = Dir.glob('{,.config/,config/}cucumber{.yml,.yaml}').first
         if File.exists?(config) && File.read(config) =~ /^parallel:/
           "--profile parallel"
         end


### PR DESCRIPTION
...ptions

Issue https://github.com/grosser/parallel_tests/issues/139

cucumber.yml can be in your current working directory, .config subdirectory config subdirectory of your current working directory. (https://github.com/cucumber/cucumber/wiki/cucumber.yml)
So adding the same logic used in "https://github.com/cucumber/cucumber/blob/master/lib/cucumber/cli/profi
le_loader.rb" for locating cucumber.yml
