### PR TITLE
Add option to use TEST_ENV_NUMBER="1" for first process

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -237,10 +237,10 @@ that if you have a long-running test suite you can't run other individual tests
 at the same time.
 
 If you'd like to isolate your parallel_tests runs completely from your normal
-test environment, you can set
-`PARALLEL_TEST_USE_TEST_ENV_NUMBER_FOR_FIRST_PROCESS=true` in your environment.
-This will make `ENV["TEST_ENV_NUMBER"]` in the first process be `"1"`.
-(Recommendation: set in a project-wide configuration file, e.g. using direnv.)
+test environment, you can set `PARALLEL_TEST_FIRST_IS_1=true` in your
+environment. This will make `ENV["TEST_ENV_NUMBER"]` in the first process be
+`"1"`. (Recommendation: set in a project-wide configuration file, e.g. using
+direnv.)
 
 
 TIPS

--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ gem "parallel_tests", group: :development
 ParallelTests uses 1 database per test-process.
 <table>
   <tr><td>Process number</td><td>1</td><td>2</td><td>3</td></tr>
-  <tr><td>ENV['TEST_ENV_NUMBER']</td><td>''</td><td>'2'</td><td>'3'</td></tr>
+  <tr><td>ENV['TEST_ENV_NUMBER']</td><td>'' (but see below)</td><td>'2'</td><td>'3'</td></tr>
 </table>
 
 ```yaml
@@ -225,6 +225,23 @@ You can run any kind of code in parallel with -e / --exec
 <tr><td>RSpec spec-suite</td><td>18s</td><td>14s</td><td>10s</td></tr>
 <tr><td>Rails-ActionPack</td><td>88s</td><td>53s</td><td>44s</td></tr>
 </table>
+
+`TEST_ENV_NUMBER`
+=================
+
+As documented above, by default `ENV["TEST_ENV_NUMBER"]` is blank for the first
+process. This means that parallel_tests' first process uses the same test
+database, etc., as when you run a single test or spec at the command line. This
+is convenient in one sense — one less environment to set up — but it does mean
+that if you have a long-running test suite you can't run other individual tests
+at the same time.
+
+If you'd like to isolate your parallel_tests runs completely from your normal
+test environment, you can set
+`PARALLEL_TEST_USE_TEST_ENV_NUMBER_FOR_FIRST_PROCESS=true` in your environment.
+This will make `ENV["TEST_ENV_NUMBER"]` in the first process be `"1"`.
+(Recommendation: set in a project-wide configuration file, e.g. using direnv.)
+
 
 TIPS
 ====

--- a/Readme.md
+++ b/Readme.md
@@ -229,18 +229,13 @@ You can run any kind of code in parallel with -e / --exec
 `TEST_ENV_NUMBER`
 =================
 
-As documented above, by default `ENV["TEST_ENV_NUMBER"]` is blank for the first
-process. This means that parallel_tests' first process uses the same test
-database, etc., as when you run a single test or spec at the command line. This
-is convenient in one sense — one less environment to set up — but it does mean
-that if you have a long-running test suite you can't run other individual tests
-at the same time.
+By default the first `ENV["TEST_ENV_NUMBER"]` is `""`. This means
+that parallel_tests reuses your default test setup for the first process.
 
-If you'd like to isolate your parallel_tests runs completely from your normal
-test environment, you can set `PARALLEL_TEST_FIRST_IS_1=true` in your
-environment. This will make `ENV["TEST_ENV_NUMBER"]` in the first process be
-`"1"`. (Recommendation: set in a project-wide configuration file, e.g. using
-direnv.)
+If you'd like to isolate your parallel_tests runs from your normal test runs,
+you can set `PARALLEL_TEST_FIRST_IS_1=true` in your environment or use
+`--first-is-1` when invoking `parallel_test`. This will make
+`ENV["TEST_ENV_NUMBER"]="1"` in the first process.
 
 
 TIPS

--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -24,11 +24,6 @@ module ParallelTests
       ].detect{|c| not c.to_s.strip.empty? }.to_i
     end
 
-    def test_env_number_first_is_1?
-      val = ENV["PARALLEL_TEST_FIRST_IS_1"]
-      val && !val.strip.empty?
-    end
-
     # copied from http://github.com/carlhuda/bundler Bundler::SharedHelpers#find_gemfile
     def bundler_enabled?
       return true if Object.const_defined?(:Bundler)

--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -24,8 +24,8 @@ module ParallelTests
       ].detect{|c| not c.to_s.strip.empty? }.to_i
     end
 
-    def always_use_test_env_number_for_first_process?
-      val = ENV["PARALLEL_TEST_USE_TEST_ENV_NUMBER_FOR_FIRST_PROCESS"]
+    def test_env_number_first_is_1?
+      val = ENV["PARALLEL_TEST_FIRST_IS_1"]
       val && !val.strip.empty?
     end
 

--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -24,6 +24,11 @@ module ParallelTests
       ].detect{|c| not c.to_s.strip.empty? }.to_i
     end
 
+    def always_use_test_env_number_for_first_process?
+      val = ENV["PARALLEL_TEST_USE_TEST_ENV_NUMBER_FOR_FIRST_PROCESS"]
+      val && !val.strip.empty?
+    end
+
     # copied from http://github.com/carlhuda/bundler Bundler::SharedHelpers#find_gemfile
     def bundler_enabled?
       return true if Object.const_defined?(:Bundler)
@@ -41,7 +46,7 @@ module ParallelTests
     end
 
     def first_process?
-      !ENV["TEST_ENV_NUMBER"] || ENV["TEST_ENV_NUMBER"].to_i == 0
+      ENV["TEST_ENV_NUMBER"].to_i <= 1
     end
 
     def wait_for_other_processes_to_finish

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -13,7 +13,7 @@ module ParallelTests
       num_processes = ParallelTests.determine_number_of_processes(options[:count])
       num_processes = num_processes * (options[:multiply] || 1)
 
-      options[:use_test_env_number_for_first_process] ||= ParallelTests.always_use_test_env_number_for_first_process?
+      options[:first_is_1] ||= ParallelTests.test_env_number_first_is_1?
 
       if options[:execute]
         execute_shell_command_in_parallel(options[:execute], num_processes, options)
@@ -192,7 +192,7 @@ module ParallelTests
         opts.on("--runtime-log [PATH]", "Location of previously recorded test runtimes") { |path| options[:runtime_log] = path }
         opts.on("--allowed-missing [INT]", Integer, "Allowed percentage of missing runtimes (default = 50)") { |percent| options[:allowed_missing_percent] = percent }
         opts.on("--unknown-runtime [FLOAT]", Float, "Use given number as unknown runtime (otherwise use average time)") { |time| options[:unknown_runtime] = time }
-        opts.on("--use-test-env-number-for-first-process", "Provide \"1\" as TEST_ENV_NUMBER to the first process instead of blank") { options[:use_test_env_number_for_first_process] = true }
+        opts.on("--first-is-1", "Provide \"1\" as TEST_ENV_NUMBER to the first process instead of blank") { options[:first_is_1] = true }
         opts.on("--verbose", "Print more output") { options[:verbose] = true }
         opts.on("-v", "--version", "Show Version") { puts ParallelTests::VERSION; exit }
         opts.on("-h", "--help", "Show this.") { puts opts; exit }

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -13,7 +13,7 @@ module ParallelTests
       num_processes = ParallelTests.determine_number_of_processes(options[:count])
       num_processes = num_processes * (options[:multiply] || 1)
 
-      options[:first_is_1] ||= ParallelTests.test_env_number_first_is_1?
+      options[:first_is_1] ||= first_is_always_1?
 
       if options[:execute]
         execute_shell_command_in_parallel(options[:execute], num_processes, options)
@@ -288,6 +288,11 @@ module ParallelTests
 
     def use_colors?
       $stdout.tty?
+    end
+
+    def first_is_always_1?
+      val = ENV["PARALLEL_TEST_FIRST_IS_1"]
+      ['1', 'true'].include?(val)
     end
   end
 end

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -13,6 +13,8 @@ module ParallelTests
       num_processes = ParallelTests.determine_number_of_processes(options[:count])
       num_processes = num_processes * (options[:multiply] || 1)
 
+      options[:use_test_env_number_for_first_process] ||= ParallelTests.always_use_test_env_number_for_first_process?
+
       if options[:execute]
         execute_shell_command_in_parallel(options[:execute], num_processes, options)
       else
@@ -190,6 +192,7 @@ module ParallelTests
         opts.on("--runtime-log [PATH]", "Location of previously recorded test runtimes") { |path| options[:runtime_log] = path }
         opts.on("--allowed-missing [INT]", Integer, "Allowed percentage of missing runtimes (default = 50)") { |percent| options[:allowed_missing_percent] = percent }
         opts.on("--unknown-runtime [FLOAT]", Float, "Use given number as unknown runtime (otherwise use average time)") { |time| options[:unknown_runtime] = time }
+        opts.on("--use-test-env-number-for-first-process", "Provide \"1\" as TEST_ENV_NUMBER to the first process instead of blank") { options[:use_test_env_number_for_first_process] = true }
         opts.on("--verbose", "Print more output") { options[:verbose] = true }
         opts.on("-v", "--version", "Show Version") { puts ParallelTests::VERSION; exit }
         opts.on("-h", "--help", "Show this.") { puts opts; exit }

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -109,8 +109,8 @@ module ParallelTests
         end
 
         def test_env_number(process_number, options={})
-          if process_number == 0
-            options[:first_is_1] ? 1 : ''
+          if process_number == 0 && !options[:first_is_1]
+            ''
           else
             process_number + 1
           end

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -71,7 +71,7 @@ module ParallelTests
 
         def execute_command(cmd, process_number, num_processes, options)
           env = (options[:env] || {}).merge(
-            "TEST_ENV_NUMBER" => test_env_number(process_number),
+            "TEST_ENV_NUMBER" => test_env_number(process_number, options),
             "PARALLEL_TEST_GROUPS" => num_processes
           )
           cmd = "nice #{cmd}" if options[:nice]
@@ -108,8 +108,12 @@ module ParallelTests
           }.compact
         end
 
-        def test_env_number(process_number)
-          process_number == 0 ? '' : process_number + 1
+        def test_env_number(process_number, options={})
+          if process_number == 0
+            options[:use_test_env_number_for_first_process] ? 1 : ''
+          else
+            process_number + 1
+          end
         end
 
         def summarize_results(results)

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -110,7 +110,7 @@ module ParallelTests
 
         def test_env_number(process_number, options={})
           if process_number == 0
-            options[:use_test_env_number_for_first_process] ? 1 : ''
+            options[:first_is_1] ? 1 : ''
           else
             process_number + 1
           end

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -50,9 +50,9 @@ describe ParallelTests::CLI do
       expect(call(["test", "--suffix", "_(test|spec).rb$"])).to eq(defaults.merge(:suffix => /_(test|spec).rb$/))
     end
 
-    it "parses --use-test-env-number-for-first-process" do
-      expect(call(["test", "--use-test-env-number-for-first-process"])).
-        to eq(defaults.merge(:use_test_env_number_for_first_process => true))
+    it "parses --first-is-1" do
+      expect(call(["test", "--first-is-1"])).
+        to eq(defaults.merge(:first_is_1 => true))
     end
 
     context "parse only-group" do
@@ -202,7 +202,7 @@ describe ParallelTests::CLI do
         end
 
         it "only includes failures" do
-          expect { 
+          expect {
             subject.send(:report_failure_rerun_commmand,
               [
                 {exit_status: 1, command: 'foo --color', seed: nil, output: 'blah'},
@@ -221,7 +221,7 @@ describe ParallelTests::CLI do
           subject.instance_variable_set(:@runner, ParallelTests::Test::Runner)
           expect(ParallelTests::Test::Runner).to receive(:command_with_seed).with(command, seed).
             and_return("my seeded command result --seed #{seed}")
-          expect { 
+          expect {
             subject.send(:report_failure_rerun_commmand,
               [
                 {exit_status: 1, command: command, seed: 555, output: 'blah'},
@@ -254,7 +254,7 @@ describe ParallelTests::CLI do
     context "specific groups to run" do
       let(:results){ {:stdout => "", :exit_status => 0} }
       let(:common_options) {
-        { files: ["test"], group_by: :filesize, use_test_env_number_for_first_process: nil }
+        { files: ["test"], group_by: :filesize, first_is_1: nil }
       }
       before do
         allow(subject).to receive(:puts)

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -254,7 +254,7 @@ describe ParallelTests::CLI do
     context "specific groups to run" do
       let(:results){ {:stdout => "", :exit_status => 0} }
       let(:common_options) {
-        { files: ["test"], group_by: :filesize, first_is_1: nil }
+        { files: ["test"], group_by: :filesize, first_is_1: false }
       }
       before do
         allow(subject).to receive(:puts)

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -385,7 +385,7 @@ EOF
 
     it "sets process number to 1 for 0 if requested" do
       run_with_file("puts ENV['TEST_ENV_NUMBER']") do |path|
-        result = call("ruby #{path}", 0, 4, { use_test_env_number_for_first_process: true })
+        result = call("ruby #{path}", 0, 4, { first_is_1: true })
         expect(result).to include({
           :stdout => "1\n",
           :exit_status => 0

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -383,6 +383,16 @@ EOF
       end
     end
 
+    it "sets process number to 1 for 0 if requested" do
+      run_with_file("puts ENV['TEST_ENV_NUMBER']") do |path|
+        result = call("ruby #{path}", 0, 4, { use_test_env_number_for_first_process: true })
+        expect(result).to include({
+          :stdout => "1\n",
+          :exit_status => 0
+        })
+      end
+    end
+
     it 'sets PARALLEL_TEST_GROUPS so child processes know that they are being run under parallel_tests' do
       run_with_file("puts ENV['PARALLEL_TEST_GROUPS']") do |path|
         result = call("ruby #{path}", 1, 4, {})

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -385,7 +385,7 @@ EOF
 
     it "sets process number to 1 for 0 if requested" do
       run_with_file("puts ENV['TEST_ENV_NUMBER']") do |path|
-        result = call("ruby #{path}", 0, 4, { first_is_1: true })
+        result = call("ruby #{path}", 0, 4, first_is_1: true)
         expect(result).to include({
           :stdout => "1\n",
           :exit_status => 0

--- a/spec/parallel_tests_spec.rb
+++ b/spec/parallel_tests_spec.rb
@@ -33,28 +33,6 @@ describe ParallelTests do
     end
   end
 
-  describe ".test_env_number_first_is_1?" do
-    let(:result) { ParallelTests.test_env_number_first_is_1? }
-
-    after do
-      ENV.delete "PARALLEL_TEST_FIRST_IS_1"
-    end
-
-    it "is false when the env var is not set" do
-      expect(result).to be_falsey
-    end
-
-    it "is false when the env var is blank" do
-      ENV["PARALLEL_TEST_FIRST_IS_1"] = ""
-      expect(result).to be_falsey
-    end
-
-    it "is true otherwise" do
-      ENV["PARALLEL_TEST_FIRST_IS_1"] = "true"
-      expect(result).to be_truthy
-    end
-  end
-
   describe ".bundler_enabled?" do
     before do
       allow(Object).to receive(:const_defined?).with(:Bundler).and_return false

--- a/spec/parallel_tests_spec.rb
+++ b/spec/parallel_tests_spec.rb
@@ -33,6 +33,28 @@ describe ParallelTests do
     end
   end
 
+  describe ".always_use_test_env_number_for_first_process?" do
+    let(:result) { ParallelTests.always_use_test_env_number_for_first_process? }
+
+    after do
+      ENV.delete "PARALLEL_TEST_USE_TEST_ENV_NUMBER_FOR_FIRST_PROCESS"
+    end
+
+    it "is false when the env var is not set" do
+      expect(result).to be_falsey
+    end
+
+    it "is false when the env var is blank" do
+      ENV["PARALLEL_TEST_USE_TEST_ENV_NUMBER_FOR_FIRST_PROCESS"] = ""
+      expect(result).to be_falsey
+    end
+
+    it "is true otherwise" do
+      ENV["PARALLEL_TEST_USE_TEST_ENV_NUMBER_FOR_FIRST_PROCESS"] = "true"
+      expect(result).to be_truthy
+    end
+  end
+
   describe ".bundler_enabled?" do
     before do
       allow(Object).to receive(:const_defined?).with(:Bundler).and_return false
@@ -131,7 +153,12 @@ describe ParallelTests do
       expect(ParallelTests.first_process?).to eq(true)
     end
 
-    it "is not first if env is set to something" do
+    it "is first if env is set to 1" do
+      ENV["TEST_ENV_NUMBER"] = "1"
+      expect(ParallelTests.first_process?).to eq(true)
+    end
+
+    it "is not first if env is set to something else" do
       ENV["TEST_ENV_NUMBER"] = "2"
       expect(ParallelTests.first_process?).to eq(false)
     end

--- a/spec/parallel_tests_spec.rb
+++ b/spec/parallel_tests_spec.rb
@@ -33,11 +33,11 @@ describe ParallelTests do
     end
   end
 
-  describe ".always_use_test_env_number_for_first_process?" do
-    let(:result) { ParallelTests.always_use_test_env_number_for_first_process? }
+  describe ".test_env_number_first_is_1?" do
+    let(:result) { ParallelTests.test_env_number_first_is_1? }
 
     after do
-      ENV.delete "PARALLEL_TEST_USE_TEST_ENV_NUMBER_FOR_FIRST_PROCESS"
+      ENV.delete "PARALLEL_TEST_FIRST_IS_1"
     end
 
     it "is false when the env var is not set" do
@@ -45,12 +45,12 @@ describe ParallelTests do
     end
 
     it "is false when the env var is blank" do
-      ENV["PARALLEL_TEST_USE_TEST_ENV_NUMBER_FOR_FIRST_PROCESS"] = ""
+      ENV["PARALLEL_TEST_FIRST_IS_1"] = ""
       expect(result).to be_falsey
     end
 
     it "is true otherwise" do
-      ENV["PARALLEL_TEST_USE_TEST_ENV_NUMBER_FOR_FIRST_PROCESS"] = "true"
+      ENV["PARALLEL_TEST_FIRST_IS_1"] = "true"
       expect(result).to be_truthy
     end
   end


### PR DESCRIPTION
See README changes and discussion on grosser/parallel_tests#297 for motivation.

The implementation allows for switching via either an environment variable or a command-line switch for the `parallel_test` executable, similar to `PARALLEL_TEST_PROCESSORS` and `-n`.

The env var is `PARALLEL_TEST_USE_TEST_ENV_NUMBER_FOR_FIRST_PROCESS` and the command line option is `--use-test-env-number-for-first-process`. I'm happy to change these to something less verbose.