### PR TITLE
Remove RSpec 1 compatibility

### DIFF
--- a/lib/parallel_tests/rspec/failures_logger.rb
+++ b/lib/parallel_tests/rspec/failures_logger.rb
@@ -2,20 +2,7 @@ require 'parallel_tests/rspec/logger_base'
 require 'parallel_tests/rspec/runner'
 
 class ParallelTests::RSpec::FailuresLogger < ParallelTests::RSpec::LoggerBase
-  if RSPEC_1
-    # RSpec 1: does not keep track of failures, so we do
-    def example_failed(example, *args)
-      if RSPEC_1
-        @failed_examples ||= []
-        @failed_examples << example
-      else
-        super
-      end
-    end
-
-    def dump_failure(*args)
-    end
-  elsif RSPEC_2
+  if RSPEC_2
     def dump_failures(*args)
     end
   else
@@ -24,9 +11,7 @@ class ParallelTests::RSpec::FailuresLogger < ParallelTests::RSpec::LoggerBase
 
   def dump_summary(*args)
     lock_output do
-      if RSPEC_1
-        dump_commands_to_rerun_failed_examples_rspec_1
-      elsif RSPEC_3
+      if RSPEC_3
         notification = args.first
         unless notification.failed_examples.empty?
           colorizer = ::RSpec::Core::Formatters::ConsoleCodes
@@ -37,16 +22,5 @@ class ParallelTests::RSpec::FailuresLogger < ParallelTests::RSpec::LoggerBase
       end
     end
     @output.flush
-  end
-
-  private
-
-  def dump_commands_to_rerun_failed_examples_rspec_1
-    (@failed_examples||[]).each do |example|
-      file, line = example.location.to_s.split(':')
-      next unless file and line
-      file.gsub!(%r(^.*?/spec/), './spec/')
-      @output.puts "#{ParallelTests::RSpec::Runner.send(:executable)} #{file}:#{line} # #{example.description}"
-    end
   end
 end

--- a/lib/parallel_tests/rspec/failures_logger.rb
+++ b/lib/parallel_tests/rspec/failures_logger.rb
@@ -11,14 +11,14 @@ class ParallelTests::RSpec::FailuresLogger < ParallelTests::RSpec::LoggerBase
 
   def dump_summary(*args)
     lock_output do
-      if RSPEC_3
+      if RSPEC_2
+        dump_commands_to_rerun_failed_examples
+      else
         notification = args.first
         unless notification.failed_examples.empty?
           colorizer = ::RSpec::Core::Formatters::ConsoleCodes
           output.puts notification.colorized_rerun_commands(colorizer)
         end
-      else
-        dump_commands_to_rerun_failed_examples
       end
     end
     @output.flush

--- a/lib/parallel_tests/rspec/logger_base.rb
+++ b/lib/parallel_tests/rspec/logger_base.rb
@@ -3,25 +3,16 @@ module ParallelTests
   end
 end
 
-begin
-  require 'rspec/core/formatters/base_text_formatter'
-  base = RSpec::Core::Formatters::BaseTextFormatter
-rescue LoadError
-  require 'spec/runner/formatter/base_text_formatter'
-  base = Spec::Runner::Formatter::BaseTextFormatter
-end
+require 'rspec/core/formatters/base_text_formatter'
 
-ParallelTests::RSpec::LoggerBaseBase = base
-
-class ParallelTests::RSpec::LoggerBase < ParallelTests::RSpec::LoggerBaseBase
-  RSPEC_1 = !defined?(RSpec::Core::Formatters::BaseTextFormatter) # do not test for Spec, this will trigger deprecation warning in rspec 2
-  RSPEC_2 = !RSPEC_1 && RSpec::Core::Version::STRING.start_with?('2')
-  RSPEC_3 = !RSPEC_1 && RSpec::Core::Version::STRING.start_with?('3')
+class ParallelTests::RSpec::LoggerBase < RSpec::Core::Formatters::BaseTextFormatter
+  RSPEC_2 = RSpec::Core::Version::STRING.start_with?('2')
+  RSPEC_3 = RSpec::Core::Version::STRING.start_with?('3')
 
   def initialize(*args)
     super
 
-    @output ||= args[1] || args[0] # rspec 1 has output as second argument
+    @output ||= args[0]
 
     if String === @output # a path ?
       FileUtils.mkdir_p(File.dirname(@output))

--- a/lib/parallel_tests/rspec/logger_base.rb
+++ b/lib/parallel_tests/rspec/logger_base.rb
@@ -7,7 +7,6 @@ require 'rspec/core/formatters/base_text_formatter'
 
 class ParallelTests::RSpec::LoggerBase < RSpec::Core::Formatters::BaseTextFormatter
   RSPEC_2 = RSpec::Core::Version::STRING.start_with?('2')
-  RSPEC_3 = RSpec::Core::Version::STRING.start_with?('3')
 
   def initialize(*args)
     super

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -17,8 +17,6 @@ module ParallelTests
           cmd = case
           when File.exist?("bin/rspec")
             WINDOWS ? "ruby bin/rspec" : "bin/rspec"
-          when File.file?("script/spec")
-            "script/spec"
           when ParallelTests.bundler_enabled?
             cmd = (run("bundle show rspec-core") =~ %r{Could not find gem.*} ? "spec" : "rspec")
             "bundle exec #{cmd}"

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -9,9 +9,7 @@ module ParallelTests
       class << self
         def run_tests(test_files, process_number, num_processes, options)
           exe = executable # expensive, so we cache
-          version = (exe =~ /\brspec\b/ ? 2 : 1)
-          cmd = [exe, options[:test_options], (rspec_2_color if version == 2), spec_opts, *test_files].compact.join(" ")
-          options = options.merge(:env => rspec_1_color) if version == 1
+          cmd = [exe, options[:test_options], color, spec_opts, *test_files].compact.join(" ")
           execute_command(cmd, process_number, num_processes, options)
         end
 
@@ -65,15 +63,7 @@ module ParallelTests
           `#{cmd}`
         end
 
-        def rspec_1_color
-          if $stdout.tty?
-            {'RSPEC_COLOR' => "1"}
-          else
-            {}
-          end
-        end
-
-        def rspec_2_color
+        def color
           '--color --tty' if $stdout.tty?
         end
 

--- a/lib/parallel_tests/rspec/runtime_logger.rb
+++ b/lib/parallel_tests/rspec/runtime_logger.rb
@@ -5,39 +5,26 @@ class ParallelTests::RSpec::RuntimeLogger < ParallelTests::RSpec::LoggerBase
   def initialize(*args)
     super
     @example_times = Hash.new(0)
-    @group_nesting = 0 unless RSPEC_1
+    @group_nesting = 0
   end
 
   if RSPEC_3
     RSpec::Core::Formatters.register self, :example_group_started, :example_group_finished, :start_dump
   end
 
-  if RSPEC_1
-    def example_started(*args)
-      @time = ParallelTests.now
-      super
-    end
+  def example_group_started(example_group)
+    @time = ParallelTests.now if @group_nesting == 0
+    @group_nesting += 1
+    super
+  end
 
-    def example_passed(example)
-      file = example.location.split(':').first
-      @example_times[file] += ParallelTests.now - @time
-      super
+  def example_group_finished(notification)
+    @group_nesting -= 1
+    if @group_nesting == 0
+      path = (RSPEC_3 ? notification.group.file_path : notification.file_path)
+      @example_times[path] += ParallelTests.now - @time
     end
-  else
-    def example_group_started(example_group)
-      @time = ParallelTests.now if @group_nesting == 0
-      @group_nesting += 1
-      super
-    end
-
-    def example_group_finished(notification)
-      @group_nesting -= 1
-      if @group_nesting == 0
-        path = (RSPEC_3 ? notification.group.file_path : notification.file_path)
-        @example_times[path] += ParallelTests.now - @time
-      end
-      super if defined?(super)
-    end
+    super if defined?(super)
   end
 
   def dump_summary(*args);end

--- a/lib/parallel_tests/rspec/runtime_logger.rb
+++ b/lib/parallel_tests/rspec/runtime_logger.rb
@@ -8,7 +8,7 @@ class ParallelTests::RSpec::RuntimeLogger < ParallelTests::RSpec::LoggerBase
     @group_nesting = 0
   end
 
-  if RSPEC_3
+  unless RSPEC_2
     RSpec::Core::Formatters.register self, :example_group_started, :example_group_finished, :start_dump
   end
 
@@ -21,7 +21,7 @@ class ParallelTests::RSpec::RuntimeLogger < ParallelTests::RSpec::LoggerBase
   def example_group_finished(notification)
     @group_nesting -= 1
     if @group_nesting == 0
-      path = (RSPEC_3 ? notification.group.file_path : notification.file_path)
+      path = (RSPEC_2 ? notification.file_path : notification.group.file_path)
       @example_times[path] += ParallelTests.now - @time
     end
     super if defined?(super)

--- a/lib/parallel_tests/rspec/summary_logger.rb
+++ b/lib/parallel_tests/rspec/summary_logger.rb
@@ -1,7 +1,7 @@
 require 'parallel_tests/rspec/failures_logger'
 
 class ParallelTests::RSpec::SummaryLogger < ParallelTests::RSpec::LoggerBase
-  if RSPEC_3
+  unless RSPEC_2
     RSpec::Core::Formatters.register self, :dump_failures
   end
 

--- a/lib/parallel_tests/rspec/summary_logger.rb
+++ b/lib/parallel_tests/rspec/summary_logger.rb
@@ -5,15 +5,8 @@ class ParallelTests::RSpec::SummaryLogger < ParallelTests::RSpec::LoggerBase
     RSpec::Core::Formatters.register self, :dump_failures
   end
 
-  if RSPEC_1
-    def dump_failure(*args)
-      lock_output { super }
-      @output.flush
-    end
-  else
-    def dump_failures(*args)
-      lock_output { super }
-      @output.flush
-    end
+  def dump_failures(*args)
+    lock_output { super }
+    @output.flush
   end
 end

--- a/spec/parallel_tests/rspec/runner_spec.rb
+++ b/spec/parallel_tests/rspec/runner_spec.rb
@@ -37,34 +37,6 @@ describe ParallelTests::RSpec::Runner do
       call('xxx', 1, 22, {})
     end
 
-    it "runs with color for rspec 1 when called for the cmdline" do
-      expect(File).to receive(:file?).with('script/spec').and_return true
-      expect(ParallelTests::Test::Runner).to receive(:execute_command) do |a, b, c, d|
-        expect(d[:env]).to eq("RSPEC_COLOR" => "1")
-      end
-
-      expect($stdout).to receive(:tty?).and_return true
-      call('xxx', 1, 22, {})
-    end
-
-    it "runs without color for rspec 1 when not called for the cmdline" do
-      expect(File).to receive(:file?).with('script/spec').and_return true
-      expect(ParallelTests::Test::Runner).to receive(:execute_command) do |a, b, c, d|
-        expect(d[:env]).to eq({})
-      end
-
-      expect($stdout).to receive(:tty?).and_return false
-      call('xxx', 1, 22, {})
-    end
-
-    it "run bundle exec spec when on bundler rspec 1" do
-      allow(File).to receive(:file?).with('script/spec').and_return false
-      allow(ParallelTests).to receive(:bundler_enabled?).and_return true
-      allow(ParallelTests::RSpec::Runner).to receive(:run).with("bundle show rspec-core").and_return "Could not find gem 'rspec-core' in bundler."
-      should_run_with %r{bundle exec spec}
-      call('xxx', 1, 22, {})
-    end
-
     it "run bundle exec rspec when on bundler rspec 2" do
       allow(File).to receive(:file?).with('script/spec').and_return false
       allow(ParallelTests).to receive(:bundler_enabled?).and_return true
@@ -115,16 +87,6 @@ describe ParallelTests::RSpec::Runner do
       allow(File).to receive(:file?).with('script/spec').and_return true
       expect(File).to receive(:file?).with('.rspec_parallel').and_return true
       should_run_with %r{script/spec\s+-O .rspec_parallel}
-      call('xxx', 1, 22, {})
-    end
-
-    it "uses -O spec/parallel_spec.opts with rspec1" do
-      expect(File).to receive(:file?).with('spec/parallel_spec.opts').and_return true
-
-      allow(ParallelTests).to receive(:bundler_enabled?).and_return true
-      allow(ParallelTests::RSpec::Runner).to receive(:run).with("bundle show rspec-core").and_return "Could not find gem 'rspec-core'."
-
-      should_run_with %r{spec\s+-O spec/parallel_spec.opts}
       call('xxx', 1, 22, {})
     end
 

--- a/spec/parallel_tests/rspec/runner_spec.rb
+++ b/spec/parallel_tests/rspec/runner_spec.rb
@@ -6,7 +6,6 @@ describe ParallelTests::RSpec::Runner do
 
   describe '.run_tests' do
     before do
-      allow(File).to receive(:file?).with('script/spec').and_return false
       allow(File).to receive(:file?).with('spec/spec.opts').and_return false
       allow(File).to receive(:file?).with('spec/parallel_spec.opts').and_return false
       allow(File).to receive(:file?).with('.rspec_parallel').and_return false
@@ -37,26 +36,6 @@ describe ParallelTests::RSpec::Runner do
       call('xxx', 1, 22, {})
     end
 
-    it "run bundle exec rspec when on bundler rspec 2" do
-      allow(File).to receive(:file?).with('script/spec').and_return false
-      allow(ParallelTests).to receive(:bundler_enabled?).and_return true
-      allow(ParallelTests::RSpec::Runner).to receive(:run).with("bundle show rspec-core").and_return "/foo/bar/rspec-core-2.0.2"
-      should_run_with %r{bundle exec rspec}
-      call('xxx', 1, 22, {})
-    end
-
-    it "runs script/spec when script/spec can be found" do
-      expect(File).to receive(:file?).with('script/spec').and_return true
-      should_run_with %r{script/spec}
-      call('xxx' ,1, 22, {})
-    end
-
-    it "runs spec when script/spec cannot be found" do
-      allow(File).to receive(:file?).with('script/spec').and_return false
-      should_not_run_with %r{ script/spec}
-      call('xxx', 1, 22, {})
-    end
-
     it "uses bin/rspec when present" do
       allow(File).to receive(:exist?).with('bin/rspec').and_return true
       should_run_with %r{bin/rspec}
@@ -66,27 +45,6 @@ describe ParallelTests::RSpec::Runner do
     it "uses no -O when no opts where found" do
       allow(File).to receive(:file?).with('spec/spec.opts').and_return false
       should_not_run_with %r{spec/spec.opts}
-      call('xxx', 1, 22, {})
-    end
-
-    it "uses -O spec/spec.opts when found (with script/spec)" do
-      allow(File).to receive(:file?).with('script/spec').and_return true
-      allow(File).to receive(:file?).with('spec/spec.opts').and_return true
-      should_run_with %r{script/spec\s+-O spec/spec.opts}
-      call('xxx', 1, 22, {})
-    end
-
-    it "uses -O spec/parallel_spec.opts when found (with script/spec)" do
-      allow(File).to receive(:file?).with('script/spec').and_return true
-      expect(File).to receive(:file?).with('spec/parallel_spec.opts').and_return true
-      should_run_with %r{script/spec\s+-O spec/parallel_spec.opts}
-      call('xxx', 1, 22, {})
-    end
-
-    it "uses -O .rspec_parallel when found (with script/spec)" do
-      allow(File).to receive(:file?).with('script/spec').and_return true
-      expect(File).to receive(:file?).with('.rspec_parallel').and_return true
-      should_run_with %r{script/spec\s+-O .rspec_parallel}
       call('xxx', 1, 22, {})
     end
 

--- a/spec/parallel_tests/rspec/runtime_logger_spec.rb
+++ b/spec/parallel_tests/rspec/runtime_logger_spec.rb
@@ -18,7 +18,7 @@ describe ParallelTests::RSpec::RuntimeLogger do
       end
 
       example = double(:file_path => "#{Dir.pwd}/spec/foo.rb")
-      if ParallelTests::RSpec::RuntimeLogger::RSPEC_3
+      unless ParallelTests::RSpec::RuntimeLogger::RSPEC_2
         example = double(:group => example)
       end
 


### PR DESCRIPTION
I’m not sure how many people still use RSpec 1, but I’m pretty sure the number is low enough to warrant this code cleanup. The idea was discussed already 5 years ago, in #98.

@grosser, I’m running into an issue with the runner that used to check the `version` based on the name of the executable; if the executable doesn’t contain the word `rspec`, we think (thought) it was RSpec v1. When running the runner_spec.rb there are some tests that set
```
allow(File).to receive(:file?).with('script/spec').and_return true
```
even one that claims to test RSpec 2 behavior: https://github.com/grosser/parallel_tests/blob/b6a2ecec90a7c370d49ee6a10f3b3d747604d61d/spec/parallel_tests/rspec/runner_spec.rb#L68-L69