### PR TITLE
Make runtime logger formatter rspec 3 friendly

### DIFF
--- a/lib/parallel_tests/rspec/logger_base.rb
+++ b/lib/parallel_tests/rspec/logger_base.rb
@@ -15,6 +15,7 @@ ParallelTests::RSpec::LoggerBaseBase = base
 
 class ParallelTests::RSpec::LoggerBase < ParallelTests::RSpec::LoggerBaseBase
   RSPEC_1 = !defined?(RSpec::Core::Formatters::BaseTextFormatter) # do not test for Spec, this will trigger deprecation warning in rspec 2
+  RSPEC_3 = !RSPEC_1 && RSpec::Core::Version::STRING.start_with?('3')
 
   def initialize(*args)
     super

--- a/lib/parallel_tests/rspec/runtime_logger.rb
+++ b/lib/parallel_tests/rspec/runtime_logger.rb
@@ -29,20 +29,14 @@ class ParallelTests::RSpec::RuntimeLogger < ParallelTests::RSpec::LoggerBase
 
     if RSpec::Core::Version::STRING.start_with?('3')
       RSpec::Core::Formatters.register self, :example_group_started, :example_group_finished, :start_dump
-      def example_group_finished(notification)
-        @group_nesting -= 1
-        if @group_nesting == 0
-          @example_times[notification.group.file_path] += ParallelTests.now - @time
-        end
+    end
+    def example_group_finished(notification)
+      @group_nesting -= 1
+      if @group_nesting == 0
+        path = RSPEC_3 ? notification.group.file_path : notification.file_path
+        @example_times[path] += ParallelTests.now - @time
       end
-    else
-      def example_group_finished(example_group)
-        @group_nesting -= 1
-        if @group_nesting == 0
-          @example_times[example_group.file_path] += ParallelTests.now - @time
-        end
-        super
-      end
+      super if defined?(super)
     end
   end
 

--- a/spec/parallel_tests/rspec/runtime_logger_spec.rb
+++ b/spec/parallel_tests/rspec/runtime_logger_spec.rb
@@ -22,15 +22,14 @@ describe ParallelTests::RSpec::RuntimeLogger do
       end
 
       if RSpec::Core::Version::STRING.start_with?('3')
-        notification = double(:group => double(:file_path => "#{Dir.pwd}/spec/foo.rb"))
-        logger.example_group_started notification
-        logger.example_group_finished notification
+        notification_or_example = double(:group => double(:file_path => "#{Dir.pwd}/spec/foo.rb"))
       else
-        example = (double(:file_path => "#{Dir.pwd}/spec/foo.rb"))
-        logger.example_group_started example
-        logger.example_group_finished example
-      end
+        notification_or_example = double(:file_path => "#{Dir.pwd}/spec/foo.rb")
+      end        
 
+      logger.example_group_started notification_or_example
+      logger.example_group_finished notification_or_example
+      
       logger.start_dump
 
       #f.close
@@ -96,7 +95,7 @@ describe ParallelTests::RSpec::RuntimeLogger do
       end
 
       system("TEST_ENV_NUMBER=1 rspec spec -I #{Bundler.root.join("lib")} --format ParallelTests::RSpec::RuntimeLogger --out runtime.log 2>&1") || raise("nope")
-
+      
       result = File.read("runtime.log")
       result.should include "a_spec.rb:0.5"
       result.should include "b_spec.rb:0.5"


### PR DESCRIPTION
This is basically the bare minimum I had to do to get our specs running without deprecation warnings.

Trying to support rspec 1,2,3  in the same file is getting pretty grungy - perhaps this would be better as a separate rspec3 only formatter (in addition to the legacy one) ?
