### PR TITLE
update readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,10 +11,11 @@ Setup for Rails
 [RailsCasts episode #413 Fast Tests](http://railscasts.com/episodes/413-fast-tests)
 
 ### Install
+Add `parallel_tests` to **both** the `:development` and `:test` groups in the
+`Gemfile`:
 
 ```ruby
-# Gemfile
-gem "parallel_tests", group: :development
+gem 'parallel_tests', group: [:development, :test]
 ```
 
 ### Add to `config/database.yml`


### PR DESCRIPTION
Only gems outside of groups or in the `:test` group show up when using `rake -T`. I copied the approach from [`rspec-rails`](https://github.com/rspec/rspec-rails#installation)'s documentation since that seems like the standard.

There is a pending [StackOverflow question](http://stackoverflow.com/questions/37013545/why-is-rake-t-run-with-rails-env-test) that may shed more light on this issue.

[resolves #500]