### PR TITLE
Add require "rubygems" to the top of the parallel_tests.rb file

### DIFF
--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -1,3 +1,4 @@
+require "rubygems"
 require "parallel"
 require "parallel_tests/railtie" if defined? Rails::Railtie
 require "rbconfig"


### PR DESCRIPTION
Depending on environment, it is possible to get a "gems/parallel_tests-0.15.3/lib/parallel_tests.rb:1:in `require': no such file to load -- parallel" error when executing.  The fix for this is to require rubygems at the top of the parallel_tests.rb file so that parallel_tests can find the parallel gem.
