### PR TITLE
moving seeding logic into 1 place

### DIFF
--- a/lib/parallel_tests/cucumber/runner.rb
+++ b/lib/parallel_tests/cucumber/runner.rb
@@ -29,8 +29,8 @@ module ParallelTests
         end
 
         def command_with_seed(cmd, seed)
-          cmd = cmd.sub(/\s--order random(:\d*)?/, '')
-          "#{cmd} --order random:#{seed}"
+          clean = cmd.sub(/\s--order\s+random(:\d+)?\b/, '')
+          "#{clean} --order random:#{seed}"
         end
       end
     end

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -47,14 +47,16 @@ module ParallelTests
           line =~ /\d+ examples?, \d+ failures?/
         end
 
+        # remove old seed and add new seed
+        # --seed 1234
+        # --order rand
+        # --order rand:1234
+        # --order random:1234
         def command_with_seed(cmd, seed)
-          cmd = cmd.sub(/ --order random:\d+/, '')
-          cmd = cmd.sub(/ --order random/, '')
-          cmd = cmd.sub(/ --order rand/, '')
-          cmd = cmd.sub(/ --seed \d+/, '')
-          cmd = cmd.sub(/ --color --tty/, '')
-          "#{cmd} --seed #{seed}"
+          clean = cmd.sub(/\s--(seed\s+\d+|order\s+rand(om)?(:\d+)?)\b/, '')
+          "#{clean} --seed #{seed}"
         end
+
 
         private
 

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -121,10 +121,10 @@ module ParallelTests
           sums.sort.map{|word, number|  "#{number} #{word}#{'s' if number != 1}" }.join(', ')
         end
 
+        # remove old seed and add new seed
         def command_with_seed(cmd, seed)
-          cmd = cmd.sub(/\s--seed(\s\d*){0,1}/, '')
-          cmd = cmd.sub(/\s--order rand(:\d*){0,1}/, '')
-          "#{cmd} --seed #{seed}"
+          clean = cmd.sub(/\s--seed\s+\d+\b/, '')
+          "#{clean} --seed #{seed}"
         end
 
         protected

--- a/spec/parallel_tests/cucumber/runner_spec.rb
+++ b/spec/parallel_tests/cucumber/runner_spec.rb
@@ -26,20 +26,20 @@ describe ParallelTests::Cucumber::Runner do
   end
 
   describe ".command_with_seed" do
+    def call(part)
+      ParallelTests::Cucumber::Runner.command_with_seed("cucumber#{part}", 555)
+    end
+
     it "adds the randomized seed" do
-      expect(ParallelTests::Cucumber::Runner.command_with_seed("cucumber", 555)).
-        to eq("cucumber --order random:555")
+      expect(call("")).to eq("cucumber --order random:555")
     end
 
     it "does not duplicate existing random command" do
-      expect(ParallelTests::Cucumber::Runner.command_with_seed("cucumber --order random good1.feature", 555)).
-        to eq("cucumber good1.feature --order random:555")
+      expect(call(" --order random good1.feature")).to eq("cucumber good1.feature --order random:555")
     end
 
     it "does not duplicate existing random command with seed" do
-      expect(ParallelTests::Cucumber::Runner.command_with_seed("cucumber --order random:123 good1.feature", 555)).
-        to eq("cucumber good1.feature --order random:555")
+      expect(call(" --order random:123 good1.feature")).to eq("cucumber good1.feature --order random:555")
     end
   end
-
 end

--- a/spec/parallel_tests/rspec/runner_spec.rb
+++ b/spec/parallel_tests/rspec/runner_spec.rb
@@ -207,36 +207,42 @@ describe ParallelTests::RSpec::Runner do
   end
 
   describe ".command_with_seed" do
+    def call(args)
+      base = "ruby -Ilib:test test/minitest/test_minitest_unit.rb"
+      result = ParallelTests::RSpec::Runner.command_with_seed("#{base}#{args}", 555)
+      result.sub(base, '')
+    end
+
     it "adds the randomized seed" do
-      expect(described_class.command_with_seed("rspec spec/file_spec.rb", 555)).
-        to eq("rspec spec/file_spec.rb --seed 555")
+      expect(call("")).to eq(" --seed 555")
     end
 
-    it "removes rspec2 color flags" do
-      expect(described_class.command_with_seed("rspec --color --tty spec/file_spec.rb", 555)).
-        to eq("rspec spec/file_spec.rb --seed 555")
+    it "does not duplicate seed" do
+      expect(call(" --seed 123")).to eq(" --seed 555")
     end
 
-    describe "existing randomization" do
-      it "does not duplicate seed" do
-        expect(described_class.command_with_seed("rspec spec/file_spec.rb --seed 123", 555)).
-          to eq("rspec spec/file_spec.rb --seed 555")
-      end
+    it "does not match strange seeds stuff" do
+      expect(call(" --seed 123asdasd")).to eq(" --seed 123asdasd --seed 555")
+    end
 
-      it "removes rand" do
-        expect(described_class.command_with_seed("rspec spec/file_spec.rb --order rand", 555)).
-          to eq("rspec spec/file_spec.rb --seed 555")
-      end
+    it "does not match non seeds" do
+      expect(call(" --seedling 123")).to eq(" --seedling 123 --seed 555")
+    end
 
-      it "removes random" do
-        expect(described_class.command_with_seed("rspec spec/file_spec.rb --order random", 555)).
-          to eq("rspec spec/file_spec.rb --seed 555")
-      end
+    it "does not duplicate random" do
+      expect(call(" --order random")).to eq(" --seed 555")
+    end
 
-      it "removes random with seed" do
-        expect(described_class.command_with_seed("rspec spec/file_spec.rb --order random:123", 555)).
-          to eq("rspec spec/file_spec.rb --seed 555")
-      end
+    it "does not duplicate rand" do
+      expect(call(" --order rand")).to eq(" --seed 555")
+    end
+
+    it "does not duplicate rand with seed" do
+      expect(call(" --order rand:123")).to eq(" --seed 555")
+    end
+
+    it "does not duplicate random with seed" do
+      expect(call(" --order random:123")).to eq(" --seed 555")
     end
   end
 end

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -504,26 +504,26 @@ EOF
   end
 
   describe ".command_with_seed" do
-    it "adds the randomized seed" do
-      expect(ParallelTests::Test::Runner.command_with_seed("ruby -Ilib:test test/minitest/test_minitest_unit.rb", 555)).
-        to eq("ruby -Ilib:test test/minitest/test_minitest_unit.rb --seed 555")
+    def call(args)
+      base = "ruby -Ilib:test test/minitest/test_minitest_unit.rb"
+      result = ParallelTests::Test::Runner.command_with_seed("#{base}#{args}", 555)
+      result.sub(base, '')
     end
 
-    describe "existing randomization" do
-      it "does not duplicate seed" do
-        expect(ParallelTests::Test::Runner.command_with_seed("ruby -Ilib:test test/minitest/test_minitest_unit.rb --seed 123", 555)).
-          to eq("ruby -Ilib:test test/minitest/test_minitest_unit.rb --seed 555")
-      end
+    it "adds the randomized seed" do
+      expect(call("")).to eq(" --seed 555")
+    end
 
-      it "does not duplicate rand" do
-        expect(ParallelTests::Test::Runner.command_with_seed("ruby -Ilib:test test/minitest/test_minitest_unit.rb --order rand", 555)).
-          to eq("ruby -Ilib:test test/minitest/test_minitest_unit.rb --seed 555")
-      end
+    it "does not duplicate seed" do
+      expect(call(" --seed 123")).to eq(" --seed 555")
+    end
 
-      it "does not duplicate rand with seed" do
-        expect(ParallelTests::Test::Runner.command_with_seed("ruby -Ilib:test test/minitest/test_minitest_unit.rb --order rand:555", 555)).
-          to eq("ruby -Ilib:test test/minitest/test_minitest_unit.rb --seed 555")
-      end
+    it "does not match strange seeds stuff" do
+      expect(call(" --seed 123asdasd")).to eq(" --seed 123asdasd --seed 555")
+    end
+
+    it "does not match non seeds" do
+      expect(call(" --seedling 123")).to eq(" --seedling 123 --seed 555")
     end
   end
 end


### PR DESCRIPTION
@bquorning 

fixing the weird old regex and making the rspec regexp also have boundaries and do everything in a single match

hope that will be less bugs and nobody needs to add new logic since that covers all frameworks ...

the other thing I did not really think about was why the color/tty option needed to be removed ... 
that is to make the result matching work ?
I'd rather have a `remove_color_flags` or so method for that ... and cleanly remove `\s--color\b` and tty ...

rework for https://github.com/grosser/parallel_tests/pull/536