### PR TITLE
ParallelTests::RSpec::LoggerBase make :close method public

### DIFF
--- a/lib/parallel_tests/rspec/logger_base.rb
+++ b/lib/parallel_tests/rspec/logger_base.rb
@@ -32,12 +32,12 @@ class ParallelTests::RSpec::LoggerBase < ParallelTests::RSpec::LoggerBaseBase
     end
   end
 
-  protected
-
   #stolen from Rspec
   def close(*args)
     @output.close  if (IO === @output) & (@output != $stdout)
   end
+
+  protected
 
   # do not let multiple processes get in each others way
   def lock_output

--- a/spec/parallel_tests/rspec/logger_base_spec.rb
+++ b/spec/parallel_tests/rspec/logger_base_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe ParallelTests::RSpec::LoggerBase do
+  before do
+    @temp_file = Tempfile.open('xxx')
+    @logger = ParallelTests::RSpec::LoggerBase.new(@temp_file)
+  end
+
+  after do
+    @temp_file.close
+  end
+
+  describe 'on tests finished' do
+    it 'should respond to close' do
+      expect(@logger).to respond_to(:close)
+    end
+
+    it 'should close output' do
+      @temp_file.should_receive(:close)
+      @logger.close
+    end
+
+    it 'should not close stdout' do
+      @logger = ParallelTests::RSpec::LoggerBase.new($stdout)
+      $stdout.should_not_receive(:close)
+      @logger.close
+    end
+
+    it 'should not close IO instance' do
+      io = double(IO)
+      @logger = ParallelTests::RSpec::LoggerBase.new(io)
+      @logger.close
+    end
+  end
+end


### PR DESCRIPTION
Incorrect method privileges for base logger. 
Default Rspec formatter like BaseTextFormatter have close as public method. In parallel_spec base logger override this method as protected. Thus in Ruby 2.1.2 loggers are not working throwing exception:

protected method `close' called for #ParallelTests::RSpec::RuntimeLogger:0x00000010371828 (NoMethodError)

Other then this issue parallel spec works perfectly with Ruby 2.1.2 and Rspec 1.3.2 in our environment
