### PR TITLE
Fix group by scenario with Spinach

### DIFF
--- a/lib/parallel_tests/gherkin/runner.rb
+++ b/lib/parallel_tests/gherkin/runner.rb
@@ -11,11 +11,13 @@ module ParallelTests
 
           if options[:group_by] == :scenarios
             grouped = test_files.map { |t| t.split(':') }.group_by(&:first)
-            combined_scenarios = grouped.map {|file,files_and_lines| "#{file}:#{files_and_lines.map(&:last).join(':')}" }
+            combined_scenarios = grouped.map do |files_and_lines|
+              files_and_lines[1].map { |file_and_line| "#{file_and_line[0]}:#{file_and_line[1]}"}
+            end
           end
 
-          sanitized_test_files = combined_scenarios.map { |val| WINDOWS ? "\"#{val}\"" : Shellwords.escape(val) }
-
+          sanitized_test_files = combined_scenarios.flatten.map { |val| WINDOWS ? "\"#{val}\"" : Shellwords.escape(val) }.join(' ')
+ 
           options[:env] ||= {}
           options[:env] = options[:env].merge({'AUTOTEST' => '1'}) if $stdout.tty? # display color when we are in a terminal
 


### PR DESCRIPTION
This resolves an issue with `Spinach`.

`Spinach` doesn't seem to support passing in arguments like
`spinach features/test.feature:5:10:20`.
When passed a command like this, it will only run the scenario on line 5.

It needs arguments passed in like
`spinach features/test.feature:5 features/test.feature:10 features/test.feature:20`

This PR makes paralell_tests output a command like the second example above, instead of the first.

See https://github.com/grosser/parallel_tests/issues/363