### PR TITLE
Display elapsed time for humans...

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -192,7 +192,11 @@ module ParallelTests
     def report_time_taken
       start = Time.now
       yield
-      puts "\nTook #{Time.now - start} seconds"
+      elapsed = Time.now - start
+      rounded = elapsed.round
+      display_parts = [ rounded / 3600, rounded % 3600 / 60, rounded % 60 ].drop_while {|dp| dp == 0}
+      display_time = display_parts.map {|dp| "%02d" % dp}.join(':').sub(/^0/, '')
+      puts "\nTook #{elapsed} seconds" + (display_parts.size > 1 ? " (#{display_time})" : "")
     end
 
     def final_fail_message

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -193,10 +193,15 @@ module ParallelTests
       start = Time.now
       yield
       elapsed = Time.now - start
+      display_elapsed = display_duration(elapsed)
+      puts "\nTook #{elapsed} seconds" + (display_elapsed.include?(':') ? " (#{display_elapsed})" : "")
+    end
+
+    def display_duration(elapsed)
       rounded = elapsed.round
-      display_parts = [ rounded / 3600, rounded % 3600 / 60, rounded % 60 ].drop_while {|dp| dp == 0}
-      display_time = display_parts.map {|dp| "%02d" % dp}.join(':').sub(/^0/, '')
-      puts "\nTook #{elapsed} seconds" + (display_parts.size > 1 ? " (#{display_time})" : "")
+      display_parts = [ rounded / 3600, rounded % 3600 / 60, rounded % 60 ].drop_while(&:zero?)
+      display_parts = [0] if display_parts.empty?
+      display_parts.map {|dp| "%02d" % dp}.join(':').sub(/^0/, '')
     end
 
     def final_fail_message

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -149,6 +149,36 @@ describe ParallelTests::CLI do
       end
     end
   end
+
+  describe "#display_duration" do
+
+    def call(*args)
+      subject.send(:display_duration, *args)
+    end
+
+    it "displays the correct string for durations near one minute" do
+      call(59.4).should == "59"
+      call(59.6).should == "1:00"
+      call(60.4).should == "1:00"
+      call(60.6).should == "1:01"
+    end
+
+    it "displays the correct string for durations near one hour" do
+      call(3599.4).should == "59:59"
+      call(3599.6).should == "1:00:00"
+      call(3600.4).should == "1:00:00"
+      call(3600.6).should == "1:00:01"
+    end
+
+    it "displays the correct string for miscellaneous durations" do
+      call(9296).should  == "2:34:56"
+      call(45296).should == "12:34:56"
+      call(2756601).should == "765:43:21" # hours into three digits?  Buy more CI hardware...
+      call(0.3).should == "0"
+      call(0.6).should == "1"
+    end
+  end
+
 end
 
 module ParallelTests
@@ -157,4 +187,3 @@ module ParallelTests
     end
   end
 end
-


### PR DESCRIPTION
...or at least for those of us who can't readily convert, e.g.  "432.565105 seconds" to "7:13"