### PR TITLE
rails 5 adds a prepend module in their minitest plugin which leads to…

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -98,17 +98,13 @@ end
 
 ```
 
-Loggers
-===================
-
 Even test group run-times
--------------------------
+=========================
+
+Test groups are often not balanced and will run for different times, making everything wait for the slowest group.
+Use these loggers to record test runtime and then use the recorded runtime to balance test groups more evenly.
 
 ### RSpec
-
-Add the `RuntimeLogger` to log how long each test takes to run.
-This log file will be loaded on the next test run, and the tests will be grouped
-so that each process should finish around the same time.
 
 Rspec: Add to your `.rspec_parallel` (or `.rspec`) :
 
@@ -124,6 +120,9 @@ require 'parallel_tests/test/runtime_logger' if ENV['RECORD_RUNTIME']
 
 results will be logged to tmp/parallel_runtime_test.log when `RECORD_RUNTIME` is set,
 so it is not always required or overwritten.
+
+Loggers
+=======
 
 RSpec: SummaryLogger
 --------------------

--- a/lib/parallel_tests/test/runtime_logger.rb
+++ b/lib/parallel_tests/test/runtime_logger.rb
@@ -75,21 +75,23 @@ end
 
 if defined?(Minitest::Runnable) # Minitest 5
   class << Minitest::Runnable
-    alias_method :run_without_runtime_log, :run
-    def run(*args)
-      ParallelTests::Test::RuntimeLogger.log_test_run(self) do
-        run_without_runtime_log(*args)
+    prepend(Module.new do
+      def run(*)
+        ParallelTests::Test::RuntimeLogger.log_test_run(self) do
+          super
+        end
       end
-    end
+    end)
   end
 
   class << Minitest
-    alias_method :run_without_runtime_log, :run
-    def run(*args)
-      result = run_without_runtime_log(*args)
-      ParallelTests::Test::RuntimeLogger.unique_log
-      result
-    end
+    prepend(Module.new do
+      def run(*args)
+        result = super
+        ParallelTests::Test::RuntimeLogger.unique_log
+        result
+      end
+    end)
   end
 elsif defined?(MiniTest::Unit) # Minitest 4
   MiniTest::Unit.class_eval do


### PR DESCRIPTION
… infinite loops if we use alias_method

  from /lib/parallel_tests/test/runtime_logger.rb:89:in `run'
  from railties-5.0.1/lib/rails/test_unit/minitest_plugin.rb:73:in `run'
  from lib/parallel_tests/test/runtime_logger.rb:89:in `run'
  from railties-5.0.1/lib/rails/test_unit/minitest_plugin.rb:73:in `run'