### PR TITLE
Only clear out the runtime log once.

### DIFF
--- a/lib/parallel_tests/gherkin/io.rb
+++ b/lib/parallel_tests/gherkin/io.rb
@@ -9,7 +9,9 @@ module ParallelTests
         if path_or_io.respond_to?(:write)
           path_or_io
         else # its a path
-          if temp_lock = Tempfile.open("#{File.basename(path_or_io)}-lock", mode: File::LOCK_EX|File::LOCK_NB)
+          temp_filename = File.join(Dir.tmpdir, "#{File.basename(path_or_io)}-lock")
+          temp_lock = File.open(temp_filename, File::CREAT|File::APPEND)
+          if temp_lock.flock(File::LOCK_EX|File::LOCK_NB)
             File.open(path_or_io, 'w').close # clean out the file
 
             at_exit do
@@ -24,7 +26,7 @@ module ParallelTests
           at_exit do
             unless file.closed?
               file.flush
-              file.close
+              File.unlink(temp_filename)
             end
           end
 

--- a/lib/parallel_tests/gherkin/io.rb
+++ b/lib/parallel_tests/gherkin/io.rb
@@ -1,3 +1,4 @@
+require 'tempfile'
 require 'parallel_tests'
 
 module ParallelTests

--- a/lib/parallel_tests/rspec/logger_base.rb
+++ b/lib/parallel_tests/rspec/logger_base.rb
@@ -1,3 +1,5 @@
+require 'tempfile'
+
 module ParallelTests
   module RSpec
   end

--- a/lib/parallel_tests/rspec/logger_base.rb
+++ b/lib/parallel_tests/rspec/logger_base.rb
@@ -27,13 +27,15 @@ class ParallelTests::RSpec::LoggerBase < ParallelTests::RSpec::LoggerBaseBase
 
     if String === @output # a path ?
       FileUtils.mkdir_p(File.dirname(@output))
-      if temp_lock = Tempfile.open("#{File.basename(@output)}-lock", mode: File::LOCK_EX|File::LOCK_NB)
+      temp_filename = File.join(Dir.tmpdir, "#{File.basename(@output)}-lock")
+      temp_lock = File.open(temp_filename, File::CREAT|File::APPEND)
+      if temp_lock.flock(File::LOCK_EX|File::LOCK_NB)
         File.open(@output, 'w'){} # overwrite previous results
 
         at_exit do
           unless temp_lock.closed?
             temp_lock.close
-            temp_lock.unlink
+            File.unlink(temp_filename)
           end
         end
       end


### PR DESCRIPTION
Should fix grosser/parallel_tests#450

Defacto this is rarely an issue in the real world because the tests take a while to
complete, but it does cause random test failures such as this one: https://travis-ci.org/grosser/parallel_tests/jobs/83490891

I haven't found a way to test the issue however, so not sure of the value of the change.