### PR TITLE
Respect default encoding if present.

### DIFF
--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -120,6 +120,9 @@ module ParallelTests
           loop do
             begin
               read = out.readpartial(1000000) # read whatever chunk we can get
+              if RUBY_VERSION >= "1.9" && Encoding.default_internal
+                read = read.force_encoding(Encoding.default_internal)
+              end
               result << read
               unless silence
                 $stdout.print read

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -70,6 +70,24 @@ describe 'CLI' do
     result.should include('Byłem tu')
   end
 
+  it "respects default encoding when reading child stdout", :encoding => true do
+    write 'test/xxx_test.rb', <<-EOF
+      # encoding: utf-8
+      require 'test/unit'
+      class XTest < Test::Unit::TestCase
+        def test_unicode
+          raise '¯\\_(ツ)_/¯'
+        end
+      end
+    EOF
+    # Need to tell Ruby to default to utf-8 to simulate environments where
+    # this is set. (Otherwise, it defaults to nil and the undefined conversion
+    # issue doesn't come up.)
+    result = run_tests('test', :fail => true,
+                       :export => 'RUBYOPT=-Eutf-8:utf-8')
+    result.should include('¯\_(ツ)_/¯')
+  end
+
   it "does not run any tests if there are none" do
     write 'spec/xxx_spec.rb', '1'
     result = run_tests "spec", :type => 'rspec'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ end
 
 RSpec.configure do |config|
   config.filter_run :focus => true
+  config.filter_run_excluding :encoding => (RUBY_VERSION < "1.9")
   config.run_all_when_everything_filtered = true
 
   config.after do


### PR DESCRIPTION
This is the pull request that grosser requested in #204. :) This fixes the `UndefinedConversionError` seen in some Ruby environments (where `Encoding.default_internal` is set and non-ASCII characters are output by tests). Commit message follows.

    IO#readpartial assumes it is dealing with binary data and always returns
    ASCII-8BIT. However, Ruby environments that have Encoding.default_internal set
    will attempt to encode() strings to that encoding when performing the
    operations listed here:

    http://ruby-doc.org/core-1.9.3/Encoding.html#method-c-default_internal