### PR TITLE
Updated rspec to use expect syntax.  Also change == to eq and =~ to match or match_array

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 gem 'bump'
 gem 'test-unit'
-gem 'rspec', '>=2.4'
+gem 'rspec', '2.14'
 gem 'cucumber'
 gem 'spinach'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,14 +26,14 @@ GEM
     json (1.7.5-java)
     parallel (0.9.0)
     rake (10.0.3)
-    rspec (2.13.0)
-      rspec-core (~> 2.13.0)
-      rspec-expectations (~> 2.13.0)
-      rspec-mocks (~> 2.13.0)
-    rspec-core (2.13.1)
-    rspec-expectations (2.13.0)
+    rspec (2.14.0)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.7)
+    rspec-expectations (2.14.4)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.13.1)
+    rspec-mocks (2.14.4)
     spinach (0.8.3)
       colorize (= 0.5.8)
       gherkin-ruby (~> 0.3.0)
@@ -49,6 +49,6 @@ DEPENDENCIES
   cucumber
   parallel_tests!
   rake
-  rspec (>= 2.4)
+  rspec (= 2.14)
   spinach
   test-unit

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -53,38 +53,38 @@ describe 'CLI' do
     result = run_tests "spec", :type => 'rspec'
 
     # test ran and gave their puts
-    result.should include('TEST1')
-    result.should include('TEST2')
+    expect(result).to include('TEST1')
+    expect(result).to include('TEST2')
 
     # all results present
-    result.scan('1 example, 0 failure').size.should == 2 # 2 results
-    result.scan('2 examples, 0 failures').size.should == 1 # 1 summary
-    result.scan(/Finished in \d+\.\d+ seconds/).size.should == 2
-    result.scan(/Took \d+\.\d+ seconds/).size.should == 1 # parallel summary
+    expect(result.scan('1 example, 0 failure').size).to eq 2 # 2 results
+    expect(result.scan('2 examples, 0 failures').size).to eq 1 # 1 summary
+    expect(result.scan(/Finished in \d+\.\d+ seconds/).size).to eq 2
+    expect(result.scan(/Took \d+\.\d+ seconds/).size).to eq 1 # parallel summary
   end
 
   it "runs tests which outputs accented characters" do
     write "spec/xxx_spec.rb", "#encoding: utf-8\ndescribe('it'){it('should'){puts 'Byłem tu'}}"
     result = run_tests "spec", :type => 'rspec'
     # test ran and gave their puts
-    result.should include('Byłem tu')
+    expect(result).to include('Byłem tu')
   end
 
   it "does not run any tests if there are none" do
     write 'spec/xxx_spec.rb', '1'
     result = run_tests "spec", :type => 'rspec'
-    result.should include('No examples found')
-    result.should include('Took')
+    expect(result).to include('No examples found')
+    expect(result).to include('Took')
   end
 
   it "fails when tests fail" do
     write 'spec/xxx_spec.rb', 'describe("it"){it("should"){puts "TEST1"}}'
-    write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){1.should == 2}}'
+    write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){1.should eq 2}}'
     result = run_tests "spec", :fail => true, :type => 'rspec'
 
-    result.scan('1 example, 1 failure').size.should == 1
-    result.scan('1 example, 0 failure').size.should == 1
-    result.scan('2 examples, 1 failure').size.should == 1
+    expect(result.scan('1 example, 1 failure').size).to eq 1
+    expect(result.scan('1 example, 0 failure').size).to eq 1
+    expect(result.scan('2 examples, 1 failure').size).to eq 1
   end
 
   it "can serialize stdout" do
@@ -92,49 +92,49 @@ describe 'CLI' do
     write 'spec/xxx2_spec.rb', 'sleep 0.01; 5.times{describe("it"){it("should"){sleep 0.01; puts "TEST2"}}}'
     result = run_tests "spec", :type => 'rspec', :add => "--serialize-stdout"
 
-    result.should_not =~ /TEST1.*TEST2.*TEST1/m
-    result.should_not =~ /TEST2.*TEST1.*TEST2/m
+    expect(result).to_not match( /TEST1.*TEST2.*TEST1/m )
+    expect(result).to_not match( /TEST2.*TEST1.*TEST2/m )
   end
 
   context "with given commands" do
     it "can exec given commands with ENV['TEST_ENV_NUM']" do
       result = `#{executable} -e 'ruby -e "print ENV[:TEST_ENV_NUMBER.to_s].to_i"' -n 4`
-      result.gsub('"','').split('').sort.should == %w[0 2 3 4]
+      expect(result.gsub('"','').split('').sort).to eq %w[0 2 3 4]
     end
 
     it "can exec given command non-parallel" do
       result = `#{executable} -e 'ruby -e "sleep(rand(10)/100.0); puts ENV[:TEST_ENV_NUMBER.to_s].inspect"' -n 4 --non-parallel`
-      result.split("\n").should == %w["" "2" "3" "4"]
+      expect(result.split("\n")).to eq %w["" "2" "3" "4"]
     end
 
     it "can serialize stdout" do
       result = `#{executable} -e 'ruby -e "5.times{sleep 0.01;puts ENV[:TEST_ENV_NUMBER.to_s].to_i;STDOUT.flush}"' -n 2 --serialize-stdout`
-      result.should_not =~ /0.*2.*0/m
-      result.should_not =~ /2.*0.*2/m
+      expect(result).to_not match( /0.*2.*0/m )
+      expect(result).to_not match( /2.*0.*2/m )
     end
 
     it "exists with success if all sub-processes returned success" do
-      system("#{executable} -e 'cat /dev/null' -n 4").should == true
+      expect(system("#{executable} -e 'cat /dev/null' -n 4")).to eq true
     end
 
     it "exists with failure if any sub-processes returned failure" do
-      system("#{executable} -e 'test -e xxxx' -n 4").should == false
+      expect(system("#{executable} -e 'test -e xxxx' -n 4")).to eq false
     end
   end
 
   it "runs through parallel_rspec" do
     version = `#{executable} -v`
-    `#{bin_folder}/parallel_rspec -v`.should == version
+    expect(`#{bin_folder}/parallel_rspec -v`).to eq version
   end
 
   it "runs through parallel_cucumber" do
     version = `#{executable} -v`
-    `#{bin_folder}/parallel_cucumber -v`.should == version
+    expect(`#{bin_folder}/parallel_cucumber -v`).to eq version
   end
 
   it "runs through parallel_spinach" do
     version = `#{executable} -v`
-    `#{bin_folder}/parallel_spinach -v`.should == version
+    expect(`#{bin_folder}/parallel_spinach -v`).to eq version
   end
 
   it "runs with --group-by found" do
@@ -151,7 +151,7 @@ describe 'CLI' do
     t = Time.now
     run_tests("spec", :processes => 2, :type => 'rspec')
     expected = 10
-    (Time.now - t).should <= expected
+    expect((Time.now - t)).to be <= expected
   end
 
   it "can run with given files" do
@@ -159,15 +159,15 @@ describe 'CLI' do
     write "spec/x2_spec.rb", "puts '222'"
     write "spec/x3_spec.rb", "puts '333'"
     result = run_tests "spec/x1_spec.rb spec/x3_spec.rb", :type => 'rspec'
-    result.should include('111')
-    result.should include('333')
-    result.should_not include('222')
+    expect(result).to include('111')
+    expect(result).to include('333')
+    expect(result).to_not include('222')
   end
 
   it "runs successfully without any files" do
     results = run_tests "", :type => 'rspec'
-    results.should include("2 processes for 0 specs")
-    results.should include("Took")
+    expect(results).to include("2 processes for 0 specs")
+    expect(results).to include("Took")
   end
 
   it "can run with test-options" do
@@ -177,7 +177,7 @@ describe 'CLI' do
       :add => "--test-options ' --version'",
       :processes => 2,
       :type => 'rspec'
-    result.should =~ /\d+\.\d+\.\d+.*\d+\.\d+\.\d+/m # prints version twice
+    expect(result).to match( /\d+\.\d+\.\d+.*\d+\.\d+\.\d+/m)  # prints version twice
   end
 
   it "runs with PARALLEL_TEST_PROCESSORS processes" do
@@ -189,7 +189,7 @@ describe 'CLI' do
       :export => "PARALLEL_TEST_PROCESSORS=#{processes}",
       :processes => processes,
       :type => 'rspec'
-    result.scan(/ENV-.?-/).should =~ ["ENV--", "ENV-2-", "ENV-3-", "ENV-4-", "ENV-5-"]
+    expect(result.scan(/ENV-.?-/)).to match_array( ["ENV--", "ENV-2-", "ENV-3-", "ENV-4-", "ENV-5-"] )
   end
 
   it "filters test by given pattern and relative paths" do
@@ -197,9 +197,9 @@ describe 'CLI' do
     write "spec/y_spec.rb", "puts 'YYY'"
     write "spec/z_spec.rb", "puts 'ZZZ'"
     result = run_tests "spec", :add => "-p '^spec/(x|z)'", :type => "rspec"
-    result.should include('XXX')
-    result.should_not include('YYY')
-    result.should include('ZZZ')
+    expect(result).to include('XXX')
+    expect(result).to_not include('YYY')
+    expect(result).to include('ZZZ')
   end
 
   it "can wait_for_other_processes_to_finish" do
@@ -208,26 +208,26 @@ describe 'CLI' do
     write "test/b_test.rb", "sleep 1; puts 'b'"
     write "test/c_test.rb", "sleep 1.5; puts 'c'"
     write "test/d_test.rb", "sleep 2; puts 'd'"
-    run_tests("test", :processes => 4).should include("b\nc\nd\na\n")
+    expect(run_tests("test", :processes => 4)).to include("b\nc\nd\na\n")
   end
 
   context "Test::Unit" do
     it "runs" do
       write "test/x1_test.rb", "require 'test/unit'; class XTest < Test::Unit::TestCase; def test_xxx; end; end"
       result = run_tests("test")
-      result.should include('1 test')
+      expect(result).to include('1 test')
     end
 
     it "passes test options" do
       write "test/x1_test.rb", "require 'test/unit'; class XTest < Test::Unit::TestCase; def test_xxx; end; end"
       result = run_tests("test", :add => '--test-options "-v"')
-      result.should include('test_xxx') # verbose output of every test
+      expect(result).to include('test_xxx') # verbose output of every test
     end
 
     it "runs successfully without any files" do
       results = run_tests("")
-      results.should include("2 processes for 0 tests")
-      results.should include("Took")
+      expect(results).to include("2 processes for 0 tests")
+      expect(results).to include("Took")
     end
   end
 
@@ -245,7 +245,7 @@ describe 'CLI' do
       write "features/good1.feature", "Feature: xxx\n  Scenario: xxx\n    Given I print accented characters"
       write "features/steps/a.rb", "#encoding: utf-8\nGiven('I print accented characters'){ puts \"I tu też\" }"
       result = run_tests "features", :type => "cucumber", :add => '--pattern good'
-      result.should include('I tu też')
+      expect(result).to include('I tu też')
     end
 
     it "passes TEST_ENV_NUMBER when running with pattern (issue #86)" do
@@ -256,9 +256,9 @@ describe 'CLI' do
 
       result = run_tests "features", :type => "cucumber", :add => '--pattern good'
 
-      result.should include('YOUR TEST ENV IS 2!')
-      result.should include('YOUR TEST ENV IS !')
-      result.should_not include('I FAIL')
+      expect(result).to include('YOUR TEST ENV IS 2!')
+      expect(result).to include('YOUR TEST ENV IS !')
+      expect(result).to_not include('I FAIL')
     end
 
     it "writes a runtime log" do
@@ -269,10 +269,10 @@ describe 'CLI' do
         write "features/good#{i}.feature", "Feature: xxx\n  Scenario: xxx\n    Given I print TEST_ENV_NUMBER\n    And I sleep a bit"
       }
       run_tests "features", :type => "cucumber"
-      read(log).gsub(/\.\d+/,'').split("\n").should =~ [
+      expect(read(log).gsub(/\.\d+/,'').split("\n")).to match_array( [
         "features/good0.feature:0",
         "features/good1.feature:0"
-      ]
+      ])
     end
 
     it "runs each feature once when there are more processes then features (issue #89)" do
@@ -280,13 +280,13 @@ describe 'CLI' do
         write "features/good#{i}.feature", "Feature: xxx\n  Scenario: xxx\n    Given I print TEST_ENV_NUMBER"
       }
       result = run_tests "features", :type => "cucumber", :add => '-n 3'
-      result.scan(/YOUR TEST ENV IS \d?!/).sort.should == ["YOUR TEST ENV IS !", "YOUR TEST ENV IS 2!"]
+      expect(result.scan(/YOUR TEST ENV IS \d?!/).sort).to eq ["YOUR TEST ENV IS !", "YOUR TEST ENV IS 2!"]
     end
 
     it "runs successfully without any files" do
       results = run_tests("", :type => "cucumber")
-      results.should include("2 processes for 0 features")
-      results.should include("Took")
+      expect(results).to include("2 processes for 0 features")
+      expect(results).to include("Took")
     end
 
     it "collates failing scenarios" do
@@ -295,7 +295,7 @@ describe 'CLI' do
       write "features/fail2.feature", "Feature: xxx\n  Scenario: xxx\n    Given I fail"
       results = run_tests "features", :processes => 3, :type => "cucumber", :fail => true
 
-      results.should include """
+      expect(results).to include """
 Failing Scenarios:
 cucumber features/fail2.feature:2 # Scenario: xxx
 cucumber features/fail1.feature:2 # Scenario: xxx
@@ -315,7 +315,7 @@ cucumber features/fail1.feature:2 # Scenario: xxx
       write "features/good1.feature", "Feature: a\n  Scenario: xxx\n    Given I print accented characters"
       write "features/steps/a.rb", "#encoding: utf-8\nclass A < Spinach::FeatureSteps\nGiven 'I print accented characters' do\n  puts \"I tu też\" \n  end\nend"
       result = run_tests "features", :type => "spinach", :add => 'features/good1.feature'#, :add => '--pattern good'
-      result.should include('I tu też')
+      expect(result).to include('I tu też')
     end
 
     it "passes TEST_ENV_NUMBER when running with pattern (issue #86)" do
@@ -326,9 +326,9 @@ cucumber features/fail1.feature:2 # Scenario: xxx
 
       result = run_tests "features", :type => "spinach", :add => '--pattern good'
 
-      result.should include('YOUR TEST ENV IS 2!')
-      result.should include('YOUR TEST ENV IS !')
-      result.should_not include('I FAIL')
+      expect(result).to include('YOUR TEST ENV IS 2!')
+      expect(result).to include('YOUR TEST ENV IS !')
+      expect(result).to_not include('I FAIL')
     end
 
     it "writes a runtime log" do
@@ -341,10 +341,10 @@ cucumber features/fail1.feature:2 # Scenario: xxx
         write "features/good#{i}.feature", "Feature: A\n  Scenario: xxx\n    Given I print TEST_ENV_NUMBER\n    And I sleep a bit"
       }
       result = run_tests "features", :type => "spinach"
-      read(log).gsub(/\.\d+/,'').split("\n").should =~ [
+      expect(read(log).gsub(/\.\d+/,'').split("\n")).to match( [
         "features/good0.feature:0",
         "features/good1.feature:0"
-      ]
+      ])
     end
 
     it "runs each feature once when there are more processes then features (issue #89)" do
@@ -352,13 +352,13 @@ cucumber features/fail1.feature:2 # Scenario: xxx
         write "features/good#{i}.feature", "Feature: A\n  Scenario: xxx\n    Given I print TEST_ENV_NUMBER\n"
       }
       result = run_tests "features", :type => "spinach", :add => '-n 3'
-      result.scan(/YOUR TEST ENV IS \d?!/).sort.should == ["YOUR TEST ENV IS !", "YOUR TEST ENV IS 2!"]
+      expect(result.scan(/YOUR TEST ENV IS \d?!/).sort).to eq ["YOUR TEST ENV IS !", "YOUR TEST ENV IS 2!"]
     end
 
     it "runs successfully without any files" do
       results = run_tests("", :type => "spinach")
-      results.should include("2 processes for 0 features")
-      results.should include("Took")
+      expect(results).to include("2 processes for 0 features")
+      expect(results).to include("Took")
     end
   end
 end

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -14,41 +14,41 @@ describe ParallelTests::CLI do
     end
 
     it "parses regular count" do
-      call(["-n3"]).should == defaults.merge(:count => 3)
+      expect(call(["-n3"])).to eq defaults.merge(:count => 3)
     end
 
     it "parses count 0 as non-parallel" do
-      call(["-n0"]).should == defaults.merge(:non_parallel => true)
+      expect(call(["-n0"])).to eq defaults.merge(:non_parallel => true)
     end
 
     it "parses non-parallel as non-parallel" do
-      call(["--non-parallel"]).should == defaults.merge(:non_parallel => true)
+      expect(call(["--non-parallel"])).to eq defaults.merge(:non_parallel => true)
     end
 
     it "finds the correct type when multiple are given" do
       call(["--type", "test", "-t", "rspec"])
-      subject.instance_variable_get(:@runner).should == ParallelTests::RSpec::Runner
+      expect(subject.instance_variable_get(:@runner)).to eq ParallelTests::RSpec::Runner
     end
 
     it "parses nice as nice" do
-      call(["--nice"]).should == defaults.merge(:nice => true)
+      expect(call(["--nice"])).to eq defaults.merge(:nice => true)
     end
   end
 
   describe "#load_runner" do
     it "requires and loads default runner" do
-      subject.should_receive(:require).with("parallel_tests/test/runner")
-      subject.send(:load_runner, "test").should == ParallelTests::Test::Runner
+      expect(subject).to receive(:require).with("parallel_tests/test/runner")
+      expect(subject.send(:load_runner, "test")).to eq ParallelTests::Test::Runner
     end
 
     it "requires and loads rspec runner" do
-      subject.should_receive(:require).with("parallel_tests/rspec/runner")
-      subject.send(:load_runner, "rspec").should == ParallelTests::RSpec::Runner
+      expect(subject).to receive(:require).with("parallel_tests/rspec/runner")
+      expect(subject.send(:load_runner, "rspec")).to eq ParallelTests::RSpec::Runner
     end
 
     it "fails to load unfindable runner" do
       expect{
-        subject.send(:load_runner, "foo").should == ParallelTests::RSpec::Runner
+        expect(subject.send(:load_runner, "foo")).to eq ParallelTests::RSpec::Runner
       }.to raise_error(LoadError)
     end
   end
@@ -59,13 +59,13 @@ describe ParallelTests::CLI do
     end
 
     it 'returns a plain fail message if colors are nor supported' do
-      subject.should_receive(:use_colors?).and_return(false)
-      subject.send(:final_fail_message).should ==  "Tests Failed"
+      expect(subject).to receive(:use_colors?).and_return(false)
+      expect(subject.send(:final_fail_message)).to eq  "Tests Failed"
     end
 
     it 'returns a colorized fail message if colors are supported' do
-      subject.should_receive(:use_colors?).and_return(true)
-      subject.send(:final_fail_message).should == "\e[31mTests Failed\e[0m"
+      expect(subject).to receive(:use_colors?).and_return(true)
+      expect(subject.send(:final_fail_message)).to eq "\e[31mTests Failed\e[0m"
     end
   end
 end

--- a/spec/parallel_tests/cucumber/failure_logger_spec.rb
+++ b/spec/parallel_tests/cucumber/failure_logger_spec.rb
@@ -28,7 +28,7 @@ describe ParallelTests::Cucumber::FailuresLogger do
 
     output_file_contents = @output.output.join("\n").concat("\n")
 
-    output_file_contents.should == <<END
+    expect(output_file_contents).to eq <<END
 feature/path/to/feature1.feature:1
 feature/path/to/feature1.feature:2
 feature/path/to/feature1.feature:3

--- a/spec/parallel_tests/cucumber/runner_spec.rb
+++ b/spec/parallel_tests/cucumber/runner_spec.rb
@@ -18,7 +18,7 @@ describe ParallelTests::Cucumber::Runner do
         results = ["Failing Scenarios:", "cucumber features/failure:1", "cucumber features/failure:2",
                    "Failing Scenarios:", "cucumber features/failure:3", "cucumber features/failure:4",
                    "Failing Scenarios:", "cucumber features/failure:5", "cucumber features/failure:6"]
-        call(results).should == "Failing Scenarios:\ncucumber features/failure:1\ncucumber features/failure:2\ncucumber features/failure:3\ncucumber features/failure:4\ncucumber features/failure:5\ncucumber features/failure:6\n\n"
+        expect(call(results)).to eq "Failing Scenarios:\ncucumber features/failure:1\ncucumber features/failure:2\ncucumber features/failure:3\ncucumber features/failure:4\ncucumber features/failure:5\ncucumber features/failure:6\n\n"
       end
     end
   end

--- a/spec/parallel_tests/gherkin/listener_spec.rb
+++ b/spec/parallel_tests/gherkin/listener_spec.rb
@@ -9,40 +9,40 @@ describe ParallelTests::Gherkin::Listener do
 
     it "returns steps count" do
       3.times {@listener.step(nil)}
-      @listener.collect.should == {"feature_file" => 3}
+      expect(@listener.collect).to eq ({ "feature_file" => 3} )
     end
 
     it "counts background steps separately" do
       @listener.background("background")
       5.times {@listener.step(nil)}
-      @listener.collect.should == {"feature_file" => 0}
+      expect(@listener.collect).to eq ({ "feature_file" => 0} )
 
       @listener.scenario("scenario")
       2.times {@listener.step(nil)}
-      @listener.collect.should == {"feature_file" => 2}
+      expect(@listener.collect).to eq ({ "feature_file" => 2} )
 
       @listener.scenario("scenario")
-      @listener.collect.should == {"feature_file" => 2}
+      expect(@listener.collect).to eq ({ "feature_file" => 2} )
 
       @listener.eof
-      @listener.collect.should == {"feature_file" => 12}
+      expect(@listener.collect).to eq ({ "feature_file" => 12} )
     end
 
     it "counts scenario outlines steps separately" do
       @listener.scenario_outline("outline")
       5.times {@listener.step(nil)}
       @listener.examples(stub('examples', :rows => Array.new(3)))
-      @listener.collect.should == {"feature_file" => 15}
+      expect(@listener.collect).to eq ({ "feature_file" => 15} )
 
       @listener.scenario("scenario")
       2.times {@listener.step(nil)}
-      @listener.collect.should == {"feature_file" => 17}
+      expect(@listener.collect).to eq ({ "feature_file" => 17} )
 
       @listener.scenario("scenario")
-      @listener.collect.should == {"feature_file" => 17}
+      expect(@listener.collect).to eq ({ "feature_file" => 17} )
 
       @listener.eof
-      @listener.collect.should == {"feature_file" => 17}
+      expect(@listener.collect).to eq ({ "feature_file" => 17} )
     end
 
     it 'counts scenarios that should not be ignored' do
@@ -50,13 +50,13 @@ describe ParallelTests::Gherkin::Listener do
       @listener.scenario( stub('scenario', :tags =>[ stub('tag', :name => '@WIP' )]) )
       @listener.step(nil)
       @listener.eof
-      @listener.collect.should == {"feature_file" => 1}
+      expect(@listener.collect).to eq ({ "feature_file" => 1} )
 
       @listener.ignore_tag_pattern = /@something_other_than_WIP/
       @listener.scenario( stub('scenario', :tags =>[ stub('tag', :name => '@WIP' )]) )
       @listener.step(nil)
       @listener.eof
-      @listener.collect.should == {"feature_file" => 2}
+      expect(@listener.collect).to eq ({ "feature_file" => 2} )
     end
 
     it 'does not count scenarios that should be ignored' do
@@ -64,7 +64,7 @@ describe ParallelTests::Gherkin::Listener do
       @listener.scenario( stub('scenario', :tags =>[ stub('tag', :name => '@WIP' )]))
       @listener.step(nil)
       @listener.eof
-      @listener.collect.should == {"feature_file" => 0}
+      expect(@listener.collect).to eq ({ "feature_file" => 0} )
     end
 
     it 'counts outlines that should not be ignored' do
@@ -73,14 +73,14 @@ describe ParallelTests::Gherkin::Listener do
       @listener.step(nil)
       @listener.examples(stub('examples', :rows => Array.new(3)))
       @listener.eof
-      @listener.collect.should == {"feature_file" => 3}
+      expect(@listener.collect).to eq ({ "feature_file" => 3} )
 
       @listener.ignore_tag_pattern = /@something_other_than_WIP/
       @listener.scenario_outline( stub('scenario', :tags =>[ stub('tag', :name => '@WIP' )]) )
       @listener.step(nil)
       @listener.examples(stub('examples', :rows => Array.new(3)))
       @listener.eof
-      @listener.collect.should == {"feature_file" => 6}
+      expect(@listener.collect).to eq ({ "feature_file" => 6} )
     end
 
     it 'does not count outlines that should be ignored' do
@@ -89,7 +89,7 @@ describe ParallelTests::Gherkin::Listener do
       @listener.step(nil)
       @listener.examples(stub('examples', :rows => Array.new(3)))
       @listener.eof
-      @listener.collect.should == {"feature_file" => 0}
+      expect(@listener.collect).to eq ({ "feature_file" => 0} )
     end
 
   end

--- a/spec/parallel_tests/gherkin/runner_behaviour.rb
+++ b/spec/parallel_tests/gherkin/runner_behaviour.rb
@@ -14,7 +14,7 @@ shared_examples_for 'gherkin runners' do
     end
 
     def should_run_with(regex)
-      ParallelTests::Test::Runner.should_receive(:execute_command).with { |a, b, c, d| a =~ regex }
+      expect(ParallelTests::Test::Runner).to receive(:execute_command).with { |a, b, c, d| a =~ regex }
     end
 
     it "allows to override runner executable via PARALLEL_TESTS_EXECUTABLE" do
@@ -83,14 +83,14 @@ shared_examples_for 'gherkin runners' do
     it "does not use parallel profile if config/{runner_name}.yml does not contain it" do
       file_contents = 'blob: -f progress'
       should_run_with %r{script/#{runner_name} .* foo bar}
-      Dir.should_receive(:glob).and_return ["config/#{runner_name}.yml"]
-      File.should_receive(:read).with("config/#{runner_name}.yml").and_return file_contents
+      expect(Dir).to receive(:glob).and_return ["config/#{runner_name}.yml"]
+      expect(File).to receive(:read).with("config/#{runner_name}.yml").and_return file_contents
       call(['xxx'], 1, 22, :test_options => 'foo bar')
     end
 
     it "does not use the parallel profile if config/{runner_name}.yml does not exist" do
       should_run_with %r{script/#{runner_name}} # TODO this test looks useless...
-      Dir.should_receive(:glob).and_return []
+      expect(Dir).to receive(:glob).and_return []
       call(['xxx'], 1, 22, {})
     end
   end
@@ -98,27 +98,27 @@ shared_examples_for 'gherkin runners' do
   describe :line_is_result? do
     it "should match lines with only one scenario" do
       line = "1 scenario (1 failed)"
-      runner_class().line_is_result?(line).should be_true
+      expect(runner_class().line_is_result?(line)).to be_true
     end
 
     it "should match lines with multiple scenarios" do
       line = "2 scenarios (1 failed, 1 passed)"
-      runner_class().line_is_result?(line).should be_true
+      expect(runner_class().line_is_result?(line)).to be_true
     end
 
     it "should match lines with only one step" do
       line = "1 step (1 failed)"
-      runner_class().line_is_result?(line).should be_true
+     expect( runner_class().line_is_result?(line)).to be_true
     end
 
     it "should match lines with multiple steps" do
       line = "5 steps (1 failed, 4 passed)"
-      runner_class().line_is_result?(line).should be_true
+      expect(runner_class().line_is_result?(line)).to be_true
     end
 
     it "should not match other lines" do
       line = '    And I should have "2" emails                                # features/step_definitions/user_steps.rb:25'
-      runner_class().line_is_result?(line).should be_false
+      expect(runner_class().line_is_result?(line)).to be_false
     end
   end
 
@@ -143,7 +143,7 @@ And I should not see "foo"                                       # features/step
 1 step (1 passed)
 
 EOF
-      runner_class().find_results(output).should == ["7 scenarios (3 failed, 4 passed)", "33 steps (3 failed, 2 skipped, 28 passed)", "4 scenarios (4 passed)", "40 steps (40 passed)", "1 scenario (1 passed)", "1 step (1 passed)"]
+      expect(runner_class().find_results(output)).to match_array(["7 scenarios (3 failed, 4 passed)", "33 steps (3 failed, 2 skipped, 28 passed)", "4 scenarios (4 passed)", "40 steps (40 passed)", "1 scenario (1 passed)", "1 step (1 passed)"])
     end
   end
 
@@ -155,23 +155,23 @@ EOF
     it "sums up results for scenarios and steps separately from each other" do
       results = ["7 scenarios (3 failed, 4 passed)", "33 steps (3 failed, 2 skipped, 28 passed)", "4 scenarios (4 passed)",
                  "40 steps (40 passed)", "1 scenario (1 passed)", "1 step (1 passed)"]
-      call(results).should == "12 scenarios (3 failed, 9 passed)\n74 steps (3 failed, 2 skipped, 69 passed)"
+      expect(call(results)).to eq "12 scenarios (3 failed, 9 passed)\n74 steps (3 failed, 2 skipped, 69 passed)"
     end
 
     it "adds same results with plurals" do
       results = ["1 scenario (1 passed)", "2 steps (2 passed)",
                  "2 scenarios (2 passed)", "7 steps (7 passed)"]
-      call(results).should == "3 scenarios (3 passed)\n9 steps (9 passed)"
+      expect(call(results)).to eq "3 scenarios (3 passed)\n9 steps (9 passed)"
     end
 
     it "adds non-similar results" do
       results = ["1 scenario (1 passed)", "1 step (1 passed)",
                  "2 scenarios (1 failed, 1 pending)", "2 steps (1 failed, 1 pending)"]
-      call(results).should == "3 scenarios (1 failed, 1 pending, 1 passed)\n3 steps (1 failed, 1 pending, 1 passed)"
+      expect(call(results)).to eq "3 scenarios (1 failed, 1 pending, 1 passed)\n3 steps (1 failed, 1 pending, 1 passed)"
     end
 
     it "does not pluralize 1" do
-      call(["1 scenario (1 passed)", "1 step (1 passed)"]).should == "1 scenario (1 passed)\n1 step (1 passed)"
+     expect( call(["1 scenario (1 passed)", "1 step (1 passed)"])).to eq "1 scenario (1 passed)\n1 step (1 passed)"
     end
   end
 

--- a/spec/parallel_tests/grouper_spec.rb
+++ b/spec/parallel_tests/grouper_spec.rb
@@ -19,10 +19,10 @@ describe ParallelTests::Grouper do
       end
 
       # testing inside mktmpdir is always green
-      result.should =~ [
+      expect(result).to match_array( [
         ["#{tmpdir}/a.feature", "#{tmpdir}/c.feature"],
         ["#{tmpdir}/b.feature"]
-      ]
+      ])
     end
   end
 
@@ -34,19 +34,19 @@ describe ParallelTests::Grouper do
     end
 
     it "groups 1 by 1 for same groups as size" do
-      call(5).should == [["5"], ["4"], ["3"], ["2"], ["1"]]
+      expect(call(5)).to eq [["5"], ["4"], ["3"], ["2"], ["1"]]
     end
 
     it "groups into even groups" do
-      call(2).should ==  [["1", "2", "5"], ["3", "4"]]
+      expect(call(2)).to eq [["1", "2", "5"], ["3", "4"]]
     end
 
     it "groups into a single group" do
-      call(1).should == [["1", "2", "3", "4", "5"]]
+      expect(call(1)).to eq [["1", "2", "3", "4", "5"]]
     end
 
     it "adds empty groups if there are more groups than feature files" do
-      call(6).should == [["5"], ["4"], ["3"], ["2"], ["1"], []]
+      expect(call(6)).to eq [["5"], ["4"], ["3"], ["2"], ["1"], []]
     end
   end
 end

--- a/spec/parallel_tests/rspec/failures_logger_spec.rb
+++ b/spec/parallel_tests/rspec/failures_logger_spec.rb
@@ -32,8 +32,8 @@ describe ParallelTests::RSpec::FailuresLogger do
     @logger.dump_failures
     @logger.dump_summary(1,2,3,4)
 
-    clean_output.should =~ /^rspec .*? should do stuff/
-    clean_output.should =~ /^rspec .*? should do other stuff/
+    expect(clean_output).to match( /^rspec .*? should do stuff/ )
+    expect(clean_output).to match( /^rspec .*? should do other stuff/ )
   end
 
   it "should invoke spec for rspec 1" do
@@ -45,7 +45,7 @@ describe ParallelTests::RSpec::FailuresLogger do
     @logger.dump_failures
     @logger.dump_summary(1,2,3,4)
 
-    clean_output.should =~ /^bundle exec spec/
+    expect(clean_output).to match( /^bundle exec spec/ )
   end
 
   it "should invoke rspec for rspec 2" do
@@ -56,7 +56,7 @@ describe ParallelTests::RSpec::FailuresLogger do
     @logger.dump_failures
     @logger.dump_summary(1,2,3,4)
 
-    clean_output.should =~ /^rspec/
+    expect(clean_output).to match( /^rspec/ )
   end
 
   it "should return relative paths" do
@@ -66,8 +66,8 @@ describe ParallelTests::RSpec::FailuresLogger do
     @logger.dump_failures
     @logger.dump_summary(1,2,3,4)
 
-    clean_output.should =~ %r(\./spec/path/to/example:123)
-    clean_output.should =~ %r(\./spec/path/to/example2:456)
+    expect(clean_output).to match( %r(\./spec/path/to/example:123) )
+    expect(clean_output).to match( %r(\./spec/path/to/example2:456) )
   end
 
 
@@ -77,6 +77,6 @@ describe ParallelTests::RSpec::FailuresLogger do
     @logger.example_failed example
     @logger.dump_failures
     @logger.dump_summary(1,2,3,4)
-    clean_output.should == ''
+    expect(clean_output).to eq ''
   end
 end

--- a/spec/parallel_tests/rspec/runner_spec.rb
+++ b/spec/parallel_tests/rspec/runner_spec.rb
@@ -18,41 +18,41 @@ describe ParallelTests::RSpec::Runner do
     end
 
     def should_run_with(regex)
-      ParallelTests::Test::Runner.should_receive(:execute_command).with{|a,b,c,d| a =~ regex}
+      expect(ParallelTests::Test::Runner).to receive(:execute_command).with{|a,b,c,d| a.match(regex)}
     end
 
     def should_not_run_with(regex)
-      ParallelTests::Test::Runner.should_receive(:execute_command).with{|a,b,c,d| a !~ regex}
+      expect(ParallelTests::Test::Runner).to receive(:execute_command).with{|a,b,c,d| a !~ regex}
     end
 
     it "runs command using nice when specifed" do
-      ParallelTests::Test::Runner.should_receive(:execute_command_and_capture_output).with{|a,b,c| b =~ %r{^nice rspec}}
+      expect{(ParallelTests::Test::Runner).to receive(:execute_command_and_capture_output).with{|a,b,c| b match( %r{^nice rspec})}}.to be_true
       call('xxx', 1, 22, :nice => true)
     end
 
     it "runs with color when called from cmdline" do
       should_run_with %r{ --tty}
-      $stdout.should_receive(:tty?).and_return true
+      expect($stdout).to receive(:tty?).and_return true
       call('xxx', 1, 22, {})
     end
 
     it "runs without color when not called from cmdline" do
       should_not_run_with %r{ --tty}
-      $stdout.should_receive(:tty?).and_return false
+      expect($stdout).to receive(:tty?).and_return false
       call('xxx', 1, 22, {})
     end
 
     it "runs with color for rspec 1 when called for the cmdline" do
-      File.should_receive(:file?).with('script/spec').and_return true
-      ParallelTests::Test::Runner.should_receive(:execute_command).with { |a, b, c, d| d[:env] == {"RSPEC_COLOR" => "1"} }
-      $stdout.should_receive(:tty?).and_return true
+      expect(File).to receive(:file?).with('script/spec').and_return true
+      expect(ParallelTests::Test::Runner).to receive(:execute_command).with { |a, b, c, d| d[:env] == {"RSPEC_COLOR" => "1"} }
+      expect($stdout).to receive(:tty?).and_return true
       call('xxx', 1, 22, {})
     end
 
     it "runs without color for rspec 1 when not called for the cmdline" do
-      File.should_receive(:file?).with('script/spec').and_return true
-      ParallelTests::Test::Runner.should_receive(:execute_command).with { |a, b, c, d| d[:env] == {} }
-      $stdout.should_receive(:tty?).and_return false
+      expect(File).to receive(:file?).with('script/spec').and_return true
+      expect(ParallelTests::Test::Runner).to receive(:execute_command).with { |a, b, c, d| d[:env] == {} }
+      expect($stdout).to receive(:tty?).and_return false
       call('xxx', 1, 22, {})
     end
 
@@ -73,7 +73,7 @@ describe ParallelTests::RSpec::Runner do
     end
 
     it "runs script/spec when script/spec can be found" do
-      File.should_receive(:file?).with('script/spec').and_return true
+      expect(File).to receive(:file?).with('script/spec').and_return true
       should_run_with %r{script/spec}
       call('xxx' ,1, 22, {})
     end
@@ -105,20 +105,20 @@ describe ParallelTests::RSpec::Runner do
 
     it "uses -O spec/parallel_spec.opts when found (with script/spec)" do
       File.stub!(:file?).with('script/spec').and_return true
-      File.should_receive(:file?).with('spec/parallel_spec.opts').and_return true
+      expect(File).to receive(:file?).with('spec/parallel_spec.opts').and_return true
       should_run_with %r{script/spec\s+-O spec/parallel_spec.opts}
       call('xxx', 1, 22, {})
     end
 
     it "uses -O .rspec_parallel when found (with script/spec)" do
       File.stub!(:file?).with('script/spec').and_return true
-      File.should_receive(:file?).with('.rspec_parallel').and_return true
+      expect(File).to receive(:file?).with('.rspec_parallel').and_return true
       should_run_with %r{script/spec\s+-O .rspec_parallel}
       call('xxx', 1, 22, {})
     end
 
     it "uses -O spec/parallel_spec.opts with rspec1" do
-      File.should_receive(:file?).with('spec/parallel_spec.opts').and_return true
+      expect(File).to receive(:file?).with('spec/parallel_spec.opts').and_return true
 
       ParallelTests.stub!(:bundler_enabled?).and_return true
       ParallelTests::RSpec::Runner.stub!(:run).with("bundle show rspec-core").and_return "Could not find gem 'rspec-core'."
@@ -129,7 +129,7 @@ describe ParallelTests::RSpec::Runner do
 
     it "uses -O spec/parallel_spec.opts with rspec2" do
       pending if RUBY_PLATFORM == "java" # FIXME not sure why, but fails on travis
-      File.should_receive(:file?).with('spec/parallel_spec.opts').and_return true
+      expect(File).to receive(:file?).with('spec/parallel_spec.opts').and_return true
 
       ParallelTests.stub!(:bundler_enabled?).and_return true
       ParallelTests::RSpec::Runner.stub!(:run).with("bundle show rspec-core").and_return "/foo/bar/rspec-core-2.4.2"
@@ -144,8 +144,8 @@ describe ParallelTests::RSpec::Runner do
     end
 
     it "returns the output" do
-      ParallelTests::RSpec::Runner.should_receive(:execute_command).and_return :x => 1
-      call('xxx', 1, 22, {}).should == {:x => 1}
+      expect(ParallelTests::RSpec::Runner).to receive(:execute_command).and_return :x => 1
+      expect(call('xxx', 1, 22, {})).to eq ({ :x => 1} )
     end
   end
 
@@ -166,7 +166,7 @@ ff.**..
 1 example, 1 failure, 1 pending
 "
 
-      call(output).should == ['0 examples, 0 failures, 0 pending','1 example, 1 failure, 1 pending']
+      expect(call(output)).to eq ['0 examples, 0 failures, 0 pending','1 example, 1 failure, 1 pending']
     end
 
     it "is robust against scrambeled output" do
@@ -181,7 +181,7 @@ ff.**..
 1 exampF.les, 1 failures, 1 pend.ing
 "
 
-      call(output).should == ['0 examples, 0 failures, 0 pending','1 examples, 1 failures, 1 pending']
+      expect(call(output)).to eq ['0 examples, 0 failures, 0 pending','1 examples, 1 failures, 1 pending']
     end
   end
 

--- a/spec/parallel_tests/rspec/runtime_logger_spec.rb
+++ b/spec/parallel_tests/rspec/runtime_logger_spec.rb
@@ -32,12 +32,12 @@ describe ParallelTests::RSpec::RuntimeLogger do
   end
 
   it "logs runtime with relative paths" do
-    log_for_a_file.should =~ @clean_output
+    expect(log_for_a_file).to match( @clean_output )
   end
 
   it "does not log if we do not run in parallel" do
     ENV.delete 'TEST_ENV_NUMBER'
-    log_for_a_file.should == ""
+    expect(log_for_a_file).to eq ""
   end
 
   it "appends to a given file" do
@@ -45,8 +45,8 @@ describe ParallelTests::RSpec::RuntimeLogger do
       f.write 'FooBar'
       ParallelTests::RSpec::RuntimeLogger.new(f)
     end
-    result.should include('FooBar')
-    result.should include('foo.rb')
+    expect(result).to include('FooBar')
+    expect(result).to include('foo.rb')
   end
 
   it "overwrites a given path" do
@@ -54,8 +54,8 @@ describe ParallelTests::RSpec::RuntimeLogger do
       f.write 'FooBar'
       ParallelTests::RSpec::RuntimeLogger.new(f.path)
     end
-    result.should_not include('FooBar')
-    result.should include('foo.rb')
+    expect(result).to_not include('FooBar')
+    expect(result).to include('foo.rb')
   end
 
   context "integration" do
@@ -91,9 +91,9 @@ describe ParallelTests::RSpec::RuntimeLogger do
       system("TEST_ENV_NUMBER=1 rspec spec -I #{Bundler.root.join("lib")} --format ParallelTests::RSpec::RuntimeLogger --out runtime.log 2>&1") || raise("nope")
 
       result = File.read("runtime.log")
-      result.should include "a_spec.rb:0.5"
-      result.should include "b_spec.rb:0.5"
-      result.should_not include "spec_helper"
+      expect(result).to include "a_spec.rb:0.5"
+      expect(result).to include "b_spec.rb:0.5"
+      expect(result).to_not include "spec_helper"
     end
 
     it "logs multiple describe blocks" do
@@ -120,7 +120,7 @@ describe ParallelTests::RSpec::RuntimeLogger do
       system("TEST_ENV_NUMBER=1 rspec spec -I #{Bundler.root.join("lib")} --format ParallelTests::RSpec::RuntimeLogger --out runtime.log 2>&1") || raise("nope")
 
       result = File.read("runtime.log")
-      result.should include "a_spec.rb:1.5"
+      expect(result).to include "a_spec.rb:1.5"
     end
   end
 end

--- a/spec/parallel_tests/rspec/summary_logger_spec.rb
+++ b/spec/parallel_tests/rspec/summary_logger_spec.rb
@@ -13,7 +13,7 @@ describe ParallelTests::RSpec::SummaryLogger do
     logger.example_failed XXX
     logger.example_failed XXX
     logger.dump_failures
-    output.output.should == [
+    expect(output.output).to eq [
       "bundle exec rspec ./spec/path/to/example.rb:123 # should do stuff",
       "bundle exec rspec ./spec/path/to/example.rb:125 # should not do stuff"
     ]
@@ -22,16 +22,16 @@ describe ParallelTests::RSpec::SummaryLogger do
   it "does not print anything for passing examples" do
     logger.example_passed mock(:location => "/my/spec/foo.rb:123")
     logger.dump_failures
-    output.output.should == []
+    expect(output.output).to eq []
     logger.dump_summary(1,2,3,4)
-    output.output.map{|o| decolorize(o) }.should == ["\nFinished in 1 second\n", "2 examples, 3 failures, 4 pending"]
+    expect(output.output.map{|o| decolorize(o) }).to eq ["\nFinished in 1 second\n", "2 examples, 3 failures, 4 pending"]
   end
 
   it "does not print anything for pending examples" do
     logger.example_pending mock(:location => "/my/spec/foo.rb:123")
     logger.dump_failures
-    output.output.should == []
+    expect(output.output).to eq []
     logger.dump_summary(1,2,3,4)
-    output.output.map{|o| decolorize(o) }.should == ["\nFinished in 1 second\n", "2 examples, 3 failures, 4 pending"]
+    expect(output.output.map{|o| decolorize(o) }).to eq ["\nFinished in 1 second\n", "2 examples, 3 failures, 4 pending"]
   end
 end

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -5,22 +5,22 @@ describe ParallelTests::Tasks do
   describe ".parse_args" do
     it "should return the count" do
       args = {:count => 2}
-      ParallelTests::Tasks.parse_args(args).should == [2, "", ""]
+      expect(ParallelTests::Tasks.parse_args(args)).to eq [2, "", ""]
     end
 
     it "should default to the prefix" do
       args = {:count => "models"}
-      ParallelTests::Tasks.parse_args(args).should == [nil, "models", ""]
+      expect(ParallelTests::Tasks.parse_args(args)).to eq [nil, "models", ""]
     end
 
     it "should return the count and pattern" do
       args = {:count => 2, :pattern => "models"}
-      ParallelTests::Tasks.parse_args(args).should == [2, "models", ""]
+      expect(ParallelTests::Tasks.parse_args(args)).to eq [2, "models", ""]
     end
 
     it "should return the count, pattern, and options" do
       args = {:count => 2, :pattern => "plain", :options => "-p default"}
-      ParallelTests::Tasks.parse_args(args).should == [2, "plain", "-p default"]
+      expect(ParallelTests::Tasks.parse_args(args)).to eq [2, "plain", "-p default"]
     end
   end
 
@@ -36,12 +36,12 @@ describe ParallelTests::Tasks do
     end
 
     it "should be test when nothing was set" do
-      ParallelTests::Tasks.rails_env.should == "test"
+      expect(ParallelTests::Tasks.rails_env).to eq "test"
     end
 
     it "should be whatever was set" do
       ENV["RAILS_ENV"] = "foo"
-      ParallelTests::Tasks.rails_env.should == "foo"
+      expect(ParallelTests::Tasks.rails_env).to eq "foo"
     end
   end
 
@@ -49,33 +49,33 @@ describe ParallelTests::Tasks do
     let(:full_path){ File.expand_path("../../../bin/parallel_test", __FILE__) }
 
     it "has the executable" do
-      File.file?(full_path).should == true
-      File.executable?(full_path).should == true
+      expect(File.file?(full_path)).to eq true
+      expect(File.executable?(full_path)).to eq true
     end
 
     it "runs command in parallel" do
-      ParallelTests::Tasks.should_receive(:system).with("#{full_path} --exec 'echo'").and_return true
+      expect(ParallelTests::Tasks).to receive(:system).with("#{full_path} --exec 'echo'").and_return true
       ParallelTests::Tasks.run_in_parallel("echo")
     end
 
     it "runs command with :count option" do
-      ParallelTests::Tasks.should_receive(:system).with("#{full_path} --exec 'echo' -n 123").and_return true
+     expect( ParallelTests::Tasks).to receive(:system).with("#{full_path} --exec 'echo' -n 123").and_return true
       ParallelTests::Tasks.run_in_parallel("echo", :count => 123)
     end
 
     it "runs without -n with blank :count option" do
-      ParallelTests::Tasks.should_receive(:system).with("#{full_path} --exec 'echo'").and_return true
+      expect(ParallelTests::Tasks).to receive(:system).with("#{full_path} --exec 'echo'").and_return true
       ParallelTests::Tasks.run_in_parallel("echo", :count => "")
     end
 
     it "runs command with :non_parallel option" do
-      ParallelTests::Tasks.should_receive(:system).with("#{full_path} --exec 'echo' --non-parallel").and_return true
+      expect(ParallelTests::Tasks).to receive(:system).with("#{full_path} --exec 'echo' --non-parallel").and_return true
       ParallelTests::Tasks.run_in_parallel("echo", :non_parallel => true)
     end
 
     it "runs aborts if the command fails" do
-      ParallelTests::Tasks.should_receive(:system).and_return false
-      ParallelTests::Tasks.should_receive(:abort).and_return false
+      expect(ParallelTests::Tasks).to receive(:system).and_return false
+      expect(ParallelTests::Tasks).to receive(:abort).and_return false
       ParallelTests::Tasks.run_in_parallel("echo")
     end
   end
@@ -94,33 +94,33 @@ describe ParallelTests::Tasks do
       end
 
       it "should hide offending lines" do
-        call("echo 123", "123").should == ["", true]
+        expect(call("echo 123", "123")).to eq ["", true]
       end
 
       it "should not hide other lines" do
-        call("echo 124", "123").should == ["124\n", true]
+        expect(call("echo 124", "123")).to eq ["124\n", true]
       end
 
       it "should fail if command fails and the pattern matches" do
-        call("echo 123 && test", "123").should == ["", false]
+        expect(call("echo 123 && test", "123")).to eq ["", false]
       end
 
       it "should fail if command fails and the pattern fails" do
-        call("echo 124 && test", "123").should == ["124\n", false]
+        expect(call("echo 124 && test", "123")).to eq ["124\n", false]
       end
     end
 
     context "without pipefail supported" do
       before do
-        ParallelTests::Tasks.should_receive(:system).with("set -o pipefail 2>/dev/null && test 1").and_return false
+        expect(ParallelTests::Tasks).to receive(:system).with("set -o pipefail 2>/dev/null && test 1").and_return false
       end
 
       it "should not filter and succeed" do
-        call("echo 123", "123").should == ["123\n", true]
+        expect(call("echo 123", "123")).to eq ["123\n", true]
       end
 
       it "should not filter and fail" do
-        call("echo 123 && test", "123").should == ["123\n", false]
+        expect(call("echo 123 && test", "123")).to eq ["123\n", false]
       end
     end
   end
@@ -141,7 +141,7 @@ describe ParallelTests::Tasks do
         foo = 2
       end
       ParallelTests::Tasks.check_for_pending_migrations
-      foo.should == 2
+      expect(foo).to eq 2
     end
 
     it "should run pending migrations is app task is defined" do
@@ -150,7 +150,7 @@ describe ParallelTests::Tasks do
         foo = 2
       end
       ParallelTests::Tasks.check_for_pending_migrations
-      foo.should == 2
+      expect(foo).to eq 2
     end
 
     it "should not execute the task twice" do
@@ -160,7 +160,7 @@ describe ParallelTests::Tasks do
       end
       ParallelTests::Tasks.check_for_pending_migrations
       ParallelTests::Tasks.check_for_pending_migrations
-      foo.should == 2
+      expect(foo).to eq 2
     end
   end
 end

--- a/spec/parallel_tests/test/runtime_logger_spec.rb
+++ b/spec/parallel_tests/test/runtime_logger_spec.rb
@@ -20,8 +20,8 @@ describe ParallelTests::Test::RuntimeLogger do
       ParallelTests::Test::RuntimeLogger.send(:class_variable_set,:@@has_started, false)
       ParallelTests::Test::RuntimeLogger.log(test, time, Time.at(time.to_f+2.00))
       result = File.read(log)
-      result.should_not include('FooBar')
-      result.should include('test/fake_test.rb:2.00')
+      expect(result).to_not include('FooBar')
+      expect(result).to include('test/fake_test.rb:2.00')
     end
 
     it "appends to the runtime_log file after first log invocation" do
@@ -38,9 +38,9 @@ describe ParallelTests::Test::RuntimeLogger do
       ParallelTests::Test::RuntimeLogger.log(test, time, Time.at(time.to_f+2.00))
       ParallelTests::Test::RuntimeLogger.log(other_test, time, Time.at(time.to_f+2.00))
       result = File.read(log)
-      result.should_not include('FooBar')
-      result.should include('test/fake_test.rb:2.00')
-      result.should include('test/other_fake_test.rb:2.00')
+      expect(result).to_not include('FooBar')
+      expect(result).to include('test/fake_test.rb:2.00')
+      expect(result).to include('test/other_fake_test.rb:2.00')
     end
   end
 
@@ -60,7 +60,7 @@ describe ParallelTests::Test::RuntimeLogger do
       end
       test = FakeTest.new
       time = Time.now
-      call(test, time, Time.at(time.to_f+2.00)).should == 'test/fake_test.rb:2.00'
+      expect(call(test, time, Time.at(time.to_f+2.00))).to eq 'test/fake_test.rb:2.00'
     end
 
     it "formats results for complex test names" do
@@ -70,7 +70,7 @@ describe ParallelTests::Test::RuntimeLogger do
       end
       test = AVeryComplex::FakeTest.new
       time = Time.now
-      call(test, time, Time.at(time.to_f+2.00)).should == 'test/a_very_complex/fake_test.rb:2.00'
+      expect(call(test, time, Time.at(time.to_f+2.00))).to eq 'test/a_very_complex/fake_test.rb:2.00'
     end
 
     it "guesses subdirectory structure for rails test classes" do
@@ -83,7 +83,7 @@ describe ParallelTests::Test::RuntimeLogger do
         end
         test = FakeControllerTest.new
         time = Time.now
-        call(test, time, Time.at(time.to_f+2.00)).should == 'test/functional/fake_controller_test.rb:2.00'
+        expect(call(test, time, Time.at(time.to_f+2.00))).to eq 'test/functional/fake_controller_test.rb:2.00'
       end
     end
   end

--- a/spec/parallel_tests_spec.rb
+++ b/spec/parallel_tests_spec.rb
@@ -12,25 +12,25 @@ describe ParallelTests do
     end
 
     it "uses the given count if set" do
-      call('5').should == 5
+      expect(call('5')).to eq 5
     end
 
     it "uses the processor count from Parallel" do
-      call(nil).should == 20
+      expect(call(nil)).to eq 20
     end
 
     it "uses the processor count from ENV before Parallel" do
       ENV['PARALLEL_TEST_PROCESSORS'] = '22'
-      call(nil).should == 22
+      expect(call(nil)).to eq 22
     end
 
     it "does not use blank count" do
-      call('   ').should == 20
+      expect(call('   ')).to eq 20
     end
 
     it "does not use blank env" do
       ENV['PARALLEL_TEST_PROCESSORS'] = '   '
-      call(nil).should == 20
+      expect(call(nil)).to eq 20
     end
   end
 
@@ -41,28 +41,28 @@ describe ParallelTests do
 
     it "should return false" do
       use_temporary_directory_for do
-        ParallelTests.send(:bundler_enabled?).should == false
+        expect(ParallelTests.send(:bundler_enabled?)).to eq false
       end
     end
 
     it "should return true when there is a constant called Bundler" do
       use_temporary_directory_for do
         Object.stub!(:const_defined?).with(:Bundler).and_return true
-        ParallelTests.send(:bundler_enabled?).should == true
+        expect(ParallelTests.send(:bundler_enabled?)).to eq true
       end
     end
 
     it "should be true when there is a Gemfile" do
       use_temporary_directory_for do
         FileUtils.touch("Gemfile")
-        ParallelTests.send(:bundler_enabled?).should == true
+        expect(ParallelTests.send(:bundler_enabled?)).to eq true
       end
     end
 
     it "should be true when there is a Gemfile in the parent directory" do
       use_temporary_directory_for do
         FileUtils.touch(File.join("..", "Gemfile"))
-        ParallelTests.send(:bundler_enabled?).should == true
+        expect(ParallelTests.send(:bundler_enabled?)).to eq true
       end
     end
   end
@@ -77,13 +77,13 @@ describe ParallelTests do
     end
 
     it "does not wait if not run in parallel" do
-      ParallelTests.should_not_receive(:sleep)
+      expect(ParallelTests).to_not receive(:sleep)
       ParallelTests.wait_for_other_processes_to_finish
     end
 
     it "stops if only itself is running" do
       ENV["TEST_ENV_NUMBER"] = "2"
-      ParallelTests.should_not_receive(:sleep)
+      expect(ParallelTests).to_not receive(:sleep)
       with_running_processes(1) do
           ParallelTests.wait_for_other_processes_to_finish
         end
@@ -97,41 +97,41 @@ describe ParallelTests do
       with_running_processes(2, 0.6) do
         ParallelTests.wait_for_other_processes_to_finish
       end
-      counter.should >= 2
+      expect(counter).to be >= 2
     end
   end
 
   describe ".number_of_running_processes" do
     it "is 0 for nothing" do
-      ParallelTests.number_of_running_processes.should == 0
+      expect(ParallelTests.number_of_running_processes).to eq 0
     end
 
     it "is 2 when 2 are running" do
       wait = 0.2
       2.times { Thread.new { `TEST_ENV_NUMBER=1; sleep #{wait}` } }
       sleep wait / 2
-      ParallelTests.number_of_running_processes.should == 2
+      expect(ParallelTests.number_of_running_processes).to eq 2
       sleep wait
     end
   end
 
   describe ".first_process?" do
     it "is first if no env is set" do
-      ParallelTests.first_process?.should == true
+      expect(ParallelTests.first_process?).to eq true
     end
 
     it "is first if env is set to blank" do
       ENV["TEST_ENV_NUMBER"] = ""
-      ParallelTests.first_process?.should == true
+      expect(ParallelTests.first_process?).to eq true
     end
 
     it "is not first if env is set to something" do
       ENV["TEST_ENV_NUMBER"] = "2"
-      ParallelTests.first_process?.should == false
+      expect(ParallelTests.first_process?).to eq false
     end
   end
 
   it "has a version" do
-    ParallelTests::VERSION.should =~ /^\d+\.\d+\.\d+/
+    expect(ParallelTests::VERSION).to match( /^\d+\.\d+\.\d+/ )
   end
 end


### PR DESCRIPTION
As you may well know, using 'expect' over 'should' is a recommended practice because of dealing with delegate/proxy objects as detailed in http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax.
As detailed in the blog post "In the future, we plan to change the defaults so that only expect is available unless you explicitly enable should. We may do this as soon as RSpec 3.0, but we want to give users plenty of time to get acquianted with it."
I noticed that expect is now being used in many of the major gems that use rspec. 
I changed the pattern matchers from =~ to match() or match_array() as required for this change and while at it I also took the opportunity to change the == format to eq as recommended in the post. 
I also updated the spec gem to 2.14 which is actually more recent than 2.4 and allows expect, including receive.
More at http://myronmars.to/n/dev-blog/2013/07/rspec-2-14-is-released
All previously passing tests still pass after this change.
