### PR TITLE
Allow passing test env number offset

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -166,6 +166,7 @@ module ParallelTests
         opts.on("--combine-stderr", "Combine stderr into stdout, useful in conjunction with --serialize-stdout") { options[:combine_stderr] = true }
         opts.on("--non-parallel", "execute same commands but do not in parallel, needs --exec") { options[:non_parallel] = true }
         opts.on("--no-symlinks", "Do not traverse symbolic links to find test files") { options[:symlinks] = false }
+        opts.on("--init-test-env-number [NUMBER]", Integer, "Initial test env number offset") { |n| options[:init_test_env_number] = n }
         opts.on('--ignore-tags [PATTERN]', 'When counting steps ignore scenarios with tags that match this pattern')  { |arg| options[:ignore_tag_pattern] = arg }
         opts.on("--nice", "execute test commands with low priority.") { options[:nice] = true }
         opts.on("--runtime-log [PATH]", "Location of previously recorded test runtimes") { |path| options[:runtime_log] = path }

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -15,6 +15,7 @@ module ParallelTests
         count = " -n #{options[:count]}" unless options[:count].to_s.empty?
         executable = File.expand_path("../../../bin/parallel_test", __FILE__)
         command = "#{executable} --exec '#{cmd}'#{count}#{' --non-parallel' if options[:non_parallel]}"
+        command << " --init-test-env-number #{options[:init_test_env_number]}" if options[:init_test_env_number]
         abort unless system(command)
       end
 

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -71,7 +71,7 @@ module ParallelTests
 
         def execute_command(cmd, process_number, num_processes, options)
           env = (options[:env] || {}).merge(
-            "TEST_ENV_NUMBER" => test_env_number(process_number),
+            "TEST_ENV_NUMBER" => test_env_number(process_number, options),
             "PARALLEL_TEST_GROUPS" => num_processes
           )
           cmd = "nice #{cmd}" if options[:nice]
@@ -107,8 +107,13 @@ module ParallelTests
           }.compact
         end
 
-        def test_env_number(process_number)
-          process_number == 0 ? '' : process_number + 1
+        def test_env_number(process_number, options)
+          number = options[:init_test_env_number].to_i + process_number
+
+          return '' if number == 0
+          return number if process_number == 0
+
+          number + 1
         end
 
         def summarize_results(results)

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -50,6 +50,10 @@ describe ParallelTests::CLI do
       expect(call(["test", "--suffix", "_(test|spec).rb$"])).to eq(defaults.merge(:suffix => /_(test|spec).rb$/))
     end
 
+    it "parses --init-test-env-number" do
+      expect(call(["test", "--init-test-env-number", "100"])).to eq(defaults.merge(:init_test_env_number => 100))
+    end
+
     context "parse only-group" do
       it "group_by should be set to filesize" do
         expect(call(["test", "--only-group", '1'])).to eq(defaults.merge(only_group: [1], group_by: :filesize))

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -72,6 +72,11 @@ describe ParallelTests::Tasks do
       ParallelTests::Tasks.run_in_parallel("echo", :non_parallel => true)
     end
 
+    it "runs command with :init_test_env_number option" do
+      expect(ParallelTests::Tasks).to receive(:system).with("#{full_path} --exec 'echo' --init-test-env-number 100").and_return true
+      ParallelTests::Tasks.run_in_parallel("echo", :init_test_env_number => 100)
+    end
+
     it "runs aborts if the command fails" do
       expect(ParallelTests::Tasks).to receive(:system).and_return false
       expect(ParallelTests::Tasks).to receive(:abort).and_return false

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -378,6 +378,29 @@ EOF
       end
     end
 
+    context 'with init test env number' do
+      let(:options) { { init_test_env_number: 100 } }
+      it "sets process number to '100' for 0" do
+        run_with_file("puts ENV['TEST_ENV_NUMBER'].inspect") do |path|
+          result = call("ruby #{path}", 0, 4, options)
+          expect(result).to eq({
+            :stdout => "\"100\"\n",
+            :exit_status => 0
+          })
+        end
+      end
+
+      it "sets process number to '102' for 1" do
+        run_with_file("puts ENV['TEST_ENV_NUMBER'].inspect") do |path|
+          result = call("ruby #{path}", 1, 4, options)
+          expect(result).to eq({
+            :stdout => "\"102\"\n",
+            :exit_status => 0
+          })
+        end
+      end
+    end
+
     it 'sets PARALLEL_TEST_GROUPS so child processes know that they are being run under parallel_tests' do
       run_with_file("puts ENV['PARALLEL_TEST_GROUPS']") do |path|
         result = call("ruby #{path}", 1, 4, {})


### PR DESCRIPTION
Second attempt of https://github.com/grosser/parallel_tests/pull/173

We are using this feature to handle `parallel_tests` on multiple Jenkins workers. Right now we use our own fork, but we would prefer original gem over fork :)