### PR TITLE
Add --ignore-tags CLI option.

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -108,6 +108,7 @@ TEXT
         opts.on("-t", "--type [TYPE]", "test(default) / rspec / cucumber") { |type| options[:type] = type }
         opts.on("--non-parallel", "execute same commands but do not in parallel, needs --exec") { options[:non_parallel] = true }
         opts.on("--no-symlinks", "Do not traverse symbolic links to find test files") { options[:symlinks] = false }
+        opts.on('--ignore-tags [PATTERN]', 'When counting steps ignore scenarios with tags that match this pattern')  { |arg| options[:ignore_tag_pattern] = arg }
         opts.on("-v", "--version", "Show Version") { puts ParallelTests::VERSION; exit }
         opts.on("-h", "--help", "Show this.") { puts opts; exit }
       end.parse!(argv)

--- a/lib/parallel_tests/grouper.rb
+++ b/lib/parallel_tests/grouper.rb
@@ -35,14 +35,17 @@ module ParallelTests
       group[:size] += size
     end
 
-    def self.by_steps(tests, num_groups)
-      features_with_steps = build_features_with_steps(tests)
+    def self.by_steps(tests, num_groups, options)
+      features_with_steps = build_features_with_steps(tests, options)
       in_even_groups_by_size(features_with_steps, num_groups)
     end
 
-    def self.build_features_with_steps(tests)
+    private
+
+    def self.build_features_with_steps(tests, options)
       require 'parallel_tests/cucumber/gherkin_listener'
       listener = Cucumber::GherkinListener.new
+      listener.ignore_tag_pattern = Regexp.compile(options[:ignore_tag_pattern]) if options[:ignore_tag_pattern]
       parser = Gherkin::Parser::Parser.new(listener, true, 'root')
       tests.each{|file|
         parser.parse(File.read(file), file, 0)

--- a/spec/parallel_tests/cucumber/gherkin_listener_spec.rb
+++ b/spec/parallel_tests/cucumber/gherkin_listener_spec.rb
@@ -44,5 +44,54 @@ describe ParallelTests::Cucumber::GherkinListener do
       @listener.eof
       @listener.collect.should == {"feature_file" => 17}
     end
+
+    it 'counts scenarios that should not be ignored' do
+      @listener.ignore_tag_pattern = nil
+      @listener.scenario( stub('scenario', :tags =>[ stub('tag', :name => '@WIP' )]) )
+      @listener.step(nil)
+      @listener.eof
+      @listener.collect.should == {"feature_file" => 1}
+
+      @listener.ignore_tag_pattern = /@something_other_than_WIP/
+      @listener.scenario( stub('scenario', :tags =>[ stub('tag', :name => '@WIP' )]) )
+      @listener.step(nil)
+      @listener.eof
+      @listener.collect.should == {"feature_file" => 2}
+    end
+
+    it 'does not count scenarios that should be ignored' do
+      @listener.ignore_tag_pattern = /@WIP/
+      @listener.scenario( stub('scenario', :tags =>[ stub('tag', :name => '@WIP' )]))
+      @listener.step(nil)
+      @listener.eof
+      @listener.collect.should == {"feature_file" => 0}
+    end
+
+    it 'counts outlines that should not be ignored' do
+      @listener.ignore_tag_pattern = nil
+      @listener.scenario_outline( stub('scenario', :tags =>[ stub('tag', :name => '@WIP' )]) )
+      @listener.step(nil)
+      3.times {@listener.examples}
+      @listener.eof
+      @listener.collect.should == {"feature_file" => 3}
+
+
+      @listener.ignore_tag_pattern = /@something_other_than_WIP/
+      @listener.scenario_outline( stub('scenario', :tags =>[ stub('tag', :name => '@WIP' )]) )
+      @listener.step(nil)
+      3.times {@listener.examples}
+      @listener.eof
+      @listener.collect.should == {"feature_file" => 6}
+    end
+
+    it 'does not count outlines that should be ignored' do
+      @listener.ignore_tag_pattern = /@WIP/
+      @listener.scenario_outline( stub('scenario', :tags =>[ stub('tag', :name => '@WIP' )]) )
+      @listener.step(nil)
+      3.times {@listener.examples}
+      @listener.eof
+      @listener.collect.should == {"feature_file" => 0}
+    end
+
   end
 end

--- a/spec/parallel_tests/grouper_spec.rb
+++ b/spec/parallel_tests/grouper_spec.rb
@@ -15,7 +15,7 @@ describe ParallelTests::Grouper do
         write("#{dir}/a.feature", "Feature: xxx\n  Scenario: xxx\n    Given something")
         write("#{dir}/b.feature", "Feature: xxx\n  Scenario: xxx\n    Given something\n  Scenario: yyy\n    Given something")
         write("#{dir}/c.feature", "Feature: xxx\n  Scenario: xxx\n    Given something")
-        ParallelTests::Grouper.by_steps(["#{dir}/a.feature", "#{dir}/b.feature", "#{dir}/c.feature"],2)
+        ParallelTests::Grouper.by_steps(["#{dir}/a.feature", "#{dir}/b.feature", "#{dir}/c.feature"], 2, {})
       end
 
       # testing inside mktmpdir is always green


### PR DESCRIPTION
Add CLI option to not count scenarios with certain tags when grouping by steps.  For example:  --ignore-tags "@(WIP|Draft|Manual)"

Test results:

rspec spec/
..........................................................................._..................................._..........................................................................

Pending:
  ParallelTests::RSpec::FailuresLogger should not log examples without location
    # Temporarily disabled with xit
    # ./spec/parallel_tests/rspec/failure_logger_spec.rb:75
  ParallelTests::RSpec::SummaryLogger prints failing examples
    # Temporarily disabled with xit
    # ./spec/parallel_tests/rspec/summary_logger_spec.rb:12

Finished in 1 minute 8.02 seconds
186 examples, 0 failures, 2 pending

real    1m9.435s
user    1m25.554s
sys 0m8.186s
