### PR TITLE
Revert "Update task to have singular command that is backwards compatible"

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -102,7 +102,11 @@ namespace :parallel do
   # just load the schema (good for integration server <-> no development db)
   desc "load dumped schema for test databases via db:schema:load --> parallel:load_schema[num_cpus]"
   task :load_schema, :count do |t,args|
-    command = "rake db:test:purge db:schema:load RAILS_ENV=#{ParallelTests::Tasks.rails_env}"
+    if Gem::Version.new(Rails.version) > Gem::Version.new('4.2.0')
+      command = "rake db:purge db:schema:load RAILS_ENV=#{ParallelTests::Tasks.rails_env}"
+    else
+      command = "rake db:drop db:create db:schema:load RAILS_ENV=#{ParallelTests::Tasks.rails_env}"
+    end
     ParallelTests::Tasks.run_in_parallel(ParallelTests::Tasks.suppress_output(command, "^   ->\\|^-- "), args)
   end
 


### PR DESCRIPTION
This reverts commit a5158e36817a13a927664d214d59a50f0662ab65.

using rails 3.2, 

```
# works
bundle exec rake db:test:purge RAILS_ENV=test

# works
bundle exec rake db:schema:load RAILS_ENV=test

# fails ("cannot find database")
bundle exec rake db:test:purge db:schema:load RAILS_ENV=test
```