### PR TITLE
Use binstubs in runner

### DIFF
--- a/lib/parallel_tests/cucumber/runner.rb
+++ b/lib/parallel_tests/cucumber/runner.rb
@@ -20,9 +20,12 @@ module ParallelTests
       end
 
       def self.determine_executable
-        if ParallelTests.bundler_enabled?
+        case
+        when File.exists?("bin/cucumber")
+          "bin/cucumber"
+        when ParallelTests.bundler_enabled?
           "bundle exec cucumber"
-        elsif File.file?("script/cucumber")
+        when File.file?("script/cucumber")
           "script/cucumber"
         else
           "cucumber"

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -14,14 +14,18 @@ module ParallelTests
       end
 
       def self.determine_executable
-        cmd = if File.file?("script/spec")
-          "script/spec"
-        elsif ParallelTests.bundler_enabled?
-          cmd = (run("bundle show rspec-core") =~ %r{Could not find gem.*} ? "spec" : "rspec")
-          "bundle exec #{cmd}"
-        else
-          %w[spec rspec].detect{|cmd| system "#{cmd} --version > /dev/null 2>&1" }
-        end
+        cmd = case
+              when File.exists?("bin/rspec")
+                "bin/rspec"
+              when File.file?("script/spec")
+                "script/spec"
+              when ParallelTests.bundler_enabled?
+                cmd = (run("bundle show rspec-core") =~ %r{Could not find gem.*} ? "spec" : "rspec")
+                "bundle exec #{cmd}"
+              else
+                %w[spec rspec].detect{|cmd| system "#{cmd} --version > /dev/null 2>&1" }
+              end
+
         cmd or raise("Can't find executables rspec or spec")
       end
 

--- a/spec/parallel_tests/cucumber/runner_spec.rb
+++ b/spec/parallel_tests/cucumber/runner_spec.rb
@@ -43,11 +43,17 @@ describe ParallelTests::Cucumber do
       call(['xxx'],1,22,{})
     end
 
+    it "uses bin/cucumber when present" do
+      File.stub(:exists?).with("bin/cucumber").and_return true
+      should_run_with %r{bin/cucumber}
+      call(['xxx'],1,22,{})
+    end
+
     it "uses options passed in" do
       should_run_with %r{script/cucumber .* -p default}
       call(['xxx'],1,22,:test_options => '-p default')
     end
-    
+
     it "sanitizes dangerous file names" do
       should_run_with %r{xx\\ x}
       call(['xx x'],1,22,{})

--- a/spec/parallel_tests/rspec/runner_spec.rb
+++ b/spec/parallel_tests/rspec/runner_spec.rb
@@ -84,6 +84,12 @@ describe ParallelTests::RSpec::Runner do
       call('xxx', 1, 22, {})
     end
 
+    it "uses bin/rspec when present" do
+      File.stub(:exists?).with('bin/rspec').and_return true
+      should_run_with %r{bin/rspec}
+      call('xxx', 1, 22, {})
+    end
+
     it "uses no -O when no opts where found" do
       File.stub!(:file?).with('spec/spec.opts').and_return false
       should_not_run_with %r{spec/spec.opts}


### PR DESCRIPTION
Rails 4 makes extensive use of the bin/ directory for executables. We
should default to using that file if it is present, otherwise fall back
on the previous options.
