### PR TITLE
Support dropping and afterwards creating the DBs with Rails 5

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -89,7 +89,7 @@ namespace :parallel do
 
   desc "drop test databases via db:drop --> parallel:drop[num_cpus]"
   task :drop, :count do |_,args|
-    ParallelTests::Tasks.run_in_parallel("rake db:drop RAILS_ENV=#{ParallelTests::Tasks.rails_env}", args)
+    ParallelTests::Tasks.run_in_parallel("rake db:drop RAILS_ENV=#{ParallelTests::Tasks.rails_env} DISABLE_DATABASE_ENVIRONMENT_CHECK=1", args)
   end
 
   desc "update test databases by dumping and loading --> parallel:prepare[num_cpus]"

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -30,7 +30,7 @@ describe 'rails' do
           sh "rm -rf db/*.sqlite3"
           sh "bundle exec rake db:setup parallel:create 2>&1"
           # Also test the case where the DBs need to be dropped
-          sh "bundle exec rake paralle:drop parallel:create 2>&1"
+          sh "bundle exec rake parallel:drop parallel:create"
           sh "bundle exec rake parallel:prepare"
           sh "export RAILS_ENV=test && bundle exec rails runner User.create" # pollute the db
           out = sh "bundle exec rake parallel:prepare parallel:test"

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -29,6 +29,8 @@ describe 'rails' do
           sh "bundle install"
           sh "rm -rf db/*.sqlite3"
           sh "bundle exec rake db:setup parallel:create 2>&1"
+          # Also test the case where the DBs need to be dropped
+          sh "bundle exec rake paralle:drop parallel:create 2>&1"
           sh "bundle exec rake parallel:prepare"
           sh "export RAILS_ENV=test && bundle exec rails runner User.create" # pollute the db
           out = sh "bundle exec rake parallel:prepare parallel:test"


### PR DESCRIPTION
In Rails 5 this can fail due to the new security setup surrounding the migrations. See #520 

Similar to #519 I added the environment variable to turn off this behaviour. I also added a test for this, but I'm not sure if it's at the right place and if it should be executed for all version of Rails or not.