### PR TITLE
Handle script/zeus_cucumber as cucumber runner

### DIFF
--- a/lib/parallel_tests/cucumber/runner.rb
+++ b/lib/parallel_tests/cucumber/runner.rb
@@ -19,7 +19,9 @@ module ParallelTests
       end
 
       def self.executable
-        if ParallelTests.bundler_enabled?
+        if File.file?("script/zeus_cucumber")
+          "script/zeus_cucumber"
+        elsif ParallelTests.bundler_enabled?
           "bundle exec cucumber"
         elsif File.file?("script/cucumber")
           "script/cucumber"


### PR DESCRIPTION
Hey,

such change would help me integrate zeus and parallel_tests for cucumber!
