### PR TITLE
Change method of calculating number of steps at Scenario Outline.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.sh
 tmp
+.bundle
+vendor

--- a/lib/parallel_tests/gherkin/listener.rb
+++ b/lib/parallel_tests/gherkin/listener.rb
@@ -48,17 +48,22 @@ module ParallelTests
         @collect[@uri] = 0
       end
 
-      def examples(*args)
-        @examples += 1
+      #
+      # @param  [Gherkin::Formatter::Model::Examples]  examples
+      #
+      def examples(examples)
+        if examples.rows.size > 0
+          @collect[@uri] += (@outline_steps * examples.rows.size)
+        end
       end
 
       def eof(*args)
-        @collect[@uri] += (@background_steps * @scenarios) + (@outline_steps * @examples)
+        @collect[@uri] += (@background_steps * @scenarios)
         reset_counters!
       end
 
       def reset_counters!
-        @examples = @outline = @outline_steps = @background = @background_steps = @scenarios = 0
+        @outline = @outline_steps = @background = @background_steps = @scenarios = 0
         @ignoring = nil
       end
 

--- a/spec/parallel_tests/gherkin/listener_spec.rb
+++ b/spec/parallel_tests/gherkin/listener_spec.rb
@@ -31,16 +31,16 @@ describe ParallelTests::Gherkin::Listener do
     it "counts scenario outlines steps separately" do
       @listener.scenario_outline("outline")
       5.times {@listener.step(nil)}
-      @listener.collect.should == {"feature_file" => 0}
+      @listener.examples(stub('examples', :rows => Array.new(3)))
+      @listener.collect.should == {"feature_file" => 15}
 
       @listener.scenario("scenario")
       2.times {@listener.step(nil)}
-      @listener.collect.should == {"feature_file" => 2}
+      @listener.collect.should == {"feature_file" => 17}
 
       @listener.scenario("scenario")
-      @listener.collect.should == {"feature_file" => 2}
+      @listener.collect.should == {"feature_file" => 17}
 
-      3.times {@listener.examples}
       @listener.eof
       @listener.collect.should == {"feature_file" => 17}
     end
@@ -71,15 +71,14 @@ describe ParallelTests::Gherkin::Listener do
       @listener.ignore_tag_pattern = nil
       @listener.scenario_outline( stub('scenario', :tags =>[ stub('tag', :name => '@WIP' )]) )
       @listener.step(nil)
-      3.times {@listener.examples}
+      @listener.examples(stub('examples', :rows => Array.new(3)))
       @listener.eof
       @listener.collect.should == {"feature_file" => 3}
-
 
       @listener.ignore_tag_pattern = /@something_other_than_WIP/
       @listener.scenario_outline( stub('scenario', :tags =>[ stub('tag', :name => '@WIP' )]) )
       @listener.step(nil)
-      3.times {@listener.examples}
+      @listener.examples(stub('examples', :rows => Array.new(3)))
       @listener.eof
       @listener.collect.should == {"feature_file" => 6}
     end
@@ -88,7 +87,7 @@ describe ParallelTests::Gherkin::Listener do
       @listener.ignore_tag_pattern = /@WIP/
       @listener.scenario_outline( stub('scenario', :tags =>[ stub('tag', :name => '@WIP' )]) )
       @listener.step(nil)
-      3.times {@listener.examples}
+      @listener.examples(stub('examples', :rows => Array.new(3)))
       @listener.eof
       @listener.collect.should == {"feature_file" => 0}
     end


### PR DESCRIPTION
Hi @grosser .

I changed the calculation of the number of steps in scenario outline.

eg:

``` feature
# Based on turnip/examples

Feature: Battle a monster
  Scenario: normal monster
    Given there is a monster
     When I attack it
     Then it should die
      And Fanfare

  Scenario Outline: a simple outline
      Given there is a monster with <hp> hitpoints
      When I attack the monster and do <damage> points damage
      Then the monster should be <state>

      Examples:
        | hp   | damage | state   |
        | 10   | 13     | alive   |
        | 8    | 5      | dead    |

  Scenario: strong monster
    Given there is a strong monster
     When I attack it
     Then it should die
      And Fanfare
```

Before calculation, number of steps is **11** (`normal monster` = 4, `a simple outline` = 3, `strong monster` = 4).
(If  `a simple outline` is written at the end of the file, number of steps is **14** ...)
