### PR TITLE
Progress indicator option

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -133,6 +133,13 @@ describe 'CLI' do
     expect(result).not_to match(/TEST2.*TEST1.*TEST2/m)
   end
 
+  it "can show simulated output when serializing stdout" do
+    write 'spec/xxx_spec.rb', 'describe("it"){it("should"){sleep 1; puts "TEST1"}}'
+    result = run_tests "spec", :type => 'rspec', :add => "--serialize-stdout", export: 'PARALLEL_TEST_HEARTBEAT_INTERVAL=0.2'
+
+    expect(result).to match(/\.{5}.*TEST1/m)
+  end
+
   it "can serialize stdout and stderr" do
     write 'spec/xxx_spec.rb', '5.times{describe("it"){it("should"){sleep 0.01; $stderr.puts "errTEST1"; puts "TEST1"}}}'
     write 'spec/xxx2_spec.rb', 'sleep 0.01; 5.times{describe("it"){it("should"){sleep 0.01; $stderr.puts "errTEST2"; puts "TEST2"}}}'


### PR DESCRIPTION
This adds a `--progress` option that will simply print out a `.` every 60 seconds until the first parallel thread finishes.

The main reason for this change is for CI environments that treat no output as something going wrong. So, when using `--serialize-output`, nothing could be output for a while, so CI thinks the process failed. This prevents this by essentially providing a "heartbeat", until the first parallel task completes and displays its output.