### PR TITLE
adding jruby-head to travis allowed_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ rvm:
   - 2.1.0
   - jruby-1.7.6
   - jruby-head
+matrix:
+  allow_failures:
+    rvm: jruby-head


### PR DESCRIPTION
Adding jruby-head to allowed_failures list in travis config so entire build does not show up as failure

/cc @grosser
