### PR TITLE
Add option to skip call to purge_before_load in parallel::load_schema and parallel::load_structure

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -115,15 +115,17 @@ namespace :parallel do
 
   # just load the schema (good for integration server <-> no development db)
   desc "load dumped schema for test databases via db:schema:load --> parallel:load_schema[num_cpus]"
-  task :load_schema, :count do |_,args|
-    command = "rake #{ParallelTests::Tasks.purge_before_load} db:schema:load RAILS_ENV=#{ParallelTests::Tasks.rails_env} DISABLE_DATABASE_ENVIRONMENT_CHECK=1"
+  task :load_schema, [:count, :purge] do |_,args|
+    purge = ['no', 'false'].exclude?(args[:purge])
+    command = "rake #{ParallelTests::Tasks.purge_before_load if purge} db:schema:load RAILS_ENV=#{ParallelTests::Tasks.rails_env} DISABLE_DATABASE_ENVIRONMENT_CHECK=1"
     ParallelTests::Tasks.run_in_parallel(ParallelTests::Tasks.suppress_schema_load_output(command), args)
   end
 
   # load the structure from the structure.sql file
   desc "load structure for test databases via db:structure:load --> parallel:load_structure[num_cpus]"
-  task :load_structure, :count do |_,args|
-    ParallelTests::Tasks.run_in_parallel("rake #{ParallelTests::Tasks.purge_before_load} db:structure:load RAILS_ENV=#{ParallelTests::Tasks.rails_env} DISABLE_DATABASE_ENVIRONMENT_CHECK=1", args)
+  task :load_structure, [:count, :purge] do |_,args|
+    purge = ['no', 'false'].exclude?(args[:purge])
+    ParallelTests::Tasks.run_in_parallel("rake #{ParallelTests::Tasks.purge_before_load if purge} db:structure:load RAILS_ENV=#{ParallelTests::Tasks.rails_env} DISABLE_DATABASE_ENVIRONMENT_CHECK=1", args)
   end
 
   desc "load the seed data from db/seeds.rb via db:seed --> parallel:seed[num_cpus]"


### PR DESCRIPTION
It should be possible to skip the call to purge_before_load in the parallel::load_schema and parallel::load_structure tasks as this resembles the behaviour of db:structure:load and db:schema:load tasks.