### PR TITLE
Makes sure tests in fixtures aren't run accidentally

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
 --color
 --order random
---exclude-pattern spec/fixtures/minitest4/vendor/bundle/**/*
+--exclude-pattern spec/fixtures/**/*


### PR DESCRIPTION
When I run the tests locally, I get the following error (not sure why this doesn't happen on travis).

```
$ bundle exec rake
rspec spec/
./parallel_tests/spec/fixtures/rails32/vendor/bundle/ruby/2.0.0/gems/rack-test-0.6.3/spec/rack/test/cookie_spec.rb:3:in `<top (required)>': uninitialized constant Rack (NameError)
	from ~/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1327:in `load'
	from ~/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1327:in `block in load_spec_files'
	from ~/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1325:in `each'
	from ~/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1325:in `load_spec_files'
	from ~/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:102:in `setup'
	from ~/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:88:in `run'
	from ~/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:73:in `run'
	from ~/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:41:in `invoke'
	from ~/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/gems/rspec-core-3.3.2/exe/rspec:4:in `<top (required)>'
	from ~/.rbenv/versions/2.0.0-p451/bin/rspec:23:in `load'
	from ~/.rbenv/versions/2.0.0-p451/bin/rspec:23:in `<main>'
rake aborted!
Command failed with status (1): [rspec spec/...]
./parallel_tests/Rakefile:9:in `block in <top (required)>'
Tasks: TOP => default
(See full trace by running task with --trace)
```

This pull request fixes running the tests.