### PR TITLE
Reject empty groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.5
+  - 2.2.2
   - jruby-1.7.9
   - jruby-head
 branches:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,14 +10,14 @@ GEM
     builder (3.2.2)
     bump (0.5.2)
     colorize (0.7.7)
-    cucumber (2.0.0)
+    cucumber (2.0.2)
       builder (>= 2.1.2)
-      cucumber-core (~> 1.1.3)
+      cucumber-core (~> 1.2.0)
       diff-lcs (>= 1.1.3)
       gherkin (~> 2.12)
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.1.2)
-    cucumber-core (1.1.3)
+    cucumber-core (1.2.0)
       gherkin (~> 2.12.0)
     diff-lcs (1.2.5)
     gherkin (2.12.2)
@@ -28,21 +28,21 @@ GEM
     json (1.8.3)
     json (1.8.3-java)
     minitest (5.5.1)
-    multi_json (1.11.1)
+    multi_json (1.11.2)
     multi_test (0.1.2)
-    parallel (1.6.0)
-    power_assert (0.2.3)
+    parallel (1.6.1)
+    power_assert (0.2.4)
     rake (10.4.2)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
       rspec-mocks (~> 3.3.0)
-    rspec-core (3.3.0)
+    rspec-core (3.3.2)
       rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.0)
+    rspec-expectations (3.3.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.0)
+    rspec-mocks (3.3.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
@@ -50,7 +50,7 @@ GEM
       colorize
       gherkin-ruby (>= 0.3.2)
       json
-    test-unit (3.1.2)
+    test-unit (3.1.3)
       power_assert
 
 PLATFORMS
@@ -68,4 +68,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -93,8 +93,8 @@ module ParallelTests
     def report_number_of_tests(groups)
       name = @runner.test_file_name
       num_processes = groups.size
-      num_tests = groups.empty? ? 0 : groups.map(&:size).inject(:+)
-      tests_per_process = num_processes <= 0 ? 0 : num_tests / num_processes
+      num_tests = groups.map(&:size).inject(0, :+)
+      tests_per_process = (num_processes == 0 ? 0 : num_tests / num_processes)
       puts "#{num_processes} processes for #{num_tests} #{name}s, ~ #{tests_per_process} #{name}s per process"
     end
 

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -35,9 +35,10 @@ module ParallelTests
 
       report_time_taken do
         groups = @runner.tests_in_groups(options[:files], num_processes, options)
+        groups.reject! &:empty?
 
         test_results = if options[:only_group]
-          groups_to_run = options[:only_group].collect{|i| groups[i - 1]}
+          groups_to_run = options[:only_group].collect{|i| groups[i - 1]}.compact
           report_number_of_tests(groups_to_run)
           execute_in_parallel(groups_to_run, groups_to_run.size, options) do |group|
             run_tests(group, groups_to_run.index(group), 1, options)
@@ -92,8 +93,9 @@ module ParallelTests
     def report_number_of_tests(groups)
       name = @runner.test_file_name
       num_processes = groups.size
-      num_tests = groups.map(&:size).inject(:+)
-      puts "#{num_processes} processes for #{num_tests} #{name}s, ~ #{num_tests / groups.size} #{name}s per process"
+      num_tests = groups.empty? ? 0 : groups.map(&:size).inject(:+)
+      tests_per_process = num_processes <= 0 ? 0 : num_tests / num_processes
+      puts "#{num_processes} processes for #{num_tests} #{name}s, ~ #{tests_per_process} #{name}s per process"
     end
 
     #exit with correct status code so rake parallel:test && echo 123 works

--- a/spec/fixtures/rails32/Gemfile.lock
+++ b/spec/fixtures/rails32/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../../
   specs:
-    parallel_tests (1.5.1)
+    parallel_tests (1.6.0)
       parallel
 
 GEM
@@ -95,4 +95,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/spec/fixtures/rails42/Gemfile.lock
+++ b/spec/fixtures/rails42/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../../
   specs:
-    parallel_tests (1.5.1)
+    parallel_tests (1.6.0)
       parallel
 
 GEM
@@ -108,4 +108,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -57,7 +57,8 @@ describe 'CLI' do
   it "runs tests in parallel" do
     write 'spec/xxx_spec.rb', 'describe("it"){it("should"){puts "TEST1"}}'
     write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){puts "TEST2"}}'
-    result = run_tests "spec", :type => 'rspec'
+    # set processes to false so we verify empty groups are discarded by default
+    result = run_tests "spec", :type => 'rspec', :processes => false
 
     # test ran and gave their puts
     expect(result).to include('TEST1')
@@ -68,6 +69,8 @@ describe 'CLI' do
     expect(result.scan('2 examples, 0 failures').size).to eq(1) # 1 summary
     expect(result.scan(/Finished in \d+\.\d+ seconds/).size).to eq(2)
     expect(result.scan(/Took \d+ seconds/).size).to eq(1) # parallel summary
+    # verify empty groups are discarded. if retained then it'd say 4 processes for 2 specs
+    expect(result.scan('2 processes for 2 specs, ~ 1 specs per process').size).to eq(1)
   end
 
   it "runs tests which outputs accented characters" do

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -180,6 +180,12 @@ describe ParallelTests::CLI do
         subject.run(['test', '-n', '3', '--only-group', '2', '-t', 'my_test_runner'])
       end
 
+      it "run no group when only_group uses invalid index" do
+        group_number = 99
+        expect(subject).to_not receive(:run_tests)
+        subject.run(['test', '-n', '3', '--only-group', group_number.to_s, '-t', 'my_test_runner'])
+      end
+
       it "run twice with multiple groups" do
         skip "fails on jruby" if RUBY_PLATFORM == "java"
         options = {count: 3, only_group: [2,3], files: ["test"], group_by: :filesize}

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -180,9 +180,10 @@ describe ParallelTests::CLI do
         subject.run(['test', '-n', '3', '--only-group', '2', '-t', 'my_test_runner'])
       end
 
-      it "run no group when only_group uses invalid index" do
-        group_number = 99
-        expect(subject).to_not receive(:run_tests)
+      it "run last group" do
+        group_number = 3
+        options = {count: 3, only_group: [group_number], files: ["test"], group_by: :filesize}
+        expect(subject).to receive(:run_tests).once.with(['eee', 'fff'], 0, 1, options).and_return(results)
         subject.run(['test', '-n', '3', '--only-group', group_number.to_s, '-t', 'my_test_runner'])
       end
 

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -12,6 +12,10 @@ describe 'rails' do
   ["rails32", "rails42"].each do |rails|
     it "can create and run" do
       skip if RUBY_PLATFORM == "java"
+      if rails == 'rails32'
+        ruby_2_2_2_or_newer = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
+        skip 'rails 3.2 does not work on ruby >= 2.2.2' if ruby_2_2_2_or_newer
+      end
 
       Dir.chdir("spec/fixtures/#{rails}") do
         Bundler.with_clean_env do


### PR DESCRIPTION
This seems like a simple bug. If I have two files (one spec in each file) then I expect 1 spec per process (2 processes for 2 specs). The current behavior is 4 processes which doesn't make sense.

Before:
```
$ parallel_rspec spec/
4 processes for 2 specs, ~ 0 specs per process
```

After:
```
$ parallel_rspec spec/
2 processes for 2 specs, ~ 1 specs per process
```