### PR TITLE
rake parallel:seed fails to find run_in_parallel method

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -103,7 +103,7 @@ namespace :parallel do
 
   desc "load the seed data from db/seeds.rb via db:seed --> parallel:seed[num_cpus]"
   task :seed, :count do |t,args|
-    run_in_parallel("rake db:seed RAILS_ENV=#{ParallelTests::Tasks.rails_env}", args)
+    ParallelTests::Tasks.run_in_parallel("rake db:seed RAILS_ENV=#{ParallelTests::Tasks.rails_env}", args)
   end
 
   ['test', 'spec', 'features'].each do |type|


### PR DESCRIPTION
For some reason, the parallel:seed task fails because It cannot find the method run_in_parallel. Throughout the rest of tasks.rb, that method is called from the ParallelTests::Tasks module, and it runs correctly. This should fix parallel:seed task.
