### PR TITLE
Allow limiting parallel:rake to X parallel runs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -68,6 +68,10 @@ Test by pattern (e.g. use one integration server per subfolder / see if you brok
 RAILS_ENV=test parallel_test -e "rake my:custom:task"
 # or
 rake parallel:rake[my:custom:task]
+# And with limiting to X CPUs
+RAILS_ENV=test parallel_test -n X -e "rake my:custom:task"
+# or
+rake parallel:rake[my:custom:task,X]
 ```
 
 

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -122,8 +122,8 @@ namespace :parallel do
   end
 
   desc "launch given rake command in parallel"
-  task :rake, :command do |_, args|
-    ParallelTests::Tasks.run_in_parallel("RAILS_ENV=#{ParallelTests::Tasks.rails_env} rake #{args.command}")
+  task :rake, :command, :count do |_, args|
+    ParallelTests::Tasks.run_in_parallel("RAILS_ENV=#{ParallelTests::Tasks.rails_env} rake #{args.command}", args)
   end
 
   ['test', 'spec', 'features', 'features-spinach'].each do |type|


### PR DESCRIPTION
Just a small sync of both interfaces.