### PR TITLE
Ensure an unlock

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -72,8 +72,13 @@ module ParallelTests
 
     def lock(lockfile)
       File.open(lockfile) do |lock|
-        lock.flock File::LOCK_EX
-        yield
+        begin
+          lock.flock File::LOCK_EX
+          yield
+        ensure
+          # This shouldn't be necessary, but appears to be
+          lock.flock File::LOCK_UN
+        end
       end
     end
 


### PR DESCRIPTION
An unlock shouldn't be necessary, but I hit a deadlock in our test suite
the second time I built w/ the new locking mechanics.