### PR TITLE
Option to split cucumber features by scenario.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'bump'
-gem 'test-unit'
-gem 'rspec', '>=2.4'
 gem 'cucumber'
+gem 'json', '~> 1.7.7'
 gem 'rake'
+gem 'rspec', '>=2.4'
+gem 'test-unit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,21 +7,20 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    builder (3.0.0)
+    builder (3.2.0)
     bump (0.3.8)
-    cucumber (1.1.4)
+    cucumber (1.3.2)
       builder (>= 2.1.2)
-      diff-lcs (>= 1.1.2)
-      gherkin (~> 2.7.1)
-      json (>= 1.4.6)
-      term-ansicolor (>= 1.0.6)
+      diff-lcs (>= 1.1.3)
+      gherkin (~> 2.12.0)
+      multi_json (~> 1.3)
     diff-lcs (1.2.4)
-    gherkin (2.7.6)
-      json (>= 1.4.6)
-    gherkin (2.7.6-java)
-      json (>= 1.4.6)
-    json (1.7.5)
-    json (1.7.5-java)
+    gherkin (2.12.0)
+      multi_json (~> 1.3)
+    gherkin (2.12.0-java)
+      multi_json (~> 1.3)
+    json (1.7.7)
+    multi_json (1.7.4)
     parallel (0.6.5)
     rake (10.0.3)
     rspec (2.13.0)
@@ -32,7 +31,6 @@ GEM
     rspec-expectations (2.13.0)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.13.1)
-    term-ansicolor (1.0.7)
     test-unit (2.4.4)
 
 PLATFORMS
@@ -42,6 +40,7 @@ PLATFORMS
 DEPENDENCIES
   bump
   cucumber
+  json (~> 1.7.7)
   parallel_tests!
   rake
   rspec (>= 2.4)

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -97,6 +97,7 @@ BANNER
 group tests by:
           found - order of finding files
           steps - number of cucumber steps
+          scenarios - individual cucumber scenarios
           default - runtime or filesize
 TEXT
 ) { |type| options[:group_by] = type.to_sym }

--- a/lib/parallel_tests/cucumber/runner.rb
+++ b/lib/parallel_tests/cucumber/runner.rb
@@ -38,7 +38,7 @@ module ParallelTests
         end
 
         def test_file_name
-          "feature"
+          @test_file_name || "feature"
         end
 
         def test_suffix
@@ -56,7 +56,7 @@ module ParallelTests
           sort_order = %w[scenario step failed undefined skipped pending passed]
 
           %w[scenario step].map do |group|
-            group_results = results.grep /^\d+ #{group}/
+            group_results = results.grep(/^\d+ #{group}/)
             next if group_results.empty?
 
             sums = sum_up_results(group_results)
@@ -86,8 +86,9 @@ module ParallelTests
         end
 
         def tests_in_groups(tests, num_groups, options={})
-          if options[:group_by] == :steps
-            Grouper.by_steps(find_tests(tests, options), num_groups, options)
+          @test_file_name = options[:group_by] == :scenario ? "scenario" : "feature"
+          if Grouper.respond_to?("by_#{options[:group_by]}".to_sym)
+            Grouper.send("by_#{options[:group_by]}".to_sym, find_tests(tests, options), num_groups, options)
           else
             super
           end

--- a/lib/parallel_tests/cucumber/scenario_line_logger.rb
+++ b/lib/parallel_tests/cucumber/scenario_line_logger.rb
@@ -1,0 +1,30 @@
+require 'gherkin/tag_expression'
+
+module ParallelTests
+  module Cucumber
+    module Formatters
+      class ScenarioLineLogger
+        attr_reader :scenarios
+
+        def initialize(tag_expression = Gherkin::TagExpression.new([]))
+          @scenarios = []
+          @tag_expression = tag_expression
+        end
+
+        def visit_feature_element(feature_element)
+          if @tag_expression.evaluate(feature_element.source_tags)
+            line = if feature_element.respond_to?(:line)
+              feature_element.line
+            else
+              feature_element.instance_variable_get(:@line)
+            end
+            @scenarios << [feature_element.feature.file, line].join(":")
+          end
+        end
+
+        def method_missing(*args)
+        end
+      end
+    end
+  end
+end

--- a/lib/parallel_tests/cucumber/scenarios.rb
+++ b/lib/parallel_tests/cucumber/scenarios.rb
@@ -1,0 +1,36 @@
+require 'gherkin/tag_expression'
+require 'cucumber/runtime'
+require 'cucumber'
+require 'parallel_tests/cucumber/scenario_line_logger'
+require 'parallel_tests/cucumber/gherkin_listener'
+
+module ParallelTests
+  module Cucumber
+    class Scenarios
+      class << self
+        def all(files, options={})
+          tag_expressions = if options[:ignore_tag_pattern]
+            options[:ignore_tag_pattern].split(/\s*,\s*/).map {|tag| "~#{tag}" }
+          else
+            []
+          end
+          split_into_scenarios files, tag_expressions
+        end
+
+        private
+
+        def split_into_scenarios(files, tags=[])
+          tag_expression = Gherkin::TagExpression.new(tags)
+          scenario_line_logger = ParallelTests::Cucumber::Formatters::ScenarioLineLogger.new(tag_expression)
+          loader = ::Cucumber::Runtime::FeaturesLoader.new(files, [], tag_expression)
+
+          loader.features.each do |feature|
+            feature.accept(scenario_line_logger)
+          end
+
+          scenario_line_logger.scenarios
+        end
+      end
+    end
+  end
+end

--- a/lib/parallel_tests/grouper.rb
+++ b/lib/parallel_tests/grouper.rb
@@ -1,3 +1,5 @@
+require 'parallel_tests/cucumber/scenarios'
+
 module ParallelTests
   class Grouper
     class << self
@@ -6,24 +8,24 @@ module ParallelTests
         in_even_groups_by_size(features_with_steps, num_groups)
       end
 
-      def in_even_groups_by_size(items_with_sizes, num_groups, options = {})
+      def by_scenario(tests, num_groups, options={})
+        scenarios = group_by_scenario(tests, options)
+        in_even_groups_by_size(scenarios, num_groups)
+      end
+
+      def in_even_groups_by_size(items, num_groups, options= {})
         groups = Array.new(num_groups) { {:items => [], :size => 0} }
 
         # add all files that should run in a single process to one group
         (options[:single_process] || []).each do |pattern|
-          matched, items_with_sizes = items_with_sizes.partition { |item, size| item =~ pattern }
+          matched, items = items.partition { |item, size| item =~ pattern }
           matched.each { |item, size| add_to_group(groups.first, item, size) }
         end
 
         groups_to_fill = (options[:isolate] ? groups[1..-1] : groups)
+        group_features_by_size(items_to_group(items), groups_to_fill)
 
-        # add all other files
-        largest_first(items_with_sizes).each do |item, size|
-          smallest = smallest_group(groups_to_fill)
-          add_to_group(smallest, item, size)
-        end
-
-        groups.map!{|g| g[:items].sort }
+        groups.map {|g| g[:items].sort }
       end
 
       private
@@ -46,10 +48,24 @@ module ParallelTests
         listener = Cucumber::GherkinListener.new
         listener.ignore_tag_pattern = Regexp.compile(options[:ignore_tag_pattern]) if options[:ignore_tag_pattern]
         parser = Gherkin::Parser::Parser.new(listener, true, 'root')
-        tests.each{|file|
-          parser.parse(File.read(file), file, 0)
-        }
+        tests.each{|file| parser.parse(File.read(file), file, 0) }
         listener.collect.sort_by{|_,value| -value }
+      end
+
+      def group_by_scenario(tests, options={})
+        ParallelTests::Cucumber::Scenarios.all(tests, options)
+      end
+
+      def group_features_by_size(items, groups_to_fill)
+        items.each do |item, size|
+          size ||= 1
+          smallest = smallest_group(groups_to_fill)
+          add_to_group(smallest, item, size)
+        end
+      end
+
+      def items_to_group(items)
+        items.first && items.first.size == 2 ? largest_first(items) : items
       end
     end
   end

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -44,20 +44,21 @@ module ParallelTests
         end
       end
 
-      # parallel:spec[:count, :pattern, :options]
+      # parallel:spec[:count, :pattern, :options, :parallel_options]
       def parse_args(args)
         # order as given by user
-        args = [args[:count], args[:pattern], args[:options]]
+        args = [args[:count], args[:pattern], args[:options], args[:parallel_options]]
 
         # count given or empty ?
-        # parallel:spec[2,models,options]
+        # parallel:spec[2,models,options,parallel_options]
         # parallel:spec[,models,options]
         count = args.shift if args.first.to_s =~ /^\d*$/
         num_processes = count.to_i unless count.to_s.empty?
         pattern = args.shift
         options = args.shift
+        parallel_options = args.shift
 
-        [num_processes, pattern.to_s, options.to_s]
+        [num_processes, pattern.to_s, options.to_s, parallel_options]
       end
     end
   end
@@ -119,7 +120,7 @@ namespace :parallel do
       $LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), '..'))
       require "parallel_tests"
 
-      count, pattern, options = ParallelTests::Tasks.parse_args(args)
+      count, pattern, options, parallel_options = ParallelTests::Tasks.parse_args(args)
       test_framework = {
         'spec' => 'rspec',
         'test' => 'test',
@@ -130,7 +131,8 @@ namespace :parallel do
       command = "#{executable} #{type} --type #{test_framework} " \
         "-n #{count} "                     \
         "--pattern '#{pattern}' "          \
-        "--test-options '#{options}'"
+        "--test-options '#{options}'"      \
+        "#{parallel_options}"
 
       abort unless system(command) # allow to chain tasks e.g. rake parallel:spec parallel:features
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -281,5 +281,27 @@ describe 'CLI' do
       results.should include("2 processes for 0 features")
       results.should include("Took")
     end
+
+    it "groups by scenario" do
+      write "features/long.feature", <<-EOS
+      Feature: xxx
+        Scenario: xxx
+          Given I print TEST_ENV_NUMBER
+
+        Scenario: xxx
+          Given I print TEST_ENV_NUMBER
+      EOS
+      result = run_tests "features", :type => "cucumber", :add => "--group-by scenario"
+      result.should include("2 processes for 2 scenarios")
+    end
+
+    it "groups by step" do
+      write "features/good1.feature", "Feature: xxx\n  Scenario: xxx\n    Given I print TEST_ENV_NUMBER"
+      write "features/good2.feature", "Feature: xxx\n  Scenario: xxx\n    Given I print TEST_ENV_NUMBER"
+
+      result = run_tests "features", :type => "cucumber", :add => '--group-by steps'
+
+      result.should include("2 processes for 2 features")
+    end
   end
 end

--- a/spec/parallel_tests/cucumber/scenarios_spec.rb
+++ b/spec/parallel_tests/cucumber/scenarios_spec.rb
@@ -1,0 +1,59 @@
+require 'tempfile'
+require 'parallel_tests/cucumber/scenarios'
+
+module ParallelTests
+  module Cucumber
+    describe Scenarios do
+      describe '.all' do
+        context 'by default' do
+          let(:feature_file) do
+            Tempfile.new('grouper.feature').tap do |feature|
+              feature.write <<-EOS
+                Feature: Grouping by scenario
+
+                  Scenario: First
+                    Given I do nothing
+
+                  Scenario: Second
+                    Given I don't do anything
+              EOS
+              feature.rewind
+            end
+          end
+
+          it 'returns all the scenarios' do
+            scenarios = Scenarios.all([feature_file.path])
+            scenarios.should eq %W(#{feature_file.path}:3 #{feature_file.path}:6)
+          end
+        end
+
+        context 'with tags' do
+          let(:feature_file) do
+            Tempfile.new('grouper.feature').tap do |feature|
+              feature.write <<-EOS
+                Feature: Grouping by scenario
+
+                  @wip
+                  Scenario: First
+                    Given I do nothing
+
+                  Scenario: Second
+                    Given I don't do anything
+
+                  @ignore
+                  Scenario: Third
+                    Given I am ignored
+              EOS
+              feature.rewind
+            end
+          end
+
+          it 'ignores those scenarios' do
+            scenarios = Scenarios.all([feature_file.path], :ignore_tag_pattern => '@ignore, @wip')
+            scenarios.should eq %W(#{feature_file.path}:7)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/parallel_tests/grouper_spec.rb
+++ b/spec/parallel_tests/grouper_spec.rb
@@ -49,4 +49,13 @@ describe ParallelTests::Grouper do
       call(6).should == [["5"], ["4"], ["3"], ["2"], ["1"], []]
     end
   end
+
+  describe :by_scenario do
+    let(:feature_file) { double 'file' }
+
+    it 'splits a feature into individual scenarios' do
+      ParallelTests::Cucumber::Scenarios.should_receive(:all).and_return({ 'feature_file:3' => 1 })
+      ParallelTests::Grouper.by_scenario([feature_file], 1)
+    end
+  end
 end

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -5,22 +5,32 @@ describe ParallelTests::Tasks do
   describe ".parse_args" do
     it "should return the count" do
       args = {:count => 2}
-      ParallelTests::Tasks.parse_args(args).should == [2, "", ""]
+      ParallelTests::Tasks.parse_args(args).should == [2, "", "", nil]
     end
 
     it "should default to the prefix" do
       args = {:count => "models"}
-      ParallelTests::Tasks.parse_args(args).should == [nil, "models", ""]
+      ParallelTests::Tasks.parse_args(args).should == [nil, "models", "", nil]
     end
 
     it "should return the count and pattern" do
       args = {:count => 2, :pattern => "models"}
-      ParallelTests::Tasks.parse_args(args).should == [2, "models", ""]
+      ParallelTests::Tasks.parse_args(args).should == [2, "models", "", nil]
     end
 
     it "should return the count, pattern, and options" do
       args = {:count => 2, :pattern => "plain", :options => "-p default"}
-      ParallelTests::Tasks.parse_args(args).should == [2, "plain", "-p default"]
+      ParallelTests::Tasks.parse_args(args).should == [2, "plain", "-p default", nil]
+    end
+
+    it "should return the count, pattern, options and parallel_options" do
+      args = {
+        :count => 2,
+        :pattern => "plain",
+        :options => "-p default",
+        :parallel_options => "--group-by steps"
+      }
+      ParallelTests::Tasks.parse_args(args).should == [2, "plain", "-p default", "--group-by steps"]
     end
   end
 

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -42,7 +42,7 @@ describe ParallelTests::Test::Runner do
 
     it "does sort when not passed do_sort option" do
       ParallelTests::Test::Runner.stub!(:tests_with_runtime).and_return([])
-      ParallelTests::Grouper.should_receive(:largest_first).and_return([])
+      ParallelTests::Grouper.should_receive(:group_features_by_size).and_return([])
       call([], 1)
     end
 


### PR DESCRIPTION
Inspired by [cukeforker](http://github.com/jarib/cukeforker). Sometimes
the time it takes to run a feature can vary even when containing the
same number of scenarios. In this case it might be more efficient to
group by scenario instead of feature.

As well as adding the option to group by scenario, this also updates the rake task with an argument to set the group type.
