### PR TITLE
Add sleep after stdout flush

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -66,7 +66,9 @@ module ParallelTests
     def report_output(result, lock)
       lock.flock File::LOCK_EX
       $stdout.puts result[:stdout]
+      # Make sure we have written all stdout
       $stdout.flush
+      sleep 0.1
     ensure
       lock.flock File::LOCK_UN
     end


### PR DESCRIPTION
Unfortunately, just calling flush is not a guarantee that stdout will be written. 

The proper way to do this is probably to do all writing from a single thread and push strings through a queue to it, but this is a simple solution that should work most of the time.