### PR TITLE
Getting parallel_tests working on Win7

### DIFF
--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -2,11 +2,12 @@ require "rubygems"
 require "parallel"
 require "parallel_tests/railtie" if defined? Rails::Railtie
 require "rbconfig"
+require "tempfile"
 
 module ParallelTests
   GREP_PROCESSES_COMMAND = \
   if RbConfig::CONFIG['host_os'] =~ /win32/
-    "wmic process get commandline | findstr TEST_ENV_NUMBER 2>&1"
+    "wmic process get commandline | findstr TEST_ENV_NUMBER | find /c \"TEST_ENV_NUMBER=\" 2>&1"
   else
     "ps -ef | grep [T]EST_ENV_NUMBER= 2>&1"
   end
@@ -38,6 +39,10 @@ module ParallelTests
       end
 
       false
+    end
+
+    def rspec_in_path?
+      `rspec -v`.index(/[\d]+(.)[\d]+/) != nil
     end
 
     def first_process?

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -16,6 +16,8 @@ module ParallelTests
 
         def determine_executable
           cmd = case
+          when ParallelTests.rspec_in_path?
+            'rspec'
           when File.exists?("bin/rspec")
             "bin/rspec"
           when File.file?("script/spec")
@@ -46,7 +48,8 @@ module ParallelTests
 
         # so it can be stubbed....
         def run(cmd)
-          `#{cmd}`
+          pid = Process.spawn("#{cmd}")
+          Process.wait(pid)
         end
 
         def rspec_1_color

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -48,8 +48,7 @@ module ParallelTests
 
         # so it can be stubbed....
         def run(cmd)
-          pid = Process.spawn("#{cmd}")
-          Process.wait(pid)
+          `#{cmd}`
         end
 
         def rspec_1_color

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -75,17 +75,16 @@ module ParallelTests
 
           output = Tempfile.new('parallel_tests')
           output_path = output.path
+          output.close
+          exitstatus = nil
           t = Thread.new {
             pid = Process.spawn(cmd, :out=>output_path, :err=>output_path)
             Process.wait(pid)
+            exitstatus = $?.exitstatus
           }
           result = capture_output(t, output_path, silence)
-          exitstatus = $?.exitstatus
 
           {:stdout => result, :exit_status => exitstatus}
-        ensure
-          output.close
-          output.unlink
         end
 
         def find_results(test_output)

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -79,10 +79,10 @@ module ParallelTests
             pid = Process.spawn(cmd, :out=>output_path, :err=>output_path)
             Process.wait(pid)
           }
-          capture_output(t, output_path, silence)
+          result = capture_output(t, output_path, silence)
           exitstatus = $?.exitstatus
 
-          {:stdout => output, :exit_status => exitstatus}
+          {:stdout => result, :exit_status => exitstatus}
         ensure
           output.close
           output.unlink

--- a/lib/parallel_tests/version.rb
+++ b/lib/parallel_tests/version.rb
@@ -1,3 +1,3 @@
 module ParallelTests
-  VERSION = Version = '0.16.11'
+  VERSION = Version = '0.16.10'
 end

--- a/lib/parallel_tests/version.rb
+++ b/lib/parallel_tests/version.rb
@@ -1,3 +1,3 @@
 module ParallelTests
-  VERSION = Version = '0.16.10'
+  VERSION = Version = '0.16.11'
 end

--- a/spec/parallel_tests/rspec/runner_spec.rb
+++ b/spec/parallel_tests/rspec/runner_spec.rb
@@ -44,6 +44,7 @@ describe ParallelTests::RSpec::Runner do
 
     it "runs with color for rspec 1 when called for the cmdline" do
       File.should_receive(:file?).with('script/spec').and_return true
+      ParallelTests.stub!(:rspec_in_path?).and_return false
       ParallelTests::Test::Runner.should_receive(:execute_command).with { |a, b, c, d| d[:env] == {"RSPEC_COLOR" => "1"} }
       $stdout.should_receive(:tty?).and_return true
       call('xxx', 1, 22, {})
@@ -51,6 +52,7 @@ describe ParallelTests::RSpec::Runner do
 
     it "runs without color for rspec 1 when not called for the cmdline" do
       File.should_receive(:file?).with('script/spec').and_return true
+      ParallelTests.stub!(:rspec_in_path?).and_return false
       ParallelTests::Test::Runner.should_receive(:execute_command).with { |a, b, c, d| d[:env] == {} }
       $stdout.should_receive(:tty?).and_return false
       call('xxx', 1, 22, {})
@@ -59,6 +61,7 @@ describe ParallelTests::RSpec::Runner do
     it "run bundle exec spec when on bundler rspec 1" do
       File.stub!(:file?).with('script/spec').and_return false
       ParallelTests.stub!(:bundler_enabled?).and_return true
+      ParallelTests.stub!(:rspec_in_path?).and_return false
       ParallelTests::RSpec::Runner.stub!(:run).with("bundle show rspec-core").and_return "Could not find gem 'rspec-core' in bundler."
       should_run_with %r{bundle exec spec}
       call('xxx', 1, 22, {})
@@ -67,6 +70,7 @@ describe ParallelTests::RSpec::Runner do
     it "run bundle exec rspec when on bundler rspec 2" do
       File.stub!(:file?).with('script/spec').and_return false
       ParallelTests.stub!(:bundler_enabled?).and_return true
+      ParallelTests.stub!(:rspec_in_path?).and_return false
       ParallelTests::RSpec::Runner.stub!(:run).with("bundle show rspec-core").and_return "/foo/bar/rspec-core-2.0.2"
       should_run_with %r{bundle exec rspec}
       call('xxx', 1, 22, {})
@@ -74,6 +78,7 @@ describe ParallelTests::RSpec::Runner do
 
     it "runs script/spec when script/spec can be found" do
       File.should_receive(:file?).with('script/spec').and_return true
+      ParallelTests.stub!(:rspec_in_path?).and_return false
       should_run_with %r{script/spec}
       call('xxx' ,1, 22, {})
     end
@@ -86,7 +91,14 @@ describe ParallelTests::RSpec::Runner do
 
     it "uses bin/rspec when present" do
       File.stub(:exists?).with('bin/rspec').and_return true
+      ParallelTests.stub!(:rspec_in_path?).and_return false
       should_run_with %r{bin/rspec}
+      call('xxx', 1, 22, {})
+    end
+
+    it "uses rspec when rspec found in execution path" do
+      ParallelTests.stub!(:rspec_in_path?).and_return true
+      should_run_with %r{rspec}
       call('xxx', 1, 22, {})
     end
 
@@ -99,6 +111,7 @@ describe ParallelTests::RSpec::Runner do
     it "uses -O spec/spec.opts when found (with script/spec)" do
       File.stub!(:file?).with('script/spec').and_return true
       File.stub!(:file?).with('spec/spec.opts').and_return true
+      ParallelTests.stub!(:rspec_in_path?).and_return false
       should_run_with %r{script/spec\s+-O spec/spec.opts}
       call('xxx', 1, 22, {})
     end
@@ -106,6 +119,7 @@ describe ParallelTests::RSpec::Runner do
     it "uses -O spec/parallel_spec.opts when found (with script/spec)" do
       File.stub!(:file?).with('script/spec').and_return true
       File.should_receive(:file?).with('spec/parallel_spec.opts').and_return true
+      ParallelTests.stub!(:rspec_in_path?).and_return false
       should_run_with %r{script/spec\s+-O spec/parallel_spec.opts}
       call('xxx', 1, 22, {})
     end
@@ -113,6 +127,7 @@ describe ParallelTests::RSpec::Runner do
     it "uses -O .rspec_parallel when found (with script/spec)" do
       File.stub!(:file?).with('script/spec').and_return true
       File.should_receive(:file?).with('.rspec_parallel').and_return true
+      ParallelTests.stub!(:rspec_in_path?).and_return false
       should_run_with %r{script/spec\s+-O .rspec_parallel}
       call('xxx', 1, 22, {})
     end
@@ -121,6 +136,7 @@ describe ParallelTests::RSpec::Runner do
       File.should_receive(:file?).with('spec/parallel_spec.opts').and_return true
 
       ParallelTests.stub!(:bundler_enabled?).and_return true
+      ParallelTests.stub!(:rspec_in_path?).and_return false
       ParallelTests::RSpec::Runner.stub!(:run).with("bundle show rspec-core").and_return "Could not find gem 'rspec-core'."
 
       should_run_with %r{spec\s+-O spec/parallel_spec.opts}
@@ -132,6 +148,7 @@ describe ParallelTests::RSpec::Runner do
       File.should_receive(:file?).with('spec/parallel_spec.opts').and_return true
 
       ParallelTests.stub!(:bundler_enabled?).and_return true
+      ParallelTests.stub!(:rspec_in_path?).and_return false
       ParallelTests::RSpec::Runner.stub!(:run).with("bundle show rspec-core").and_return "/foo/bar/rspec-core-2.4.2"
 
       should_run_with %r{rspec\s+--color --tty -O spec/parallel_spec.opts}


### PR DESCRIPTION
Fixes how number of running processes are retrieved

Adds a rspec_in_path? method that checks for handling of 'rspec' command without the need for adding a bin or script path

moves to using Process.spawn to handle problem of sub-processes that are started and detached blocking completion of the 'open' command so tests would not complete

*Edit* removed version change because Travis build didn't pick up version 0.16.11

updated rspec/runner_spec.rb tests to ensure handling of new rspec_in_path? method