### PR TITLE
Add option to pass in location of runtime log

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -141,6 +141,7 @@ TEXT
         opts.on("--no-symlinks", "Do not traverse symbolic links to find test files") { options[:symlinks] = false }
         opts.on('--ignore-tags [PATTERN]', 'When counting steps ignore scenarios with tags that match this pattern')  { |arg| options[:ignore_tag_pattern] = arg }
         opts.on("--nice", "execute test commands with low priority.") { options[:nice] = true }
+        opts.on("--runtime-log [PATH]", "Location of previously recorded test runtimes") { |path| options[:runtime_log] = path }
         opts.on("-v", "--version", "Show Version") { puts ParallelTests::VERSION; exit }
         opts.on("-h", "--help", "Show this.") { puts opts; exit }
       end.parse!(argv)

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -46,7 +46,7 @@ module ParallelTests
           elsif options[:group_by] == :filesize
             with_filesize_info(tests)
           else
-            with_runtime_info(tests)
+            with_runtime_info(tests, options)
           end
           Grouper.in_even_groups_by_size(tests, num_groups, options)
         end
@@ -130,12 +130,13 @@ module ParallelTests
           result
         end
 
-        def with_runtime_info(tests)
-          lines = File.read(runtime_log).split("\n") rescue []
+        def with_runtime_info(tests, options = {})
+          log = options[:runtime_log] || runtime_log
+          lines = File.read(log).split("\n") rescue []
 
           # use recorded test runtime if we got enough data
           if lines.size * 1.5 > tests.size
-            puts "Using recorded test runtime"
+            puts "Using recorded test runtime: #{log}"
             times = Hash.new(1)
             lines.each do |line|
               test, time = line.split(":")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -127,6 +127,19 @@ def test_tests_in_groups(klass, folder, suffix)
       groups[1].should == [@files[2],@files[4],@files[6],@files[7]]
     end
 
+    it 'partitions from custom runtime-data location' do
+      klass.stub!(:puts)
+      @log = 'tmp/custom_runtime.log'
+      setup_runtime_log
+
+      groups = klass.tests_in_groups([test_root], 2, :runtime_log => @log)
+      groups.size.should == 2
+      # 10 + 1 + 3 + 5 = 19
+      groups[0].should == [@files[0],@files[1],@files[3],@files[5]]
+      # 2 + 4 + 6 + 7 = 19
+      groups[1].should == [@files[2],@files[4],@files[6],@files[7]]
+    end
+
     it "alpha-sorts partitions when runtime-data is available" do
       klass.stub!(:puts)
       setup_runtime_log


### PR DESCRIPTION
Background: On Jenkins, each new branch gets a new workspace folder. This means that the tests have to start from scratch with runtime grouping.

This change allows the location of the runtime log (to be read*) to be set using the cli option:

```
--runtime-log [PATH]
```

Hence runtimes can be shared between builds, and for the first build of a new branch.

\* The output location for the log can be manipulated by setting the output location for the formatter
