### PR TITLE
Spike to create a parallel_test type that optionally pulls test_suffix from env variable.

### DIFF
--- a/lib/parallel_tests/gherkin/runner.rb
+++ b/lib/parallel_tests/gherkin/runner.rb
@@ -23,7 +23,7 @@ module ParallelTests
         end
 
         def test_suffix
-          /\.feature/
+          /\.feature$/
         end
 
         def line_is_result?(line)

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -39,7 +39,7 @@ module ParallelTests
         end
 
         def test_suffix
-          /_spec.rb/
+          /_spec\.rb$/
         end
 
         private

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -17,7 +17,7 @@ module ParallelTests
         end
 
         def test_suffix
-          /_(test|spec).rb/
+          /_(test|spec).rb$/
         end
 
         def test_file_name

--- a/spec/parallel_tests/gherkin/runner_behaviour.rb
+++ b/spec/parallel_tests/gherkin/runner_behaviour.rb
@@ -174,4 +174,20 @@ EOF
       call(["1 scenario (1 passed)", "1 step (1 passed)"]).should == "1 scenario (1 passed)\n1 step (1 passed)"
     end
   end
+
+  describe ".find_tests" do
+    include FindTestsHelper
+
+    def call(*args)
+      ParallelTests::Gherkin::Runner.send(:find_tests, *args)
+    end
+
+    it "doesn't find bakup files with the same name as test files" do
+      with_files(['a/x.feature','a/x.feature.bak']) do |root|
+        call(["#{root}/"]).should == [
+          "#{root}/a/x.feature",
+        ]
+      end
+    end
+  end
 end

--- a/spec/parallel_tests/rspec/runner_spec.rb
+++ b/spec/parallel_tests/rspec/runner_spec.rb
@@ -184,4 +184,20 @@ ff.**..
       call(output).should == ['0 examples, 0 failures, 0 pending','1 examples, 1 failures, 1 pending']
     end
   end
+
+  describe ".find_tests" do
+    include FindTestsHelper
+
+    def call(*args)
+      ParallelTests::RSpec::Runner.send(:find_tests, *args)
+    end
+
+    it "doesn't find bakup files with the same name as test files" do
+      with_files(['a/x_spec.rb','a/x_spec.rb.bak']) do |root|
+        call(["#{root}/"]).should == [
+          "#{root}/a/x_spec.rb",
+        ]
+      end
+    end
+  end
 end

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -129,31 +129,10 @@ EOF
   end
 
   describe ".find_tests" do
+    include FindTestsHelper
+
     def call(*args)
       ParallelTests::Test::Runner.send(:find_tests, *args)
-    end
-
-    def with_files(files)
-      begin
-        root = "/tmp/test-find_tests-#{rand(999)}"
-        `mkdir #{root}`
-        files.each do |file|
-          parent = "#{root}/#{File.dirname(file)}"
-          `mkdir -p #{parent}` unless File.exist?(parent)
-          `touch #{root}/#{file}`
-        end
-        yield root
-      ensure
-        `rm -rf #{root}`
-      end
-    end
-
-    def inside_dir(dir)
-      old = Dir.pwd
-      Dir.chdir dir
-      yield
-    ensure
-      Dir.chdir old
     end
 
     it "finds test in folders with appended /" do
@@ -227,6 +206,22 @@ EOF
             "a/z_test.rb",
           ]
         end
+      end
+    end
+
+    it "doesn't find bakup files with the same name as test files" do
+      with_files(['a/x_test.rb','a/x_test.rb.bak']) do |root|
+        call(["#{root}/"]).should == [
+          "#{root}/a/x_test.rb",
+        ]
+      end
+    end
+
+    it "finds minispec files" do
+      with_files(['a/x_spec.rb']) do |root|
+        call(["#{root}/"]).should == [
+          "#{root}/a/x_spec.rb",
+        ]
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -155,3 +155,28 @@ def test_tests_in_groups(klass, folder, suffix)
     end
   end
 end
+
+module FindTestsHelper
+  def with_files(files)
+    begin
+      root = "/tmp/test-find_tests-#{rand(999)}"
+      `mkdir #{root}`
+      files.each do |file|
+        parent = "#{root}/#{File.dirname(file)}"
+        `mkdir -p #{parent}` unless File.exist?(parent)
+        `touch #{root}/#{file}`
+      end
+      yield root
+    ensure
+      `rm -rf #{root}`
+    end
+  end
+
+  def inside_dir(dir)
+    old = Dir.pwd
+    Dir.chdir dir
+    yield
+  ensure
+    Dir.chdir old
+  end
+end


### PR DESCRIPTION
I'm looking for comments on how this could be useful to the parallel_tests project.  I originally attempted to have it support our minispec test suite, but realized with a few tweaks it could be made to serve about anything.  You could combine my patch with the PARALLEL_TESTS_EXECUTABLE variable and run about anything you could imagine.

For our minispec suite, we had *_spec.rb files under a test folder and we didn't need to load any test unit stuff in run_tests.  This way i just run

PARALLEL_TEST_SUFFIX=*_spec.rb parallel_test -t env ./test

Since this is a spike, i didn't get too crazy with the testing, but it would seem that it should be able to support all the ParallelTests::Test:Runner specs.

So, just wondering how insane you think this is, and how i could modify it to better suite your vision of the project.
