### PR TITLE
Add option to invoke parallel task using 'nice' flag

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -51,7 +51,7 @@ module ParallelTests
       # parallel:spec[:count, :pattern, :options]
       def parse_args(args)
         # order as given by user
-        args = [args[:count], args[:pattern], args[:options]]
+        args = [args[:count], args[:pattern], args[:options], args[:nice]]
 
         # count given or empty ?
         # parallel:spec[2,models,options]
@@ -60,8 +60,9 @@ module ParallelTests
         num_processes = count.to_i unless count.to_s.empty?
         pattern = args.shift
         options = args.shift
+        nice = args.shift
 
-        [num_processes, pattern.to_s, options.to_s]
+        [num_processes, pattern.to_s, options.to_s, nice]
       end
     end
   end
@@ -130,7 +131,7 @@ namespace :parallel do
       $LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), '..'))
       require "parallel_tests"
 
-      count, pattern, options = ParallelTests::Tasks.parse_args(args)
+      count, pattern, options, nice = ParallelTests::Tasks.parse_args(args)
       test_framework = {
         'spec' => 'rspec',
         'test' => 'test',
@@ -147,6 +148,8 @@ namespace :parallel do
         "-n #{count} "                     \
         "--pattern '#{pattern}' "          \
         "--test-options '#{options}'"
+      command = "#{command} --nice" if nice
+
       if ParallelTests::WINDOWS
         ruby_binary = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])
         command = "#{ruby_binary} #{command}"

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -5,22 +5,27 @@ describe ParallelTests::Tasks do
   describe ".parse_args" do
     it "should return the count" do
       args = {:count => 2}
-      ParallelTests::Tasks.parse_args(args).should == [2, "", ""]
+      ParallelTests::Tasks.parse_args(args).should == [2, "", "", nil]
+    end
+
+    it "should return the nice flag" do
+      args = {:nice => true}
+      ParallelTests::Tasks.parse_args(args).should == [nil, "", "", true]
     end
 
     it "should default to the prefix" do
       args = {:count => "models"}
-      ParallelTests::Tasks.parse_args(args).should == [nil, "models", ""]
+      ParallelTests::Tasks.parse_args(args).should == [nil, "models", "", nil]
     end
 
     it "should return the count and pattern" do
       args = {:count => 2, :pattern => "models"}
-      ParallelTests::Tasks.parse_args(args).should == [2, "models", ""]
+      ParallelTests::Tasks.parse_args(args).should == [2, "models", "", nil]
     end
 
     it "should return the count, pattern, and options" do
       args = {:count => 2, :pattern => "plain", :options => "-p default"}
-      ParallelTests::Tasks.parse_args(args).should == [2, "plain", "-p default"]
+      ParallelTests::Tasks.parse_args(args).should == [2, "plain", "-p default", nil]
     end
 
     it "should return the count, pattern, and options" do
@@ -29,7 +34,7 @@ describe ParallelTests::Tasks do
         :pattern => "plain",
         :options => "-p default --group-by steps",
       }
-      ParallelTests::Tasks.parse_args(args).should == [2, "plain", "-p default --group-by steps"]
+      ParallelTests::Tasks.parse_args(args).should == [2, "plain", "-p default --group-by steps", nil]
     end
   end
 


### PR DESCRIPTION
We seem to get intermittent failures when we run our test suite using parallel_test. I managed to consistently reproduce these failures on a single test in isolation by running `n` instances of `yes >/dev/null &` (where n is the number of cores - 1). The failures stopped when I changed the command above to `nice yes >/dev/null &`. So the "nice" option in parallel_test is really valuable for us.

However we have our own rake task that explicitly invokes the parallel:test task rather than running `parallel_spec` directly from the command line so this PR makes it so you can pass along the nice flag like you can currently do for pattern, count, and option args.
