### PR TITLE
Rake Db Setup Task

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,6 +36,9 @@ test:
 ### Copy development schema (repeat after migrations)
     rake parallel:prepare
 
+### Setup environment from scratch (create db and loads schema, useful for CI)
+    rake parallel:setup
+
 ### Run!
     rake parallel:test          # Test::Unit
     rake parallel:spec          # RSpec

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -72,6 +72,11 @@ module ParallelTests
 end
 
 namespace :parallel do
+  desc "setup test databases via db:setup --> parallel:setup[num_cpus]"
+  task :setup, :count do |_,args|
+    ParallelTests::Tasks.run_in_parallel("rake db:setup RAILS_ENV=#{ParallelTests::Tasks.rails_env}", args)
+  end
+
   desc "create test databases via db:create --> parallel:create[num_cpus]"
   task :create, :count do |_,args|
     ParallelTests::Tasks.run_in_parallel("rake db:create RAILS_ENV=#{ParallelTests::Tasks.rails_env}", args)

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -24,11 +24,7 @@ describe ParallelTests::Tasks do
     end
 
     it "should return the count, pattern, and options" do
-      args = {
-        :count => 2,
-        :pattern => "plain",
-        :options => "-p default --group-by steps",
-      }
+      args = {:count => 2, :pattern => "plain", :options => "-p default --group-by steps"}
       expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "plain", "-p default --group-by steps"])
     end
   end

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -123,6 +123,17 @@ describe ParallelTests::Tasks do
     end
   end
 
+  describe ".suppress_schema_load_output" do
+    before do
+      allow(ParallelTests::Tasks).to receive(:suppress_output)
+    end
+
+    it 'should call suppress output with command' do
+      ParallelTests::Tasks.suppress_schema_load_output('command')
+      expect(ParallelTests::Tasks).to have_received(:suppress_output).with('command', "^   ->\\|^-- ")
+    end
+  end
+
   describe ".check_for_pending_migrations" do
     after do
       Rake.application.instance_variable_get('@tasks').delete("db:abort_if_pending_migrations")


### PR DESCRIPTION
**Context**: While using parallel tests on CI we need to recreate and load schema for every build
**Problem**: Running parallel:create parallel:load_schema - load environment twice for each process.
**Solution**: Single Rails rake task to create and load schema with single command without reloading environment.