### PR TITLE
Option to split cucumber features by scenario.

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -97,6 +97,7 @@ BANNER
 group tests by:
           found - order of finding files
           steps - number of cucumber steps
+          scenarios - individual cucumber scenarios
           default - runtime or filesize
 TEXT
 ) { |type| options[:group_by] = type.to_sym }

--- a/lib/parallel_tests/cucumber/runner.rb
+++ b/lib/parallel_tests/cucumber/runner.rb
@@ -86,8 +86,11 @@ module ParallelTests
         end
 
         def tests_in_groups(tests, num_groups, options={})
-          if options[:group_by] == :steps
+          case options[:group_by]
+          when :steps
             Grouper.by_steps(find_tests(tests, options), num_groups, options)
+          when :scenarios
+            Grouper.by_scenario(find_tests(tests, options))
           else
             super
           end

--- a/lib/parallel_tests/cucumber/scenario_line_logger.rb
+++ b/lib/parallel_tests/cucumber/scenario_line_logger.rb
@@ -1,0 +1,29 @@
+require 'gherkin/tag_expression'
+
+module ParallelTests
+  module Cucumber
+    module Formatters
+      class ScenarioLineLogger
+        attr_reader :scenarios
+
+        def initialize(tag_expression = Gherkin::TagExpression.new([]))
+          @scenarios = []
+          @tag_expression = tag_expression
+        end
+
+        def visit_feature_element(feature_element)
+          if @tag_expression.eval(feature_element.source_tag_names)
+            @scenarios << if feature_element.respond_to? :line
+              [feature_element.feature.file, feature_element.line].join(":")
+            else
+              [feature_element.feature.file, feature_element.instance_variable_get(:@line)].join(":")
+            end
+          end
+        end
+
+        def method_missing(*args)
+        end
+      end
+    end
+  end
+end

--- a/lib/parallel_tests/cucumber/scenarios.rb
+++ b/lib/parallel_tests/cucumber/scenarios.rb
@@ -1,0 +1,28 @@
+require 'gherkin/tag_expression'
+require 'cucumber/runtime'
+require 'cucumber'
+require 'parallel_tests/cucumber/scenario_line_logger'
+
+module ParallelTests
+  module Cucumber
+    class Scenarios
+      def self.all(files)
+        split_into_scenarios files
+      end
+
+      private
+
+      def self.split_into_scenarios(files)
+        tag_expression = Gherkin::TagExpression.new([])
+        scenario_line_logger = ParallelTests::Cucumber::Formatters::ScenarioLineLogger.new(tag_expression)
+        loader = ::Cucumber::Runtime::FeaturesLoader.new(files, [], tag_expression)
+
+        loader.features.each do |feature|
+          feature.accept(scenario_line_logger)
+        end
+
+        scenario_line_logger.scenarios
+      end
+    end
+  end
+end

--- a/lib/parallel_tests/grouper.rb
+++ b/lib/parallel_tests/grouper.rb
@@ -1,9 +1,15 @@
+require 'parallel_tests/cucumber/scenarios'
+
 module ParallelTests
   class Grouper
     class << self
       def by_steps(tests, num_groups, options)
         features_with_steps = build_features_with_steps(tests, options)
         in_even_groups_by_size(features_with_steps, num_groups)
+      end
+
+      def by_scenario(tests)
+        group_by_scenario(tests)
       end
 
       def in_even_groups_by_size(items_with_sizes, num_groups, options = {})
@@ -23,7 +29,7 @@ module ParallelTests
           add_to_group(smallest, item, size)
         end
 
-        groups.map!{|g| g[:items].sort }
+        groups.map {|g| g[:items].sort }
       end
 
       private
@@ -50,6 +56,10 @@ module ParallelTests
           parser.parse(File.read(file), file, 0)
         }
         listener.collect.sort_by{|_,value| -value }
+      end
+
+      def group_by_scenario(tests)
+        ParallelTests::Cucumber::Scenarios.all(tests)
       end
     end
   end

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -44,20 +44,21 @@ module ParallelTests
         end
       end
 
-      # parallel:spec[:count, :pattern, :options]
+      # parallel:spec[:count, :pattern, :options, :parallel_options]
       def parse_args(args)
         # order as given by user
-        args = [args[:count], args[:pattern], args[:options]]
+        args = [args[:count], args[:pattern], args[:options], args[:parallel_options]]
 
         # count given or empty ?
-        # parallel:spec[2,models,options]
+        # parallel:spec[2,models,options,parallel_options]
         # parallel:spec[,models,options]
         count = args.shift if args.first.to_s =~ /^\d*$/
         num_processes = count.to_i unless count.to_s.empty?
         pattern = args.shift
         options = args.shift
+        parallel_options = args.shift
 
-        [num_processes, pattern.to_s, options.to_s]
+        [num_processes, pattern.to_s, options.to_s, parallel_options]
       end
     end
   end
@@ -119,7 +120,7 @@ namespace :parallel do
       $LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), '..'))
       require "parallel_tests"
 
-      count, pattern, options = ParallelTests::Tasks.parse_args(args)
+      count, pattern, options, parallel_options = ParallelTests::Tasks.parse_args(args)
       test_framework = {
         'spec' => 'rspec',
         'test' => 'test',
@@ -130,7 +131,8 @@ namespace :parallel do
       command = "#{executable} #{type} --type #{test_framework} " \
         "-n #{count} "                     \
         "--pattern '#{pattern}' "          \
-        "--test-options '#{options}'"
+        "--test-options '#{options}'"      \
+        "#{parallel_options}"
 
       abort unless system(command) # allow to chain tasks e.g. rake parallel:spec parallel:features
     end

--- a/spec/parallel_tests/grouper_spec.rb
+++ b/spec/parallel_tests/grouper_spec.rb
@@ -49,4 +49,26 @@ describe ParallelTests::Grouper do
       call(6).should == [["5"], ["4"], ["3"], ["2"], ["1"], []]
     end
   end
+
+  describe :by_scenario do
+    let(:feature_file) do
+      Tempfile.new('grouper.feature').tap do |feature|
+        feature.write <<-EOS
+          Feature: Grouping by scenario
+
+            Scenario: First
+              Given I do nothing
+
+            Scenario: Second
+              Given I don't do anything
+        EOS
+        feature.rewind
+      end
+    end
+
+    it 'splits a feature into individual scenarios' do
+      groups = ParallelTests::Grouper.by_scenario([feature_file.path])
+      groups.should eq %W(#{feature_file.path}:3 #{feature_file.path}:6)
+    end
+  end
 end

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -5,22 +5,32 @@ describe ParallelTests::Tasks do
   describe ".parse_args" do
     it "should return the count" do
       args = {:count => 2}
-      ParallelTests::Tasks.parse_args(args).should == [2, "", ""]
+      ParallelTests::Tasks.parse_args(args).should == [2, "", "", nil]
     end
 
     it "should default to the prefix" do
       args = {:count => "models"}
-      ParallelTests::Tasks.parse_args(args).should == [nil, "models", ""]
+      ParallelTests::Tasks.parse_args(args).should == [nil, "models", "", nil]
     end
 
     it "should return the count and pattern" do
       args = {:count => 2, :pattern => "models"}
-      ParallelTests::Tasks.parse_args(args).should == [2, "models", ""]
+      ParallelTests::Tasks.parse_args(args).should == [2, "models", "", nil]
     end
 
     it "should return the count, pattern, and options" do
       args = {:count => 2, :pattern => "plain", :options => "-p default"}
-      ParallelTests::Tasks.parse_args(args).should == [2, "plain", "-p default"]
+      ParallelTests::Tasks.parse_args(args).should == [2, "plain", "-p default", nil]
+    end
+
+    it "should return the count, pattern, options and parallel_options" do
+      args = {
+        :count => 2,
+        :pattern => "plain",
+        :options => "-p default",
+        :parallel_options => "--group-by steps"
+      }
+      ParallelTests::Tasks.parse_args(args).should == [2, "plain", "-p default", "--group-by steps"]
     end
   end
 


### PR DESCRIPTION
Inspired by [cukeforker](http://github.com/jarib/cukeforker). 

Sometimes it's preferable to run scenarios in parallel, eg. when you have large feature files. This gives you the option to do that.
- Splits features into scenarios for grouping.
- Adds an extra argument to the rake task to allow passing options direct to parallel test rather than the runner.
