### PR TITLE
Fix use of options to match what previous test is intending.

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -150,7 +150,7 @@ namespace :parallel do
       command = "#{executable} #{type} --type #{test_framework} " \
         "-n #{count} "                     \
         "--pattern '#{pattern}' "          \
-        "--test-options '#{options}'"
+        "#{options}"
       if ParallelTests::WINDOWS
         ruby_binary = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])
         command = "#{ruby_binary} #{command}"

--- a/spec/fixtures/minitest4/Gemfile.lock
+++ b/spec/fixtures/minitest4/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../../
   specs:
-    parallel_tests (1.6.1)
+    parallel_tests (1.7.0)
       parallel
 
 GEM

--- a/spec/fixtures/rails32/Gemfile.lock
+++ b/spec/fixtures/rails32/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../../
   specs:
-    parallel_tests (1.6.0)
+    parallel_tests (1.7.0)
       parallel
 
 GEM

--- a/spec/fixtures/rails42/Gemfile.lock
+++ b/spec/fixtures/rails42/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../../
   specs:
-    parallel_tests (1.6.0)
+    parallel_tests (1.7.0)
       parallel
 
 GEM

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -33,7 +33,6 @@ describe ParallelTests::Tasks do
     end
 
     it "should use count, pattern, and options in calling the cli" do
-      command = ''
       expect_any_instance_of(Object).to receive(:system)
         .with(/parallel_test test --type test -n 5 --pattern 'foo' -p default --group-by steps/)
         .and_return(true)

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -31,6 +31,15 @@ describe ParallelTests::Tasks do
       }
       expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "plain", "-p default --group-by steps"])
     end
+
+    it "should use count, pattern, and options in calling the cli" do
+      command = ''
+      expect_any_instance_of(Object).to receive(:system)
+        .with(/parallel_test test --type test -n 5 --pattern 'foo' -p default --group-by steps/)
+        .and_return(true)
+
+      Rake.application['parallel:test'].invoke(5,"foo","-p default --group-by steps")
+    end
   end
 
   describe ".rails_env" do


### PR DESCRIPTION
This pull request is about using the options parameter in the `rake parallel:test` and friends in the way the  existing tests imply. Current implementation means that the options set there are always set as `--test-options`.

Currently:
`rake "parallel:spec[5,foo,-p bar -z baz]"`

Will call

`parallel_test test --type test -n 5 --pattern 'foo' --test-options '-p bar -z baz'`

However, the test at https://github.com/grosser/parallel_tests/blob/master/spec/parallel_tests/tasks_spec.rb#L26-L34 definitely implies that the options should be passed through straight, since the options listed are parallel tests options, not rspec options.

This pull request does that. Now the command will run:

`parallel_test test --type test -n 5 --pattern 'foo' -p bar -z baz`