### PR TITLE
Print out commands that led to failing tests

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -92,13 +92,13 @@ module ParallelTests
     end
 
     def report_failure_rerun_commmand(test_results)
-      failing_sets = test_results.select{|test_result| test_result[:exit_status] != 0 }
-      return unless failing_sets.size > 0
+      failing_sets = test_results.reject { |r| r[:exit_status] == 0 }
+      return if failing_sets.none?
 
       puts "\n\nTests have failed for a parallel_test group. Use the following command to run the group again:\n\n"
       failing_sets.each do |failing_set|
         command = failing_set[:command]
-        command = command + " --seed #{failing_set[:seed]}" if failing_set[:seed]
+        command = @runner.command_with_seed(command, failing_set[:seed]) if failing_set[:seed]
         puts command
       end
     end

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -97,8 +97,9 @@ module ParallelTests
 
       puts "\n\nTests have failed for a parallel_test group. Use the following command to run the group again:\n\n"
       failing_sets.each do |failing_set|
-        puts failing_set[:command]
-        puts "\nCheckout your local branch to the deployed SHA and add '--seed #{failing_set[:seed]}' to the command to run tests in the same order.\n" if failing_set[:seed]
+        command = failing_set[:command]
+        command = command.gsub('rspec', "rspec --seed #{failing_set[:seed]}") if failing_set[:seed]
+        puts command
       end
     end
 

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -98,7 +98,7 @@ module ParallelTests
       puts "\n\nTests have failed for a parallel_test group. Use the following command to run the group again:\n\n"
       failing_sets.each do |failing_set|
         command = failing_set[:command]
-        command = command.gsub('rspec', "rspec --seed #{failing_set[:seed]}") if failing_set[:seed]
+        command = command + " --seed #{failing_set[:seed]}" if failing_set[:seed]
         puts command
       end
     end

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -59,7 +59,7 @@ module ParallelTests
 
     def run_tests(group, process_number, num_processes, options)
       if group.empty?
-        {:stdout => '', :exit_status => 0}
+        {:stdout => '', :exit_status => 0, :command => '', :seed => nil}
       else
         @runner.run_tests(group, process_number, num_processes, options)
       end
@@ -88,6 +88,18 @@ module ParallelTests
       results = @runner.find_results(test_results.map { |result| result[:stdout] }*"")
       puts ""
       puts @runner.summarize_results(results)
+      report_failure_rerun_commmand(test_results)
+    end
+
+    def report_failure_rerun_commmand(test_results)
+      failing_sets = test_results.select{|test_result| test_result[:exit_status] != 0 }
+      return unless failing_sets.size > 0
+
+      puts "\n\nTests have failed for a parallel_test group. Use the following command to run the group again:\n\n"
+      failing_sets.each do |failing_set|
+        puts failing_set[:command]
+        puts "\nCheckout your local branch to the deployed SHA and add '--seed #{failing_set[:seed]}' to the command to run tests in the same order.\n" if failing_set[:seed]
+      end
     end
 
     def report_number_of_tests(groups)

--- a/lib/parallel_tests/cucumber/runner.rb
+++ b/lib/parallel_tests/cucumber/runner.rb
@@ -27,6 +27,7 @@ module ParallelTests
         end
 
         def command_with_seed(cmd, seed)
+          cmd = cmd.sub(/\s--order random(:\d*){0,1}/, '')
           "#{cmd} --order random:#{seed}"
         end
 

--- a/lib/parallel_tests/cucumber/runner.rb
+++ b/lib/parallel_tests/cucumber/runner.rb
@@ -26,6 +26,10 @@ module ParallelTests
           output.join("\n\n")
         end
 
+        def command_with_seed(cmd, seed)
+          "#{cmd} --order random:#{seed}"
+        end
+
         private
 
         def failing_scenario_regex

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -95,8 +95,9 @@ module ParallelTests
 
           output = open("|#{cmd}", "r") { |output| capture_output(output, silence) }
           exitstatus = $?.exitstatus
+          seed = output.scan(/seed (\d+)/).flatten.first
 
-          {:stdout => output, :exit_status => exitstatus}
+          {:stdout => output, :exit_status => exitstatus, :command => cmd, :seed => seed}
         end
 
         def find_results(test_output)

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -117,6 +117,10 @@ module ParallelTests
           sums.sort.map{|word, number|  "#{number} #{word}#{'s' if number != 1}" }.join(', ')
         end
 
+        def command_with_seed(cmd, seed)
+          "#{cmd} --seed #{seed}"
+        end
+
         protected
 
         def executable

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -95,7 +95,7 @@ module ParallelTests
 
           output = open("|#{cmd}", "r") { |output| capture_output(output, silence) }
           exitstatus = $?.exitstatus
-          seed = output.scan(/seed (\d+)/).flatten.first
+          seed = output[/seed (\d+)/,1]
 
           {:stdout => output, :exit_status => exitstatus, :command => cmd, :seed => seed}
         end

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -118,6 +118,8 @@ module ParallelTests
         end
 
         def command_with_seed(cmd, seed)
+          cmd = cmd.sub(/\s--seed(\s\d*){0,1}/, '')
+          cmd = cmd.sub(/\s--order rand(:\d*){0,1}/, '')
           "#{cmd} --seed #{seed}"
         end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -279,6 +279,14 @@ describe 'CLI' do
 
   context "RSpec" do
     it_fails_without_any_files "rspec"
+
+    it "captures seed with random failures" do
+      write 'spec/xxx_spec.rb', 'describe("it"){it("should"){puts "TEST1"}}'
+      write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){1.should == 2}}'
+      result = run_tests "spec", :add => "--test-options '--seed 1234'", :fail => true, :type => 'rspec'
+      expect(result).to include("Randomized with seed 1234")
+      expect(result).to include("bundle exec rspec spec/xxx2_spec.rb --seed 1234")
+    end
   end
 
   context "Test::Unit" do
@@ -398,6 +406,13 @@ cucumber features/fail1.feature:2 # Scenario: xxx
       result = run_tests "features", :type => "cucumber", :add => '--group-by steps'
 
       expect(result).to include("2 processes for 2 features")
+    end
+
+    it "captures seed with random failures" do
+      write "features/good1.feature", "Feature: xxx\n  Scenario: xxx\n    Given I fail"
+      result = run_tests "features", :type => "cucumber", :add => '--test-options "--order random:1234"', :fail => true
+      expect(result).to include("Randomized with seed 1234")
+      expect(result).to include("bundle exec cucumber features/good1.feature --order random:1234")
     end
   end
 

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -183,14 +183,20 @@ describe ParallelTests::CLI do
         }.to output(/foo --color\nbaz/).to_stdout
       end
 
-      it "prints the command with the seed" do
+      it "prints the command with the seed added by the runner" do
+        command = 'rspec --color spec/foo_spec.rb'
+        seed = 555
+
+        subject.instance_variable_set(:@runner, ParallelTests::Test::Runner)
+        expect(ParallelTests::Test::Runner).to receive(:command_with_seed).with(command, seed).
+          and_return("my seeded command result --seed #{seed}")
         expect { 
           subject.send(:report_failure_rerun_commmand,
             [
-              {exit_status: 1, command: 'rspec --color spec/foo_spec.rb', seed: 555, output: 'blah'},
+              {exit_status: 1, command: command, seed: 555, output: 'blah'},
             ]
           )
-        }.to output(/rspec --color spec\/foo_spec\.rb --seed 555/).to_stdout
+        }.to output(/my seeded command result --seed 555/).to_stdout
       end
     end
   end

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -137,6 +137,40 @@ describe ParallelTests::CLI do
     end
   end
 
+  describe ".report_failure_rerun_commmand" do
+    it "prints nothing if there are no failures" do
+      expect($stdout).not_to receive(:puts)
+
+      subject.send(:report_failure_rerun_commmand,
+        [
+          {exit_status: 0, command: 'foo', seed: nil, output: 'blah'},
+        ]
+      )
+    end
+
+    describe "failure" do
+      it "prints a message and the command if there is a failure" do
+        expect { 
+          subject.send(:report_failure_rerun_commmand,
+            [
+              {exit_status: 1, command: 'foo', seed: nil, output: 'blah'},
+            ]
+          )
+        }.to output("\n\nTests have failed for a parallel_test group. Use the following command to run the group again:\n\nfoo\n").to_stdout
+      end
+
+      it "prints the seed" do
+        expect { 
+          subject.send(:report_failure_rerun_commmand,
+            [
+              {exit_status: 1, command: 'foo', seed: 555, output: 'blah'},
+            ]
+          )
+        }.to output(/Checkout your local branch to the deployed SHA and add '--seed 555' to the command to run tests in the same order.\n/).to_stdout
+      end
+    end
+  end
+
   describe "#final_fail_message" do
     before do
       subject.instance_variable_set(:@runner, ParallelTests::Test::Runner)

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -159,6 +159,30 @@ describe ParallelTests::CLI do
         }.to output("\n\nTests have failed for a parallel_test group. Use the following command to run the group again:\n\nfoo\n").to_stdout
       end
 
+      it "prints multiple commands if there are multiple failures" do
+        expect { 
+          subject.send(:report_failure_rerun_commmand,
+            [
+              {exit_status: 1, command: 'foo', seed: nil, output: 'blah'},
+              {exit_status: 1, command: 'bar', seed: nil, output: 'blah'},
+              {exit_status: 1, command: 'baz', seed: nil, output: 'blah'},
+            ]
+          )
+        }.to output(/foo\nbar\nbaz/).to_stdout
+      end
+
+      it "only includes faiures" do
+        expect { 
+          subject.send(:report_failure_rerun_commmand,
+            [
+              {exit_status: 1, command: 'foo', seed: nil, output: 'blah'},
+              {exit_status: 0, command: 'bar', seed: nil, output: 'blah'},
+              {exit_status: 1, command: 'baz', seed: nil, output: 'blah'},
+            ]
+          )
+        }.to output(/foo\nbaz/).to_stdout
+      end
+
       it "prints the seed" do
         expect { 
           subject.send(:report_failure_rerun_commmand,

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -175,22 +175,22 @@ describe ParallelTests::CLI do
         expect { 
           subject.send(:report_failure_rerun_commmand,
             [
-              {exit_status: 1, command: 'foo', seed: nil, output: 'blah'},
+              {exit_status: 1, command: 'foo --color', seed: nil, output: 'blah'},
               {exit_status: 0, command: 'bar', seed: nil, output: 'blah'},
               {exit_status: 1, command: 'baz', seed: nil, output: 'blah'},
             ]
           )
-        }.to output(/foo\nbaz/).to_stdout
+        }.to output(/foo --color\nbaz/).to_stdout
       end
 
-      it "prints the seed" do
+      it "prints the command with the seed" do
         expect { 
           subject.send(:report_failure_rerun_commmand,
             [
-              {exit_status: 1, command: 'foo', seed: 555, output: 'blah'},
+              {exit_status: 1, command: 'rspec --color spec/foo_spec.rb', seed: 555, output: 'blah'},
             ]
           )
-        }.to output(/Checkout your local branch to the deployed SHA and add '--seed 555' to the command to run tests in the same order.\n/).to_stdout
+        }.to output(/rspec --seed 555 --color spec\/foo_spec\.rb/).to_stdout
       end
     end
   end

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -190,7 +190,7 @@ describe ParallelTests::CLI do
               {exit_status: 1, command: 'rspec --color spec/foo_spec.rb', seed: 555, output: 'blah'},
             ]
           )
-        }.to output(/rspec --seed 555 --color spec\/foo_spec\.rb/).to_stdout
+        }.to output(/rspec --color spec\/foo_spec\.rb --seed 555/).to_stdout
       end
     end
   end

--- a/spec/parallel_tests/cucumber/runner_spec.rb
+++ b/spec/parallel_tests/cucumber/runner_spec.rb
@@ -24,4 +24,12 @@ describe ParallelTests::Cucumber::Runner do
       end
     end
   end
+
+  describe ".command_with_seed" do
+    it "adds the randomized seed" do
+      expect(ParallelTests::Cucumber::Runner.command_with_seed("cucumber", 555)).
+        to eq("cucumber --order random:555")
+    end
+  end
+
 end

--- a/spec/parallel_tests/cucumber/runner_spec.rb
+++ b/spec/parallel_tests/cucumber/runner_spec.rb
@@ -30,6 +30,16 @@ describe ParallelTests::Cucumber::Runner do
       expect(ParallelTests::Cucumber::Runner.command_with_seed("cucumber", 555)).
         to eq("cucumber --order random:555")
     end
+
+    it "does not duplicate existing random command" do
+      expect(ParallelTests::Cucumber::Runner.command_with_seed("cucumber --order random good1.feature", 555)).
+        to eq("cucumber good1.feature --order random:555")
+    end
+
+    it "does not duplicate existing random command with seed" do
+      expect(ParallelTests::Cucumber::Runner.command_with_seed("cucumber --order random:123 good1.feature", 555)).
+        to eq("cucumber good1.feature --order random:555")
+    end
   end
 
 end

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -488,7 +488,7 @@ EOF
 
     describe "rspec seed" do
       it "includes seed when provided" do
-        run_with_file("puts 'seed 555'") do |path|
+        run_with_file("puts 'Run options: --seed 555'") do |path|
           result = call("ruby #{path}", 1, 4, {})
           expect(result).to include({
             :seed => "555"
@@ -504,6 +504,13 @@ EOF
           })
         end
       end
+    end
+  end
+
+  describe ".command_with_seed" do
+    it "adds the randomized seed" do
+      expect(ParallelTests::Test::Runner.command_with_seed("ruby -Ilib:test test/minitest/test_minitest_unit.rb", 555)).
+        to eq("ruby -Ilib:test test/minitest/test_minitest_unit.rb --seed 555")
     end
   end
 end

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -512,5 +512,22 @@ EOF
       expect(ParallelTests::Test::Runner.command_with_seed("ruby -Ilib:test test/minitest/test_minitest_unit.rb", 555)).
         to eq("ruby -Ilib:test test/minitest/test_minitest_unit.rb --seed 555")
     end
+
+    describe "existing randomization" do
+      it "does not duplicate seed" do
+        expect(ParallelTests::Test::Runner.command_with_seed("ruby -Ilib:test test/minitest/test_minitest_unit.rb --seed 123", 555)).
+          to eq("ruby -Ilib:test test/minitest/test_minitest_unit.rb --seed 555")
+      end
+
+      it "does not duplicate rand" do
+        expect(ParallelTests::Test::Runner.command_with_seed("ruby -Ilib:test test/minitest/test_minitest_unit.rb --order rand", 555)).
+          to eq("ruby -Ilib:test test/minitest/test_minitest_unit.rb --seed 555")
+      end
+
+      it "does not duplicate rand with seed" do
+        expect(ParallelTests::Test::Runner.command_with_seed("ruby -Ilib:test test/minitest/test_minitest_unit.rb --order rand:555", 555)).
+          to eq("ruby -Ilib:test test/minitest/test_minitest_unit.rb --seed 555")
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds additional reporting on the commands that caused a failing test. This helps massively in finding tests that depend on the order they were run in or the group that they were run in.

This pull request always prints the report, however this could be made optional. However, I feel it's in keeping with the generalized reporting approach taken by tools such as `rspec`.