### PR TITLE
Ability to modify suffix for tests via a cli option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -195,6 +195,9 @@ Options are:
     -e, --exec [COMMAND]             execute this code parallel and with ENV['TEST_ENV_NUMBER']
     -o, --test-options '[OPTIONS]'   execute test commands with those options
     -t, --type [TYPE]                test(default) / rspec / cucumber / spinach
+        --suffix [PATTERN]           override built in test file pattern (should match suffix):
+          '_spec.rb$' - matches rspec files
+          '_(test|spec).rb$' - matches test or spec files
         --serialize-stdout           Serialize stdout output, nothing will be written until everything is done
         --combine-stderr             Combine stderr into stdout, useful in conjunction with --serialize-stdout
         --non-parallel               execute same commands but do not in parallel, needs --exec

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -156,6 +156,12 @@ module ParallelTests
             abort
           end
         end
+        opts.on("--suffix [PATTERN]", <<-TEXT.gsub(/^          /, '')
+          override built in test file pattern (should match suffix):
+                    '_spec\.rb$' - matches rspec files
+                    '_(test|spec).rb$' - matches test or spec files
+          TEXT
+          ) { |pattern| options[:suffix] = /#{pattern}/ }
         opts.on("--serialize-stdout", "Serialize stdout output, nothing will be written until everything is done") { options[:serialize_stdout] = true }
         opts.on("--combine-stderr", "Combine stderr into stdout, useful in conjunction with --serialize-stdout") { options[:combine_stderr] = true }
         opts.on("--non-parallel", "execute same commands but do not in parallel, needs --exec") { options[:non_parallel] = true }

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -196,7 +196,7 @@ module ParallelTests
           (tests || []).map do |file_or_folder|
             if File.directory?(file_or_folder)
               files = files_in_folder(file_or_folder, options)
-              files.grep(test_suffix).grep(options[:pattern]||//)
+              files.grep(options[:suffix]||test_suffix).grep(options[:pattern]||//)
             else
               file_or_folder
             end

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -46,6 +46,10 @@ describe ParallelTests::CLI do
       expect(call(["test", "--verbose"])).to eq(defaults.merge(:verbose => true))
     end
 
+    it "parses --suffix" do
+      expect(call(["test", "--suffix", "_(test|spec).rb$"])).to eq(defaults.merge(:suffix => /_(test|spec).rb$/))
+    end
+
     context "parse only-group" do
       it "group_by should be set to filesize" do
         expect(call(["test", "--only-group", '1'])).to eq(defaults.merge(only_group: [1], group_by: :filesize))

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -264,6 +264,18 @@ EOF
       end
     end
 
+    it "finds test files in folders using suffix and overriding built in suffix" do
+      with_files(['a/x_test.rb','a/y_test.rb','a/z_other.rb','a/x_different.rb']) do |root|
+        Dir.chdir root do
+          expect(call(["a"], :suffix => /_(test|other)\.rb$/).sort).to eq([
+            "a/x_test.rb",
+            "a/y_test.rb",
+            "a/z_other.rb",
+          ])
+        end
+      end
+    end
+
     it "doesn't find bakup files with the same name as test files" do
       with_files(['a/x_test.rb','a/x_test.rb.bak']) do |root|
         expect(call(["#{root}/"])).to eq([


### PR DESCRIPTION
This pull request adds the ability to modify the suffix regexp based on a command line option `--suffix [PATTERN]`. This then modifies the search function to replace `test_suffix`.

This was recommended as the non-invasive version of #436 which allows me to create a gem to use that suffix, or use it directly.

Many thanks for considering this so that we don't have to fork!