### PR TITLE
Allow runtime logfile to be specified

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -107,7 +107,7 @@ so that each process should finish around the same time.
 Rspec: Add to your `.rspec_parallel` (or `.rspec`) :
 
     --format progress
-    --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log
+    --format ParallelTests::RSpec::RuntimeLogger --out <%= ENV['PARALLEL_RUNTIME_LOGFILE'] || 'tmp/parallel_runtime_rspec.log' %>
 
 ### Test::Unit & Minitest 4/5
 

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -32,7 +32,7 @@ module ParallelTests
         end
 
         def runtime_log
-          'tmp/parallel_runtime_rspec.log'
+          ENV['PARALLEL_RUNTIME_LOGFILE'] || 'tmp/parallel_runtime_rspec.log'
         end
 
         def test_file_name


### PR DESCRIPTION
We run our regular specs with a full set of cores and then our feature
specs can only run on 2 cores because of concurrency issues with
Chromedriver.  Each time we run specs, the previous version of the
runtime logfile gets trampled and we don't see the speed benefits.  This
change allows an optional env var to be set PARALLEL_RUNTIME_LOGFILE
that will keep the runtime separate for each run.

usage:

`PARALLEL_RUNTIME_LOGFILE=tmp/feature_spec_runtime.log bundle exec
parallel_rspec spec/features/*`

and the original without the env var would still work

`bundle exec parallel_rspec spec/features/*` 