### PR TITLE
Add ability to run db:abort_if_pending_migrations and db:test:prepare from the app namespace.

### DIFF
--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -123,6 +123,7 @@ describe ParallelTests::Tasks do
   describe ".check_for_pending_migrations" do
     after do
       Rake.application.instance_variable_get('@tasks').delete("db:abort_if_pending_migrations")
+      Rake.application.instance_variable_get('@tasks').delete("app:db:abort_if_pending_migrations")
     end
 
     it "should do nothing if pending migrations is no defined" do
@@ -132,6 +133,15 @@ describe ParallelTests::Tasks do
     it "should run pending migrations is task is defined" do
       foo = 1
       Rake::Task.define_task("db:abort_if_pending_migrations") do
+        foo = 2
+      end
+      ParallelTests::Tasks.check_for_pending_migrations
+      foo.should == 2
+    end
+
+    it "should run pending migrations is app task is defined" do
+      foo = 1
+      Rake::Task.define_task("app:db:abort_if_pending_migrations") do
         foo = 2
       end
       ParallelTests::Tasks.check_for_pending_migrations


### PR DESCRIPTION
The problem is that after adding `require 'parallel_tests/tasks'` to my engine's rakefile I still can't run `rake parallel:prepare` as standard `load 'rails/tasks/engine.rake'` doesn't bring `db:abort_if_pending_migrations` and `db:test:preapre` to the global namespace, so they are located at the `app:` namespace.
