### PR TITLE
Fix ignore rspec pending failures.

### DIFF
--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -43,6 +43,10 @@ module ParallelTests
           /_spec\.rb$/
         end
 
+        def line_is_result?(line)
+          line =~ /\d+ examples?, \d+ failures?/
+        end
+
         private
 
         # so it can be stubbed....

--- a/spec/parallel_tests/rspec/runner_spec.rb
+++ b/spec/parallel_tests/rspec/runner_spec.rb
@@ -176,9 +176,13 @@ describe ParallelTests::RSpec::Runner do
         Pending: (Failures listed here are expected and do not affect your suite's status)
 
         1) Foo
-           Got 1 failure:
+           Got 1 failure and 1 other error:
 
            1.1) Failure/Error:
+                  Bar
+                  Baz
+
+           1.2) Failure/Error:
                   Bar
                   Baz
         1 examples, 0 failures, 1 pending


### PR DESCRIPTION
Hi

Current ignore rspec pending failures is tested as ```Got 1 failure:```.
But sometimes rspec print as ```Got x failure and x other error:``` . (https://github.com/rspec/rspec-core/blob/fc767bef47807008899c24a8fd919236567c9023/lib/rspec/core/formatters/exception_presenter.rb#L484-L489) So, if it is printed, failed to detect result line.

I know [this  commit]( https://github.com/grosser/parallel_tests/commit/f16ffc9fd0d4cbd061d500da3070ece729f59edd) refactor ```line_is_result?```. But,  I think ```line =~ /\d+ examples?, \d+ failures?/``` seems to be simply and easy to understand for rspec.

thanks.

