### PR TITLE
Add env flag to toggle bundler usage

### DIFF
--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -27,6 +27,9 @@ module ParallelTests
 
     # copied from http://github.com/carlhuda/bundler Bundler::SharedHelpers#find_gemfile
     def bundler_enabled?
+      env = ENV["PARALLEL_TEST_BUNDLER"]
+      return ['true', '1'].include?(env.downcase) unless env.nil?
+
       return true if Object.const_defined?(:Bundler)
 
       previous = nil

--- a/spec/parallel_tests_spec.rb
+++ b/spec/parallel_tests_spec.rb
@@ -39,9 +39,20 @@ describe ParallelTests do
       Object.stub!(:const_defined?).with(:Bundler).and_return false
     end
 
+    after do
+      ENV.delete("PARALLEL_TEST_BUNDLER")
+    end
+
     it "should return false" do
       use_temporary_directory_for do
         ParallelTests.send(:bundler_enabled?).should == false
+      end
+    end
+
+    it "should return 'PARALLEL_TEST_BUNDLER' env flag" do
+      use_temporary_directory_for do
+        ENV["PARALLEL_TEST_BUNDLER"] = 'true'
+        ParallelTests.send(:bundler_enabled?).should == true
       end
     end
 


### PR DESCRIPTION
Hey thx for the great lib. Ran into an issue similar to #306. Have a project Gemfile committed for travis / automated build systems / and such but don't typically use it locally (custom dev env).

When I run rspec via the parallel_tests rake task, the bundler_enabled? method in lib/parallel_tests, detects my gemfile and enables bundler, resuling in "bundle show rspec-core" getting executed in lib/rspec/runner.rb#determine_executable. This fails (again bundler not used / avail in certain environments) resulting in parallel_tests using / falling back to executing the 'spec' resulting in:

bundler: command not found: spec
Install missing gem executables with `bundle install`

Threw together a patch where bundler could be manually enabled / disabled via an env variable. Alternative solutions could be devised, though thought this was a simple / flexible way offering more control. Again thanks for the lib.

  -Mo