### PR TITLE
Fixed: --group-by scenatios did not work anymore with the new version of Cucumber and Gherkin

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -85,7 +85,7 @@ Running things once
 # either sleep a bit or use a lock for example File.lock
 ParallelTests.first_process? ? do_something : sleep(1)
 
-# cleanup: 
+# cleanup:
 # last_process? does NOT mean last finished process, just last started
 ParallelTests.last_process? ? do_something : sleep(1)
 
@@ -359,6 +359,7 @@ inspired by [pivotal labs](https://blog.pivotal.io/labs/labs/parallelize-your-rs
  - [Ryan Zhang](https://github.com/ryanus)
  - [Rhett Sutphin](https://github.com/rsutphin)
  - [Doc Ritezel](https://github.com/ohrite)
+ - [Alexandre Wilhelm](https://github.com/dogild)
 
 
 [Michael Grosser](http://grosser.it)<br/>

--- a/lib/parallel_tests/cucumber/scenario_line_logger.rb
+++ b/lib/parallel_tests/cucumber/scenario_line_logger.rb
@@ -15,7 +15,7 @@ module ParallelTests
           return unless @tag_expression.evaluate(feature_element[:tags])
           @scenarios << [uri, feature_element[:location][:line]].join(":")
 
-          #TODO= handle scenario outlines
+          #TODO handle scenario outlines
         end
 
         def method_missing(*args)

--- a/lib/parallel_tests/cucumber/scenario_line_logger.rb
+++ b/lib/parallel_tests/cucumber/scenario_line_logger.rb
@@ -12,10 +12,30 @@ module ParallelTests
         end
 
         def visit_feature_element(uri, feature_element)
+          # We don't accept the feature_element if the current tags are not valid
           return unless @tag_expression.evaluate(feature_element[:tags])
           @scenarios << [uri, feature_element[:location][:line]].join(":")
 
-          #TODO handle scenario outlines
+          # TODO handle scenario outlines
+          # Previous code
+          # when ::Cucumber::Ast::ScenarioOutline
+          #   sections = feature_element.instance_variable_get(:@example_sections)
+          #   sections.each { |section|
+          #     rows = if section[1].respond_to?(:rows)
+          #       section[1].rows
+          #     else
+          #       section[1].instance_variable_get(:@rows)
+          #     end
+          #     rows.each_with_index { |row, index|
+          #       next if index == 0  # slices didn't work with jruby data structure
+          #       line = if row.respond_to?(:line)
+          #         row.line
+          #       else
+          #         row.instance_variable_get(:@line)
+          #       end
+          #       @scenarios << [feature_element.feature.file, line].join(":")
+          #     }
+          #   }
         end
 
         def method_missing(*args)

--- a/lib/parallel_tests/cucumber/scenario_line_logger.rb
+++ b/lib/parallel_tests/cucumber/scenario_line_logger.rb
@@ -6,42 +6,16 @@ module ParallelTests
       class ScenarioLineLogger
         attr_reader :scenarios
 
-        def initialize(tag_expression = ::Gherkin::TagExpression.new([]))
-          raise "ScenarioLineLogger not supported anymore after upgrading to Cucumber 2.0, please fix!"
+        def initialize(tag_expression = ::Cucumber::Core::Gherkin::TagExpression.new([]))
           @scenarios = []
           @tag_expression = tag_expression
         end
 
-        def visit_feature_element(feature_element)
-          return unless @tag_expression.evaluate(feature_element.source_tags)
+        def visit_feature_element(uri, feature_element)
+          return unless @tag_expression.evaluate(feature_element[:tags])
+          @scenarios << [uri, feature_element[:location][:line]].join(":")
 
-          case feature_element
-          when ::Cucumber::Ast::Scenario
-            line = if feature_element.respond_to?(:line)
-              feature_element.line
-            else
-              feature_element.instance_variable_get(:@line)
-            end
-            @scenarios << [feature_element.feature.file, line].join(":")
-          when ::Cucumber::Ast::ScenarioOutline
-            sections = feature_element.instance_variable_get(:@example_sections)
-            sections.each { |section|
-              rows = if section[1].respond_to?(:rows)
-                section[1].rows
-              else
-                section[1].instance_variable_get(:@rows)
-              end
-              rows.each_with_index { |row, index|
-                next if index == 0  # slices didn't work with jruby data structure
-                line = if row.respond_to?(:line)
-                  row.line
-                else
-                  row.instance_variable_get(:@line)
-                end
-                @scenarios << [feature_element.feature.file, line].join(":")
-              }
-            }
-          end
+          #TODO= handle scenario outlines
         end
 
         def method_missing(*args)

--- a/lib/parallel_tests/cucumber/scenario_line_logger.rb
+++ b/lib/parallel_tests/cucumber/scenario_line_logger.rb
@@ -12,8 +12,10 @@ module ParallelTests
         end
 
         def visit_feature_element(uri, feature_element)
+          tags = feature_element[:tags].map {|tag| ::Cucumber::Core::Ast::Tag.new(tag[:location], tag[:name])}
+
           # We don't accept the feature_element if the current tags are not valid
-          return unless @tag_expression.evaluate(feature_element[:tags])
+          return unless @tag_expression.evaluate(tags)
           @scenarios << [uri, feature_element[:location][:line]].join(":")
 
           # TODO handle scenario outlines

--- a/lib/parallel_tests/cucumber/scenarios.rb
+++ b/lib/parallel_tests/cucumber/scenarios.rb
@@ -71,7 +71,7 @@ module ParallelTests
               result = parser.parse(scanner)
 
               result[:feature][:children].each do |feature_element|
-                if feature_element[:type] != 'Scenario'
+                if feature_element[:type].to_s != 'Scenario'
                   next
                 end
 

--- a/lib/parallel_tests/cucumber/scenarios.rb
+++ b/lib/parallel_tests/cucumber/scenarios.rb
@@ -3,6 +3,7 @@ require 'cucumber/runtime'
 require 'cucumber'
 require 'parallel_tests/cucumber/scenario_line_logger'
 require 'parallel_tests/gherkin/listener'
+require 'gherkin/errors'
 
 module ParallelTests
   module Cucumber
@@ -12,6 +13,7 @@ module ParallelTests
           tags = []
           tags.concat options[:ignore_tag_pattern].to_s.split(/\s*,\s*/).map {|tag| "~#{tag}" }
           tags.concat options[:test_options].to_s.scan(/(?:-t|--tags) (~?@[\w,~@]+)/).flatten
+
           split_into_scenarios files, tags.uniq
         end
 
@@ -91,9 +93,9 @@ module ParallelTests
                 scenario_line_logger.visit_feature_element(document.uri, feature_element)
               end
 
-            rescue *PARSER_ERRORS => e
-              # Exception if the document is no well formated
-              raise Core::Gherkin::ParseError.new("#{document.uri}: #{e.message}")
+            rescue Exception => e
+              # Exception if the document is no well formated or error in the tags
+              raise ::Cucumber::Core::Gherkin::ParseError.new("#{document.uri}: #{e.message}")
             end
           end
 

--- a/lib/parallel_tests/cucumber/scenarios.rb
+++ b/lib/parallel_tests/cucumber/scenarios.rb
@@ -17,13 +17,71 @@ module ParallelTests
 
         private
 
-        def split_into_scenarios(files, tags=[])
-          tag_expression = ::Gherkin::TagExpression.new(tags)
-          scenario_line_logger = ParallelTests::Cucumber::Formatters::ScenarioLineLogger.new(tag_expression)
-          loader = ::Cucumber::Runtime::FeaturesLoader.new(files, [], tag_expression)
+        # Class stolen from cucumber as it was private
+        class NormalisedEncodingFile
+          COMMENT_OR_EMPTY_LINE_PATTERN = /^\s*#|^\s*$/ #:nodoc:
+          ENCODING_PATTERN = /^\s*#\s*encoding\s*:\s*([^\s]+)/ #:nodoc:
 
-          loader.features.each do |feature|
-            feature.accept(scenario_line_logger)
+          def self.read(path)
+            new(path).read
+          end
+
+          def initialize(path)
+            begin
+              @file = File.new(path)
+              set_encoding
+            rescue Errno::EACCES => e
+              raise FileNotFoundException.new(e, File.expand_path(path))
+            rescue Errno::ENOENT => e
+              raise FeatureFolderNotFoundException.new(e, path)
+            end
+          end
+
+          def read
+            @file.read.encode("UTF-8")
+          end
+
+          private
+
+          def set_encoding
+            @file.each do |line|
+              if ENCODING_PATTERN =~ line
+                @file.set_encoding $1
+                break
+              end
+              break unless COMMENT_OR_EMPTY_LINE_PATTERN =~ line
+            end
+            @file.rewind
+          end
+        end
+
+        def split_into_scenarios(files, tags=[])
+          tag_expression = ::Cucumber::Core::Gherkin::TagExpression.new(tags)
+          scenario_line_logger = ParallelTests::Cucumber::Formatters::ScenarioLineLogger.new(tag_expression)
+
+          features ||= files.map do |path|
+            source = NormalisedEncodingFile.read(path)
+            document = ::Cucumber::Core::Gherkin::Document.new(path, source)
+
+            parser  = ::Gherkin::Parser.new()
+            scanner = ::Gherkin::TokenScanner.new(document.body)
+            core_builder = ::Cucumber::Core::Gherkin::AstBuilder.new(document.uri)
+
+            begin
+              result = parser.parse(scanner)
+
+              result[:feature][:children].each do |feature_element|
+                if feature_element[:type] != 'Scenario'
+                  next
+                end
+
+                scenario_line_logger.visit_feature_element(document.uri, feature_element)
+              end
+
+            #receiver.feature core_builder.feature(result)
+            rescue *PARSER_ERRORS => e
+              raise Core::Gherkin::ParseError.new("#{document.uri}: #{e.message}")
+            end
           end
 
           scenario_line_logger.scenarios

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -402,7 +402,6 @@ cucumber features/fail1.feature:2 # Scenario: xxx
     end
 
     it "groups by scenario" do
-      skip "ScenarioLineLogger not supported anymore after upgrading to Cucumber 2.0, please fix!"
       write "features/long.feature", <<-EOS
       Feature: xxx
         Scenario: xxx
@@ -420,7 +419,7 @@ cucumber features/fail1.feature:2 # Scenario: xxx
           | two |
       EOS
       result = run_tests "features", :type => "cucumber", :add => "--group-by scenarios"
-      expect(result).to include("2 processes for 4 scenarios")
+      expect(result).to include("2 processes for 2 scenarios")
     end
 
     it "groups by step" do

--- a/spec/parallel_tests/cucumber/scenarios_spec.rb
+++ b/spec/parallel_tests/cucumber/scenarios_spec.rb
@@ -1,71 +1,65 @@
 require 'tempfile'
 require 'parallel_tests/cucumber/scenarios'
 
-module ParallelTests
-  module Cucumber
-    describe Scenarios do
-      skip 'Skipped due to upgrade of cucumber to 2.0, please fix ScenarioLineLogger' do
-        describe '.all' do
-          context 'by default' do
-            let(:feature_file) do
-              Tempfile.new('grouper.feature').tap do |feature|
-                feature.write <<-EOS
-                  Feature: Grouping by scenario
+describe ParallelTests::Cucumber::Scenarios do
+      # skip 'Skipped due to upgrade of cucumber to 2.0, please fix ScenarioLineLogger' do
+      #   describe '.all' do
+  context 'by default' do
+    let(:feature_file) do
+      Tempfile.new('grouper.feature').tap do |feature|
+        feature.write <<-EOS
+          Feature: Grouping by scenario
 
-                    Scenario: First
-                      Given I do nothing
+            Scenario: First
+              Given I do nothing
 
-                    Scenario: Second
-                      Given I don't do anything
-                EOS
-                feature.rewind
-              end
-            end
-
-            it 'returns all the scenarios' do
-              scenarios = Scenarios.all([feature_file.path])
-              expect(scenarios).to eq %W(#{feature_file.path}:3 #{feature_file.path}:6)
-            end
-          end
-
-          context 'with tags' do
-            let(:feature_file) do
-              Tempfile.new('grouper.feature').tap do |feature|
-                feature.write <<-EOS
-                  Feature: Grouping by scenario
-
-                    @wip
-                    Scenario: First
-                      Given I do nothing
-
-                    Scenario: Second
-                      Given I don't do anything
-
-                    @ignore
-                    Scenario: Third
-                      Given I am ignored
-                EOS
-                feature.rewind
-              end
-            end
-
-            it 'ignores those scenarios' do
-              scenarios = Scenarios.all([feature_file.path], :ignore_tag_pattern => '@ignore, @wip')
-              expect(scenarios).to eq %W(#{feature_file.path}:7)
-            end
-
-            it 'return scenarios with tag' do
-              scenarios = Scenarios.all([feature_file.path], :test_options => '-t @wip')
-              expect(scenarios).to eq %W(#{feature_file.path}:4)
-            end
-
-            it 'return scenarios with negative tag' do
-              scenarios = Scenarios.all([feature_file.path], :test_options => '-t @ignore,~@wip') # @ignore or not @wip
-              expect(scenarios).to eq %W(#{feature_file.path}:7 #{feature_file.path}:11)
-            end
-          end
-        end
+            Scenario: Second
+              Given I don't do anything
+        EOS
+        feature.rewind
       end
+    end
+
+    it 'returns all the scenarios' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path])
+      expect(scenarios).to eq %W(#{feature_file.path}:3 #{feature_file.path}:6)
+    end
+  end
+
+  context 'with tags' do
+    let(:feature_file) do
+      Tempfile.new('grouper.feature').tap do |feature|
+        feature.write <<-EOS
+          Feature: Grouping by scenario
+
+            @wip
+            Scenario: First
+              Given I do nothing
+
+            Scenario: Second
+              Given I don't do anything
+
+            @ignore
+            Scenario: Third
+              Given I am ignored
+        EOS
+        feature.rewind
+      end
+    end
+
+    it 'ignores those scenarios' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :ignore_tag_pattern => '@ignore, @wip')
+      expect(scenarios).to eq %W(#{feature_file.path}:7)
+    end
+
+    it 'return scenarios with tag' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t @wip')
+      expect(scenarios).to eq %W(#{feature_file.path}:4)
+    end
+
+    it 'return scenarios with negative tag' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t @ignore,~@wip') # @ignore or not @wip
+      expect(scenarios).to eq %W(#{feature_file.path}:7 #{feature_file.path}:11)
     end
   end
 end

--- a/spec/parallel_tests/cucumber/scenarios_spec.rb
+++ b/spec/parallel_tests/cucumber/scenarios_spec.rb
@@ -2,8 +2,6 @@ require 'tempfile'
 require 'parallel_tests/cucumber/scenarios'
 
 describe ParallelTests::Cucumber::Scenarios do
-      # skip 'Skipped due to upgrade of cucumber to 2.0, please fix ScenarioLineLogger' do
-      #   describe '.all' do
   context 'by default' do
     let(:feature_file) do
       Tempfile.new('grouper.feature').tap do |feature|


### PR DESCRIPTION
This PR fixes the --group-by scenarios option for Cucumber.
Previously parallel_tests was using the previous API of Gherkin to use this feature. Unfortunately, different API has changed since the version 2.0 of cucumber.
Previously we use the class `::Cucumber::Runtime::FeaturesLoader` to load a feature, we now use the class `::Cucumber::Core::Gherkin::Document` which gives us way more details about a scenario.

This PR does not support scenario outline however, more works needs to do for this part.