### PR TITLE
Support app namespace when running db:test:purge task

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -8,7 +8,9 @@ module ParallelTests
       end
 
       def purge_before_load
-        "db:test:purge" if Gem::Version.new(Rails.version) > Gem::Version.new('4.2.0')
+        if Gem::Version.new(Rails.version) > Gem::Version.new('4.2.0')
+          Rake::Task.task_defined?('db:test:purge') ? 'db:test:purge' : 'app:db:test:purge'
+        end
       end
 
       def run_in_parallel(cmd, options={})

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -172,4 +172,34 @@ describe ParallelTests::Tasks do
       expect(foo).to eq(2)
     end
   end
+
+  describe '.purge_before_load' do
+    context 'Rails < 4.2.0' do
+      before do
+        stub_const('Rails', double(version: '3.2.1'))
+      end
+
+      it "should return nil for Rails < 4.2.0" do
+        expect(ParallelTests::Tasks.purge_before_load).to eq nil
+      end
+    end
+
+    context 'Rails > 4.2.0' do
+      before do
+        stub_const('Rails', double(version: '4.2.8'))
+      end
+
+      it "should return db:test:purge when defined" do
+        allow(Rake::Task).to receive(:task_defined?).with('db:test:purge') { true }
+
+        expect(ParallelTests::Tasks.purge_before_load).to eq 'db:test:purge'
+      end
+
+      it "should return app:db:test:purge when db:test:purge is not defined" do
+        allow(Rake::Task).to receive(:task_defined?).with('db:test:purge') { false }
+
+        expect(ParallelTests::Tasks.purge_before_load).to eq 'app:db:test:purge'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Similar to the other `db` tasks, we need to account for the task existing under the `app` namespace (for engines).  This first checks if `db:test:purge` exists, and if it doesn't, falls back to `app:db:test:purge`.  Also added test coverage for `purge_before_load`.