### PR TITLE
Updating syntax for travis allowed_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ rvm:
   - jruby-head
 matrix:
   allow_failures:
-    rvm: jruby-head
+    - rvm: jruby-head


### PR DESCRIPTION
Using new travis syntax for allowed_failures in the travis.yml for jruby-head

Issue being tracked in
https://github.com/jruby/jruby/issues/1913
