### PR TITLE
Added print to logger so that cucumber rerun failed text

### DIFF
--- a/lib/parallel_tests/cucumber/failures_logger.rb
+++ b/lib/parallel_tests/cucumber/failures_logger.rb
@@ -14,7 +14,7 @@ module ParallelTests
         unless @lines.empty?
           lock_output do
             @lines.each do |line|
-              @io.puts "#{feature.file}:#{line}"
+              @io.print "#{feature.file}:#{line}"
             end
           end
         end

--- a/lib/parallel_tests/cucumber/failures_logger.rb
+++ b/lib/parallel_tests/cucumber/failures_logger.rb
@@ -14,7 +14,7 @@ module ParallelTests
         unless @lines.empty?
           lock_output do
             @lines.each do |line|
-              @io.print "#{feature.file}:#{line}"
+              @io.print "#{feature.file}:#{line} "
             end
           end
         end


### PR DESCRIPTION
Currently parallel cucumber logs failed scenarios to new line so when tried to rerun failed scenarios with cucumber -rerun formater it only runs only one feature. 
Demo repo where this bug exist.  https://github.com/Shashikant86/parallel-cucumber-failed-rerun This PR will fix the issue and rerun all failed scenario