### PR TITLE
cache first test, before `self.tests` is emptied

### DIFF
--- a/lib/parallel_tests/test/runtime_logger.rb
+++ b/lib/parallel_tests/test/runtime_logger.rb
@@ -82,10 +82,11 @@ class ::Test::Unit::TestSuite
   alias :run_without_timing :run unless defined? @@timing_installed
 
   def run(result, &progress_block)
+    first_test = self.tests.first
     start_time=Time.now
     run_without_timing(result, &progress_block)
     end_time=Time.now
-    ParallelTests::Test::RuntimeLogger.log(self.tests.first, start_time, end_time)
+    ParallelTests::Test::RuntimeLogger.log(first_test, start_time, end_time)
   end
 
   @@timing_installed = true


### PR DESCRIPTION
A combination of Rails 3.2 with Test/Unit results in the runtime logger not working correctly. Instead of an expected output like this:

```
test/unit/sample_test.rb:0.24
```

the runtime log ends up with a lot of these lines:

```
test/unit/nil_class.rb:0.25
test/unit/nil_class.rb:0.25
```

The issue seems to be that `Test::Unit::TestSuite#run_without_timing` empties the `tests` array. This is fixed by caching the first test name.

Here is a sample Rails app where this happens: https://github.com/vangberg/parallel-tests-rails-runtime-logger-example-app/commit/b135c5a6a948fba0048ff60aa2a08117bab98a44

I haven't been able to figure out what part of the stack is doing this.
