### PR TITLE
Runtime stat with test names containing colons symbol

### DIFF
--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -192,7 +192,7 @@ module ParallelTests
           log = options[:runtime_log] || runtime_log
           lines = File.read(log).split("\n")
           lines.each_with_object({}) do |line, times|
-            test, time = line.split(":", 2)
+            test, _, time = line.rpartition(':')
             next unless test and time
             times[test] = time.to_f if tests.include?(test)
           end

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -100,6 +100,16 @@ describe ParallelTests::Test::Runner do
         call(["aaa", "bbb", "ccc"], 3, group_by: :runtime)
       end
 
+      it "groups when test name contains colons" do
+        File.write("tmp/parallel_runtime_test.log", "ccc[1:2:3]:1\nbbb[1:2:3]:2\naaa[1:2:3]:3")
+        expect(call(["aaa[1:2:3]", "bbb[1:2:3]", "ccc[1:2:3]"], 2, group_by: :runtime)).to match_array([["aaa[1:2:3]"], ["bbb[1:2:3]", "ccc[1:2:3]"]])
+      end
+
+      it "groups when not even statistic" do
+        File.write("tmp/parallel_runtime_test.log", "aaa:1\nbbb:1\nccc:8")
+        expect(call(["aaa", "bbb", "ccc"], 2, group_by: :runtime)).to match_array([["aaa", "bbb"], ["ccc"]])
+      end
+
       it "groups with average for missing" do
         File.write("tmp/parallel_runtime_test.log", "xxx:123\nbbb:10\nccc:1")
         expect(call(["aaa", "bbb", "ccc", "ddd"], 2, group_by: :runtime)).to eq([["bbb", "ccc"], ["aaa", "ddd"]])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'bundler/setup'
 require 'tempfile'
 require 'tmpdir'
+require 'timeout'
 
 require 'parallel_tests'
 require 'parallel_tests/test/runtime_logger'


### PR DESCRIPTION
In case of example containing `:` like `some_spec.rb[1:2:3]` or 'some:spec.rb' runtimes file will contain records like
```
some_spec.rb[1:2:3]:123
some:spec.rb:321
```
and parsed file will have wrong name/runtime statistic. 

