### PR TITLE
Make parallel_cucumber to work under Windows

### DIFF
--- a/lib/parallel_tests/gherkin/runner.rb
+++ b/lib/parallel_tests/gherkin/runner.rb
@@ -7,7 +7,12 @@ module ParallelTests
 
       class << self
         def run_tests(test_files, process_number, num_processes, options)
-          sanitized_test_files = test_files.map { |val| Shellwords.escape(val) }
+          if RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/ #Shellwords doesn't work for windows
+            sanitized_test_files = test_files.map { |val| "\"#{val}\"" }
+          else
+            sanitized_test_files = test_files.map { |val| Shellwords.escape(val) }
+          end
+
           options = options.merge(:env => {"AUTOTEST" => "1"}) if $stdout.tty? # display color when we are in a terminal
           cmd = [
             executable,


### PR DESCRIPTION
Shellwords doesn't work for Windows. To escape non valid windows path characters we can use double quotes.
This solution works for me.
