### PR TITLE
Edit check for determining Windows platform

### DIFF
--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -60,7 +60,7 @@ module ParallelTests
 
         def execute_command_and_capture_output(env, cmd, silence)
           # make processes descriptive / visible in ps -ef
-          windows = RbConfig::CONFIG['host_os'] =~ /win32/ || /mingw32/
+          windows = RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/ 
           separator = windows ? ' & ' : ';'
           exports = env.map do |k,v|
             if windows


### PR DESCRIPTION
You're currently using 

``` ruby
RbConfig::CONFIG['host_os'] =~ /win32/
```

to identify when the gem is being used on Windows. This works for JRuby on Windows 7, which results to `mswin32`. But on Windows 7 and MRI 1.9.3, this results to `mingw32`. 

My PR changes the regex to `/cygwin|mswin|mingw|bccwin|wince|emx/`. This is the same regex that RSpec uses.
