### PR TITLE
Disable Spring by default when running executable - #301

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -8,6 +8,8 @@ module ParallelTests
     def run(argv)
       options = parse_options!(argv)
 
+      ENV['DISABLE_SPRING']='1'
+
       num_processes = ParallelTests.determine_number_of_processes(options[:count])
       num_processes = num_processes * (options[:multiply] || 1)
 

--- a/spec/parallel_tests/rspec/runner_spec.rb
+++ b/spec/parallel_tests/rspec/runner_spec.rb
@@ -148,6 +148,11 @@ describe ParallelTests::RSpec::Runner do
       expect(ParallelTests::RSpec::Runner).to receive(:execute_command).and_return :x => 1
       expect(call('xxx', 1, 22, {})).to eq({:x => 1})
     end
+
+    it "has DISABLE_SPRING var set" do
+      call('xxx', 1, 22, {})
+      expect(ENV['DISABLE_SPRING']).to eq '1'
+    end
   end
 
   describe :find_results do


### PR DESCRIPTION
I don't know very much about rake tasks, so I don't know how to fix if it is running with rake, but this fixes bundle exec parallel_rspec.