### PR TITLE
Replace :rubygems in Gemfile with 'https://rubygems.org'.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org' 
 gemspec
 
 gem 'bump'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       parallel
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     builder (3.0.0)
     bump (0.3.8)


### PR DESCRIPTION
Bundler some time ago started display warning message like follow:

The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or
'http://rubygems.org' if not.

So, this change is to remove it and let everything go smother.
