### PR TITLE
Fix typos in readme and help output

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -196,7 +196,7 @@ Options are:
     -v, --version                    Show Version
     -h, --help                       Show this.
 
-You can run any kind of code in parallel with -e / --execute
+You can run any kind of code in parallel with -e / --exec
 
     parallel_test -n 5 -e 'ruby -e "puts %[hello from process #{ENV[:TEST_ENV_NUMBER.to_s].inspect}]"'
     hello from process "2"

--- a/Readme.md
+++ b/Readme.md
@@ -182,7 +182,7 @@ Options are:
     -s, --single [PATTERN]           Run all matching files in the same process
     -i, --isolate                    Do not run any other tests in the group used by --single(-s)
         --only-group INT[, INT]
-    -e, --exec [COMMAND]             execute this code parallel and with ENV['TEST_ENV_NUM']
+    -e, --exec [COMMAND]             execute this code parallel and with ENV['TEST_ENV_NUMBER']
     -o, --test-options '[OPTIONS]'   execute test commands with those options
     -t, --type [TYPE]                test(default) / rspec / cucumber / spinach
         --serialize-stdout           Serialize stdout output, nothing will be written until everything is done

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -140,7 +140,7 @@ module ParallelTests
 
         opts.on("--only-group INT[, INT]", Array) { |groups| options[:only_group] = groups.map(&:to_i) }
 
-        opts.on("-e", "--exec [COMMAND]", "execute this code parallel and with ENV['TEST_ENV_NUM']") { |path| options[:execute] = path }
+        opts.on("-e", "--exec [COMMAND]", "execute this code parallel and with ENV['TEST_ENV_NUMBER']") { |path| options[:execute] = path }
         opts.on("-o", "--test-options '[OPTIONS]'", "execute test commands with those options") { |arg| options[:test_options] = arg }
         opts.on("-t", "--type [TYPE]", "test(default) / rspec / cucumber / spinach") do |type|
           begin

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -139,7 +139,7 @@ describe 'CLI' do
   end
 
   context "with given commands" do
-    it "can exec given commands with ENV['TEST_ENV_NUM']" do
+    it "can exec given commands with ENV['TEST_ENV_NUMBER']" do
       result = `#{executable} -e 'ruby -e "print ENV[:TEST_ENV_NUMBER.to_s].to_i"' -n 4`
       result.gsub('"','').split('').sort.should == %w[0 2 3 4]
     end


### PR DESCRIPTION
Fixed a couple of typos in the README (see commits for details).

Additionally documented a section on PARALLEL_TEST_GROUPS and how to use that to load balance.