### PR TITLE
Allow use of the 'only-group' option when executing commands in parallel

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -226,13 +226,17 @@ module ParallelTests
     end
 
     def execute_shell_command_in_parallel(command, num_processes, options)
-      runs = (0...num_processes).to_a
+      runs = if options[:only_group]
+               options[:only_group].map{|g| g - 1}
+             else
+               (0...num_processes).to_a
+             end
       results = if options[:non_parallel]
         runs.map do |i|
           ParallelTests::Test::Runner.execute_command(command, i, num_processes, options)
         end
       else
-        execute_in_parallel(runs, num_processes, options) do |i|
+        execute_in_parallel(runs, runs.size, options) do |i|
           ParallelTests::Test::Runner.execute_command(command, i, num_processes, options)
         end
       end.flatten

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -153,6 +153,11 @@ describe 'CLI' do
       expect(result.split("\n")).to eq(%w["" "2" "3" "4"])
     end
 
+    it "can exec given command with a restricted set of groups" do
+      result = `#{executable} -e 'ruby -e "print ENV[:TEST_ENV_NUMBER.to_s].to_i"' -n 4 --only-group 1,3`
+      expect(result.gsub('"','').split('').sort).to eq(%w[0 3])
+    end
+
     it "can serialize stdout" do
       result = `#{executable} -e 'ruby -e "5.times{sleep 0.01;puts ENV[:TEST_ENV_NUMBER.to_s].to_i;STDOUT.flush}"' -n 2 --serialize-stdout`
       expect(result).not_to match(/0.*2.*0/m)


### PR DESCRIPTION
The --only-group option is very handy for splitting a task across machines.

If Machine A has 4 cores and Machine B has 2 cores, you could run

on Machine A: -n 6 --only-group 1,2,3,4
on Machine B: -n 6 --only-group 5,6

and have the entire task run. Currently the --only-group option is only respected when running tests. This commit would allow it to be used for any arbitrary command (with the -e flag).

Just don't forget to aggregate your results at the end!