### PR TITLE
Negative numbers can be passed for number of processes

### DIFF
--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -18,11 +18,12 @@ module ParallelTests
 
   class << self
     def determine_number_of_processes(count)
+      count, reserved_processors = reserve_processors(count)
       [
         count,
         ENV["PARALLEL_TEST_PROCESSORS"],
         Parallel.processor_count
-      ].detect{|c| not c.to_s.strip.empty? }.to_i
+      ].detect{|c| not c.to_s.strip.empty? }.to_i - reserved_processors
     end
 
     # copied from http://github.com/carlhuda/bundler Bundler::SharedHelpers#find_gemfile
@@ -64,6 +65,18 @@ module ParallelTests
       else
         Time.now
       end
+    end
+
+    private
+
+    def reserve_processors(count)
+      if count.to_i < 0
+        reservered_count = count.to_i.abs
+        count = nil
+      else
+        reservered_count = 0
+      end
+      [count, reservered_count]
     end
   end
 end

--- a/spec/parallel_tests_spec.rb
+++ b/spec/parallel_tests_spec.rb
@@ -15,6 +15,10 @@ describe ParallelTests do
       call('5').should == 5
     end
 
+    it "subtracts the given count if set" do
+      call('-2').should == 18
+    end
+
     it "uses the processor count from Parallel" do
       call(nil).should == 20
     end
@@ -22,6 +26,11 @@ describe ParallelTests do
     it "uses the processor count from ENV before Parallel" do
       ENV['PARALLEL_TEST_PROCESSORS'] = '22'
       call(nil).should == 22
+    end
+
+    it "subtracts from the the processor count from ENV before Parallel" do
+      ENV['PARALLEL_TEST_PROCESSORS'] = '22'
+      call('-2').should == 20
     end
 
     it "does not use blank count" do


### PR DESCRIPTION
This allows you reserve cores from running the tests without
hardcoding the number of cores incase you run on a system with
more or fewer cores.