### PR TITLE
Fix RSpec::Runner.command_with_seed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 2.1.5
   - 2.2.2
   - 2.3.1
-  - jruby-1.7.9
   - jruby-head
 branches:
   only: [master]

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -52,6 +52,7 @@ module ParallelTests
           cmd = cmd.sub(/ --order random/, '')
           cmd = cmd.sub(/ --order rand/, '')
           cmd = cmd.sub(/ --seed \d+/, '')
+          cmd = cmd.sub(/ --color --tty/, '')
           "#{cmd} --seed #{seed}"
         end
 

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -47,6 +47,14 @@ module ParallelTests
           line =~ /\d+ examples?, \d+ failures?/
         end
 
+        def command_with_seed(cmd, seed)
+          cmd = cmd.sub(/ --order random:\d+/, '')
+          cmd = cmd.sub(/ --order random/, '')
+          cmd = cmd.sub(/ --order rand/, '')
+          cmd = cmd.sub(/ --seed \d+/, '')
+          "#{cmd} --seed #{seed}"
+        end
+
         private
 
         # so it can be stubbed....

--- a/spec/parallel_tests/rspec/runner_spec.rb
+++ b/spec/parallel_tests/rspec/runner_spec.rb
@@ -205,4 +205,33 @@ describe ParallelTests::RSpec::Runner do
       end
     end
   end
+
+  describe ".command_with_seed" do
+    it "adds the randomized seed" do
+      expect(described_class.command_with_seed("rspec spec/file_spec.rb", 555)).
+        to eq("rspec spec/file_spec.rb --seed 555")
+    end
+
+    describe "existing randomization" do
+      it "does not duplicate seed" do
+        expect(described_class.command_with_seed("rspec spec/file_spec.rb --seed 123", 555)).
+          to eq("rspec spec/file_spec.rb --seed 555")
+      end
+
+      it "removes rand" do
+        expect(described_class.command_with_seed("rspec spec/file_spec.rb --order rand", 555)).
+          to eq("rspec spec/file_spec.rb --seed 555")
+      end
+
+      it "removes random" do
+        expect(described_class.command_with_seed("rspec spec/file_spec.rb --order random", 555)).
+          to eq("rspec spec/file_spec.rb --seed 555")
+      end
+
+      it "removes random with seed" do
+        expect(described_class.command_with_seed("rspec spec/file_spec.rb --order random:123", 555)).
+          to eq("rspec spec/file_spec.rb --seed 555")
+      end
+    end
+  end
 end

--- a/spec/parallel_tests/rspec/runner_spec.rb
+++ b/spec/parallel_tests/rspec/runner_spec.rb
@@ -212,6 +212,11 @@ describe ParallelTests::RSpec::Runner do
         to eq("rspec spec/file_spec.rb --seed 555")
     end
 
+    it "removes rspec2 color flags" do
+      expect(described_class.command_with_seed("rspec --color --tty spec/file_spec.rb", 555)).
+        to eq("rspec spec/file_spec.rb --seed 555")
+    end
+
     describe "existing randomization" do
       it "does not duplicate seed" do
         expect(described_class.command_with_seed("rspec spec/file_spec.rb --seed 123", 555)).


### PR DESCRIPTION
`rspec --order random` would have ` --order rand` removed and output `rspecom`.