### PR TITLE
Fix system calls from a directory names that includes spaces

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -14,7 +14,7 @@ module ParallelTests
       def run_in_parallel(cmd, options={})
         count = " -n #{options[:count]}" unless options[:count].to_s.empty?
         executable = File.expand_path("../../../bin/parallel_test", __FILE__)
-        command = "#{executable} --exec '#{cmd}'#{count}#{' --non-parallel' if options[:non_parallel]}"
+        command = "#{Shellwords.escape executable} --exec '#{cmd}'#{count}#{' --non-parallel' if options[:non_parallel]}"
         abort unless system(command)
       end
 
@@ -147,7 +147,7 @@ namespace :parallel do
       end
       executable = File.join(File.dirname(__FILE__), '..', '..', 'bin', 'parallel_test')
 
-      command = "#{executable} #{type} --type #{test_framework} " \
+      command = "#{Shellwords.escape executable} #{type} --type #{test_framework} " \
         "-n #{count} "                     \
         "--pattern '#{pattern}' "          \
         "--test-options '#{options}'"


### PR DESCRIPTION
Our Jenkins jobs have names with spaces and this change makes parallel_tests run with no problems.