### PR TITLE
optional skip migration check for task parallel:prepare

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,8 +35,9 @@ test:
 
 ### Copy development schema (repeat after migrations)
     rake parallel:prepare
+    rake parallel:prepare PARALLEL_SKIP_MIGRATION_CHECK=true # useful for CI
 
-### Setup environment from scratch (create db and loads schema, useful for CI)
+### Setup environment from scratch (create db, load schema, and load seed)
     rake parallel:setup
 
 ### Run!

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -7,6 +7,10 @@ module ParallelTests
         ENV['RAILS_ENV'] || 'test'
       end
 
+      def skip_migration_check
+        ENV['PARALLEL_SKIP_MIGRATION_CHECK'].to_s.strip.size > 0
+      end
+
       def purge_before_load
         "db:test:purge" if Gem::Version.new(Rails.version) > Gem::Version.new('4.2.0')
       end
@@ -94,7 +98,7 @@ namespace :parallel do
 
   desc "update test databases by dumping and loading --> parallel:prepare[num_cpus]"
   task(:prepare, [:count]) do |_,args|
-    ParallelTests::Tasks.check_for_pending_migrations
+    ParallelTests::Tasks.check_for_pending_migrations unless ParallelTests::Tasks.skip_migration_check
     if defined?(ActiveRecord) && ActiveRecord::Base.schema_format == :ruby
       # dump then load in parallel
       Rake::Task['db:schema:dump'].invoke


### PR DESCRIPTION
useful for CI because on CI we have no development environment and prepare database like this:
```bash
bundle exec rake parallel:prepare RAILS_ENV=test PARALLEL_SKIP_MIGRATION_CHECK=true
```
Task `parallel:setup` calls `db:setup` for each process but it load seed (which should not be loaded when running tests) 