### PR TITLE
Fix group by scenarios

### DIFF
--- a/lib/parallel_tests/cucumber/scenario_line_logger.rb
+++ b/lib/parallel_tests/cucumber/scenario_line_logger.rb
@@ -11,33 +11,22 @@ module ParallelTests
           @tag_expression = tag_expression
         end
 
-        def visit_feature_element(uri, feature_element)
-          tags = feature_element[:tags].map {|tag| ::Cucumber::Core::Ast::Tag.new(tag[:location], tag[:name])}
-
-          # We don't accept the feature_element if the current tags are not valid
-          return unless @tag_expression.evaluate(tags)
-          @scenarios << [uri, feature_element[:location][:line]].join(":")
-
-          # TODO handle scenario outlines
-          # Previous code
-          # when ::Cucumber::Ast::ScenarioOutline
-          #   sections = feature_element.instance_variable_get(:@example_sections)
-          #   sections.each { |section|
-          #     rows = if section[1].respond_to?(:rows)
-          #       section[1].rows
-          #     else
-          #       section[1].instance_variable_get(:@rows)
-          #     end
-          #     rows.each_with_index { |row, index|
-          #       next if index == 0  # slices didn't work with jruby data structure
-          #       line = if row.respond_to?(:line)
-          #         row.line
-          #       else
-          #         row.instance_variable_get(:@line)
-          #       end
-          #       @scenarios << [feature_element.feature.file, line].join(":")
-          #     }
-          #   }
+        def visit_feature_element(uri, feature_element, feature_tags)
+          scenario_tags = feature_element[:tags].map {|tag| ::Cucumber::Core::Ast::Tag.new(tag[:location], tag[:name])}
+          scenario_tags = feature_tags + scenario_tags
+          if feature_element[:examples].nil? # :Scenario
+            # We don't accept the feature_element if the current tags are not valid
+            return unless @tag_expression.evaluate(scenario_tags)
+            @scenarios << [uri, feature_element[:location][:line]].join(":")
+          else # :ScenarioOutline
+            feature_element[:examples].each do |example|
+              example_tags = example[:tags].map {|tag| ::Cucumber::Core::Ast::Tag.new(tag[:location], tag[:name])}
+              example_tags = scenario_tags + example_tags
+              next unless @tag_expression.evaluate(example_tags)
+              rows = example[:tableBody].select { |body| body[:type] == :TableRow }
+              rows.each { |row| @scenarios << [uri, row[:location][:line]].join(':') }
+            end
+          end
         end
 
         def method_missing(*args)

--- a/lib/parallel_tests/cucumber/scenarios.rb
+++ b/lib/parallel_tests/cucumber/scenarios.rb
@@ -42,16 +42,15 @@ module ParallelTests
             begin
               # We make an attempt to parse the gherkin document, this could be failed if the document is not well formated
               result = parser.parse(scanner)
+              feature_tags = result[:feature][:tags].map { |tag| ::Cucumber::Core::Ast::Tag.new(tag[:location], tag[:name]) }
 
               # We loop on each children of the feature
               result[:feature][:children].each do |feature_element|
-                # If the type of the child is not a scenario, we continue, we are only interested by the name of the scenario here
-                if feature_element[:type].to_s != 'Scenario'
-                  next
-                end
+                # If the type of the child is not a scenario or scenario outline, we continue, we are only interested by the name of the scenario here
+                next unless /Scenario/.match(feature_element[:type])
 
                 # It's a scenario, we add it to the scenario_line_logger
-                scenario_line_logger.visit_feature_element(document.uri, feature_element)
+                scenario_line_logger.visit_feature_element(document.uri, feature_element, feature_tags)
               end
 
             rescue StandardError => e

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -419,7 +419,7 @@ cucumber features/fail1.feature:2 # Scenario: xxx
           | two |
       EOS
       result = run_tests "features", :type => "cucumber", :add => "--group-by scenarios"
-      expect(result).to include("2 processes for 2 scenarios")
+      expect(result).to include("2 processes for 4 scenarios")
     end
 
     it "groups by step" do

--- a/spec/parallel_tests/cucumber/scenarios_spec.rb
+++ b/spec/parallel_tests/cucumber/scenarios_spec.rb
@@ -28,36 +28,157 @@ describe ParallelTests::Cucumber::Scenarios do
     let(:feature_file) do
       Tempfile.new('grouper.feature').tap do |feature|
         feature.write <<-EOS
+          @colours
           Feature: Grouping by scenario
 
-            @wip
-            Scenario: First
-              Given I do nothing
+            @black
+            Scenario: Black
+              Given I am black
 
-            Scenario: Second
-              Given I don't do anything
+            @white
+            Scenario: White
+              Given I am blue
 
-            @ignore
-            Scenario: Third
-              Given I am ignored
+            @black @white
+            Scenario: Gray
+              Given I am Gray
+
+            @red
+            Scenario Outline: Red
+              Give I am <colour>
+              @blue
+              Examples:
+                | colour  |
+                | magenta |
+                | fuschia |
+
+              @green
+              Examples:
+                | colour |
+                | yellow |
+
+              @blue @green
+              Examples:
+               | colour |
+               | white  |
         EOS
         feature.rewind
       end
     end
 
-    it 'ignores those scenarios' do
-      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :ignore_tag_pattern => '@ignore, @wip')
-      expect(scenarios).to eq %W(#{feature_file.path}:7)
+    it 'Singe Feature Tag: colours' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t @colours')
+      expect(scenarios.length).to eq 7
     end
 
-    it 'return scenarios with tag' do
-      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t @wip')
-      expect(scenarios).to eq %W(#{feature_file.path}:4)
+    it 'Single Scenario Tag: white' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t @white')
+      expect(scenarios.length).to eq 2
     end
 
-    it 'return scenarios with negative tag' do
-      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t @ignore,~@wip') # @ignore or not @wip
-      expect(scenarios).to eq %W(#{feature_file.path}:7 #{feature_file.path}:11)
+    it 'Multiple Scenario Tags 1: black && white' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t @black -t @white')
+      expect(scenarios.length).to eq 1
+    end
+
+    it 'Multiple Scenario Tags 2: black || white scenarios' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t @black,@white')
+      expect(scenarios.length).to eq 3
+    end
+
+    it 'Scenario Outline Tag: red' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t @red')
+      expect(scenarios.length).to eq 4
+    end
+
+    it 'Example Tag: blue' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t @blue')
+      expect(scenarios.length).to eq 3
+    end
+
+    it 'Multiple Example Tags 1: blue && green' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t @blue -t @green')
+      expect(scenarios.length).to eq 1
+    end
+
+    it 'Multiple Example Tags 2: blue || green' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t @blue,@green')
+      expect(scenarios.length).to eq 4
+    end
+
+    it 'Single Negative Feature Tag: !colours' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t ~@colours')
+      expect(scenarios.length).to eq 0
+    end
+
+    it 'Single Negative Scenario Tag: !black' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t ~@black')
+      expect(scenarios.length).to eq 5
+    end
+
+    it 'Multiple Negative Scenario Tags And: !black || !white' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t ~@black -t ~@white')
+      expect(scenarios.length).to eq 4
+    end
+
+    it 'Multiple Negative Scenario Tags Or: !(black && white)' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t ~@black,~@white')
+      expect(scenarios.length).to eq 6
+    end
+
+    it 'Negative Scenario Outline Tag: !red' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t ~@red')
+      expect(scenarios.length).to eq 3
+    end
+
+    it 'Negative Example Tag: !blue' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t ~@blue')
+      expect(scenarios.length).to eq 4
+    end
+
+    it 'Multiple Negative Example Tags 1: !blue || !green' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t ~@blue -t ~@green')
+      expect(scenarios.length).to eq 3
+    end
+
+    it 'Multiple Negative Example Tags 2: !(blue && green) ' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t ~@blue,~@green')
+      expect(scenarios.length).to eq 6
+    end
+
+    it 'Scenario and Example Mixed Tags: black || green' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t @black,@green')
+      expect(scenarios.length).to eq 4
+    end
+
+    it 'Positive and Negative Mixed Tags: red && !blue' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :test_options => '-t @red -t ~@blue')
+      expect(scenarios.length).to eq 1
+    end
+
+    it 'Ignore Tag Pattern Feature: colours' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :ignore_tag_pattern => '@colours')
+      expect(scenarios.length).to eq 0
+    end
+
+    it 'Ignore Tag Pattern Scenario: black' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :ignore_tag_pattern => '@black')
+      expect(scenarios.length).to eq 5
+    end
+
+    it 'Ignore Tag Pattern Scenario Outline: red' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :ignore_tag_pattern => '@red')
+      expect(scenarios.length).to eq 3
+    end
+
+    it 'Ignore Tag Pattern Example: green' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :ignore_tag_pattern => '@green')
+      expect(scenarios.length).to eq 5
+    end
+
+    it 'Ignore Tag Pattern Multiple Tags: black || red' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], :ignore_tag_pattern => '@black, @red')
+      expect(scenarios.length).to eq 1
     end
   end
 end


### PR DESCRIPTION
Fixed --group-by scenario for latest cucumber
- Scenario Outline tagging and example table tagging is accounted for
- Feature tagging is accounted for

Cucumber dry run number of scenarios matches parallel test output now.