### PR TITLE
uninitialized constant ParallelTests::Cucumber::FailuresLogger::Io

### DIFF
--- a/lib/parallel_tests/cucumber/failures_logger.rb
+++ b/lib/parallel_tests/cucumber/failures_logger.rb
@@ -1,4 +1,5 @@
 require 'cucumber/formatter/rerun'
+require 'parallel_tests/cucumber/io'
 
 module ParallelTests
   module Cucumber


### PR DESCRIPTION
Broken:

```
┌─[tedwards@fujited]─[~/codebase/qa/ui_tests_mi]
└──╼ cat Gemfile|grep parallel_tests
gem "parallel_tests"

┌─[tedwards@fujited]─[~/codebase/qa/ui_tests_mi]
└──╼ parallel_cucumber features/automated
4 processes for 76 features, ~ 19 features per process
Using the parallel profile...
uninitialized constant ParallelTests::Cucumber::FailuresLogger::Io
Error creating formatter: ParallelTests::Cucumber::FailuresLogger (NameError)
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/parallel_tests-0.12.1/lib/parallel_tests/cucumber/failures_logger.rb:6:in `<class:FailuresLogger>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/parallel_tests-0.12.1/lib/parallel_tests/cucumber/failures_logger.rb:5:in `<module:Cucumber>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/parallel_tests-0.12.1/lib/parallel_tests/cucumber/failures_logger.rb:4:in `<module:ParallelTests>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/parallel_tests-0.12.1/lib/parallel_tests/cucumber/failures_logger.rb:3:in `<top (required)>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/constantize.rb:16:in `require'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/constantize.rb:16:in `rescue in constantize'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/constantize.rb:5:in `constantize'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:79:in `formatter_class'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:171:in `block in formatters'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:167:in `map'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:167:in `formatters'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:72:in `build_tree_walker'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/runtime.rb:43:in `run!'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/main.rb:43:in `execute!'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/main.rb:20:in `execute'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/bin/cucumber:14:in `<top (required)>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/bin/cucumber:19:in `load'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/bin/cucumber:19:in `<main>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/bin/ruby_noexec_wrapper:14:in `eval'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/bin/ruby_noexec_wrapper:14:in `<main>'
Using the parallel profile...
uninitialized constant ParallelTests::Cucumber::FailuresLogger::Io
Error creating formatter: ParallelTests::Cucumber::FailuresLogger (NameError)
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/parallel_tests-0.12.1/lib/parallel_tests/cucumber/failures_logger.rb:6:in `<class:FailuresLogger>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/parallel_tests-0.12.1/lib/parallel_tests/cucumber/failures_logger.rb:5:in `<module:Cucumber>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/parallel_tests-0.12.1/lib/parallel_tests/cucumber/failures_logger.rb:4:in `<module:ParallelTests>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/parallel_tests-0.12.1/lib/parallel_tests/cucumber/failures_logger.rb:3:in `<top (required)>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/constantize.rb:16:in `require'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/constantize.rb:16:in `rescue in constantize'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/constantize.rb:5:in `constantize'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:79:in `formatter_class'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:171:in `block in formatters'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:167:in `map'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:167:in `formatters'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:72:in `build_tree_walker'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/runtime.rb:43:in `run!'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/main.rb:43:in `execute!'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/main.rb:20:in `execute'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/bin/cucumber:14:in `<top (required)>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/bin/cucumber:19:in `load'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/bin/cucumber:19:in `<main>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/bin/ruby_noexec_wrapper:14:in `eval'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/bin/ruby_noexec_wrapper:14:in `<main>'
Using the parallel profile...
uninitialized constant ParallelTests::Cucumber::FailuresLogger::Io
Error creating formatter: ParallelTests::Cucumber::FailuresLogger (NameError)
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/parallel_tests-0.12.1/lib/parallel_tests/cucumber/failures_logger.rb:6:in `<class:FailuresLogger>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/parallel_tests-0.12.1/lib/parallel_tests/cucumber/failures_logger.rb:5:in `<module:Cucumber>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/parallel_tests-0.12.1/lib/parallel_tests/cucumber/failures_logger.rb:4:in `<module:ParallelTests>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/parallel_tests-0.12.1/lib/parallel_tests/cucumber/failures_logger.rb:3:in `<top (required)>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/constantize.rb:16:in `require'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/constantize.rb:16:in `rescue in constantize'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/constantize.rb:5:in `constantize'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:79:in `formatter_class'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:171:in `block in formatters'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:167:in `map'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:167:in `formatters'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:72:in `build_tree_walker'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/runtime.rb:43:in `run!'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/main.rb:43:in `execute!'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/main.rb:20:in `execute'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/bin/cucumber:14:in `<top (required)>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/bin/cucumber:19:in `load'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/bin/cucumber:19:in `<main>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/bin/ruby_noexec_wrapper:14:in `eval'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/bin/ruby_noexec_wrapper:14:in `<main>'
Using the parallel profile...
uninitialized constant ParallelTests::Cucumber::FailuresLogger::Io
Error creating formatter: ParallelTests::Cucumber::FailuresLogger (NameError)
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/parallel_tests-0.12.1/lib/parallel_tests/cucumber/failures_logger.rb:6:in `<class:FailuresLogger>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/parallel_tests-0.12.1/lib/parallel_tests/cucumber/failures_logger.rb:5:in `<module:Cucumber>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/parallel_tests-0.12.1/lib/parallel_tests/cucumber/failures_logger.rb:4:in `<module:ParallelTests>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/parallel_tests-0.12.1/lib/parallel_tests/cucumber/failures_logger.rb:3:in `<top (required)>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/constantize.rb:16:in `require'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/constantize.rb:16:in `rescue in constantize'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/constantize.rb:5:in `constantize'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:79:in `formatter_class'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:171:in `block in formatters'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:167:in `map'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:167:in `formatters'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/configuration.rb:72:in `build_tree_walker'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/runtime.rb:43:in `run!'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/main.rb:43:in `execute!'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/lib/cucumber/cli/main.rb:20:in `execute'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/gems/cucumber-1.2.1/bin/cucumber:14:in `<top (required)>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/bin/cucumber:19:in `load'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/bin/cucumber:19:in `<main>'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/bin/ruby_noexec_wrapper:14:in `eval'
/home/tedwards/.rvm/gems/ruby-1.9.3-p374@ui_tests_mi/bin/ruby_noexec_wrapper:14:in `<main>'
```

Fixed:

```
┌─[tedwards@fujited]─[~/codebase/qa/ui_tests_mi]
└──╼ grep parallel_tests Gemfile
gem "parallel_tests", :git => 'git://github.com/toddedw/ruby-parallel_tests.git'
┌─[tedwards@fujited]─[~/codebase/qa/ui_tests_mi]
└──╼ parallel_cucumber features/automated
4 processes for 76 features, ~ 19 features per process
Using the parallel profile...

Current Unique String: 130506142417760_yekcg
Using the parallel profile...
```

I didn't get around to writing tests for this but I could possibly find time to do that tonight. Let me know what you think.

Thanks,

Todd Edwards
todd@mtn.cc
