### PR TITLE
Add logging of test command

### DIFF
--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -12,6 +12,7 @@ module ParallelTests
           version = (exe =~ /\brspec\b/ ? 2 : 1)
           cmd = [exe, options[:test_options], (rspec_2_color if version == 2), spec_opts, *test_files].compact.join(" ")
           options = options.merge(:env => rspec_1_color) if version == 1
+          puts cmd
           execute_command(cmd, process_number, num_processes, options)
         end
 


### PR DESCRIPTION
Heyo,

This adds a puts to log the test commands running for rspec. This mirrors the behaviour of the normal rake rspec task.

This makes it easier to see which files were run in which order to debug test pollution.

Let me know what you think.