### PR TITLE
Fix file lock

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -64,11 +64,11 @@ module ParallelTests
     end
 
     def report_output(result, lock)
-      lock.flock File::LOCK_EX
-      $stdout.puts result[:stdout]
-      $stdout.flush
-    ensure
-      lock.flock File::LOCK_UN
+      File.open(lock.path) do |open_lock|
+        open_lock.flock File::LOCK_EX
+        $stdout.puts result[:stdout]
+        $stdout.flush
+      end
     end
 
     def report_results(test_results)


### PR DESCRIPTION
Each process needs its own handle, the lock wasn't actually locking the
way it was.

Proper fix for #386

Repro:

test.rb:

```ruby
require 'tempfile'

def bad(lock, i)
  str = "#{i.to_s} #{("a" * 99)}\n" * 1000
  lock.flock(File::LOCK_EX)
  $stdout.puts str
ensure
  lock.flock(File::LOCK_UN)
end

def good(lock, i)
  File.open(lock.path, "w+") do |lock|
    str = "#{i.to_s} #{("a" * 99)}\n" * 1000
    lock.flock(File::LOCK_EX)
    $stdout.puts str
  end
end

Tempfile.open('test.lock') do |lock|
  pids = 100.times.map { |i|
    fork {
      send ARGV[0], lock, i
    }
  }.compact

  pids.each do |pid|
    Process.wait pid
  end
end
```

```bash
$ ruby test.rb bad | uniq | wc -l
1014

$ ruby test.rb good | uniq | wc -l
100
```

100 is the right answer.