### PR TITLE
ParallelTests:Cucumber::FailuresLogger should output failures, not lines

### DIFF
--- a/lib/parallel_tests/cucumber/failures_logger.rb
+++ b/lib/parallel_tests/cucumber/failures_logger.rb
@@ -8,6 +8,7 @@ module ParallelTests
 
       def initialize(runtime, path_or_io, options)
         @io = prepare_io(path_or_io)
+        @lines = {}
       end
 
       def after_feature(feature)

--- a/spec/fixtures/minitest4/Gemfile.lock
+++ b/spec/fixtures/minitest4/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../../
   specs:
-    parallel_tests (1.3.5)
+    parallel_tests (1.3.7)
       parallel
 
 GEM


### PR DESCRIPTION
This fixes these errors:
```
undefined method `[]' for nil:NilClass (NoMethodError)
/usr/local/rvm/gems/jruby-1.7.16/gems/cucumber-2.0.0/lib/cucumber/formatter/rerun.rb:15:in `after_test_case'
```
```
undefined method `empty?' for nil:NilClass (NoMethodError)
/usr/local/rvm/gems/jruby-1.7.16/gems/parallel_tests-1.3.7/lib/parallel_tests/cucumber/failures_logger.rb:14:in `after_feature'
```