### PR TITLE
Capitalize the description lines of rake tasks

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -79,23 +79,23 @@ module ParallelTests
 end
 
 namespace :parallel do
-  desc "setup test databases via db:setup --> parallel:setup[num_cpus]"
+  desc "Setup test databases via db:setup --> parallel:setup[num_cpus]"
   task :setup, :count do |_,args|
     command = "rake db:setup RAILS_ENV=#{ParallelTests::Tasks.rails_env}"
     ParallelTests::Tasks.run_in_parallel(ParallelTests::Tasks.suppress_schema_load_output(command), args)
   end
 
-  desc "create test databases via db:create --> parallel:create[num_cpus]"
+  desc "Create test databases via db:create --> parallel:create[num_cpus]"
   task :create, :count do |_,args|
     ParallelTests::Tasks.run_in_parallel("rake db:create RAILS_ENV=#{ParallelTests::Tasks.rails_env}", args)
   end
 
-  desc "drop test databases via db:drop --> parallel:drop[num_cpus]"
+  desc "Drop test databases via db:drop --> parallel:drop[num_cpus]"
   task :drop, :count do |_,args|
     ParallelTests::Tasks.run_in_parallel("rake db:drop RAILS_ENV=#{ParallelTests::Tasks.rails_env} DISABLE_DATABASE_ENVIRONMENT_CHECK=1", args)
   end
 
-  desc "update test databases by dumping and loading --> parallel:prepare[num_cpus]"
+  desc "Update test databases by dumping and loading --> parallel:prepare[num_cpus]"
   task(:prepare, [:count]) do |_,args|
     ParallelTests::Tasks.check_for_pending_migrations
     if defined?(ActiveRecord) && ActiveRecord::Base.schema_format == :ruby
@@ -111,36 +111,36 @@ namespace :parallel do
   end
 
   # when dumping/resetting takes too long
-  desc "update test databases via db:migrate --> parallel:migrate[num_cpus]"
+  desc "Update test databases via db:migrate --> parallel:migrate[num_cpus]"
   task :migrate, :count do |_,args|
     ParallelTests::Tasks.run_in_parallel("rake db:migrate RAILS_ENV=#{ParallelTests::Tasks.rails_env}", args)
   end
 
   # just load the schema (good for integration server <-> no development db)
-  desc "load dumped schema for test databases via db:schema:load --> parallel:load_schema[num_cpus]"
+  desc "Load dumped schema for test databases via db:schema:load --> parallel:load_schema[num_cpus]"
   task :load_schema, :count do |_,args|
     command = "rake #{ParallelTests::Tasks.purge_before_load} db:schema:load RAILS_ENV=#{ParallelTests::Tasks.rails_env} DISABLE_DATABASE_ENVIRONMENT_CHECK=1"
     ParallelTests::Tasks.run_in_parallel(ParallelTests::Tasks.suppress_schema_load_output(command), args)
   end
 
   # load the structure from the structure.sql file
-  desc "load structure for test databases via db:structure:load --> parallel:load_structure[num_cpus]"
+  desc "Load structure for test databases via db:structure:load --> parallel:load_structure[num_cpus]"
   task :load_structure, :count do |_,args|
     ParallelTests::Tasks.run_in_parallel("rake #{ParallelTests::Tasks.purge_before_load} db:structure:load RAILS_ENV=#{ParallelTests::Tasks.rails_env} DISABLE_DATABASE_ENVIRONMENT_CHECK=1", args)
   end
 
-  desc "load the seed data from db/seeds.rb via db:seed --> parallel:seed[num_cpus]"
+  desc "Load the seed data from db/seeds.rb via db:seed --> parallel:seed[num_cpus]"
   task :seed, :count do |_,args|
     ParallelTests::Tasks.run_in_parallel("rake db:seed RAILS_ENV=#{ParallelTests::Tasks.rails_env}", args)
   end
 
-  desc "launch given rake command in parallel"
+  desc "Launch given rake command in parallel"
   task :rake, :command, :count do |_, args|
     ParallelTests::Tasks.run_in_parallel("RAILS_ENV=#{ParallelTests::Tasks.rails_env} rake #{args.command}", args)
   end
 
   ['test', 'spec', 'features', 'features-spinach'].each do |type|
-    desc "run #{type} in parallel with parallel:#{type}[num_cpus]"
+    desc "Run #{type} in parallel with parallel:#{type}[num_cpus]"
     task type, [:count, :pattern, :options] do |t, args|
       ParallelTests::Tasks.check_for_pending_migrations
 


### PR DESCRIPTION
Here is the result of running the `rake -T` command in Rails application.

```console
% bin/rake -T

(snip)

rake initializers                                      # Print out all defined initializers in the order they are invoked by Rails
rake log:clear                                         # Truncates all/specified *.log files in log/ to zero bytes (specify which logs wit...
rake middleware                                        # Prints out your Rack middleware stack
rake notes                                             # Enumerate all annotations (use notes:optimize, :fixme, :todo for focus)
rake notes:custom                                      # Enumerate a custom annotation, specify with ANNOTATION=CUSTOM
rake parallel:create[count]                            # create test databases via db:create --> parallel:create[num_cpus]
rake parallel:drop[count]                              # drop test databases via db:drop --> parallel:drop[num_cpus]
rake parallel:features[count,pattern,options]          # run features in parallel with parallel:features[num_cpus]
rake parallel:features-spinach[count,pattern,options]  # run features-spinach in parallel with parallel:features-spinach[num_cpus]
rake parallel:load_schema[count]                       # load dumped schema for test databases via db:schema:load --> parallel:load_schema...
rake parallel:load_structure[count]                    # load structure for test databases via db:structure:load --> parallel:load_structu...
rake parallel:migrate[count]                           # update test databases via db:migrate --> parallel:migrate[num_cpus]
rake parallel:prepare[count]                           # update test databases by dumping and loading --> parallel:prepare[num_cpus]
rake parallel:rake[command,count]                      # launch given rake command in parallel
rake parallel:seed[count]                              # load the seed data from db/seeds.rb via db:seed --> parallel:seed[num_cpus]
rake parallel:setup[count]                             # setup test databases via db:setup --> parallel:setup[num_cpus]
rake parallel:spec[count,pattern,options]              # run spec in parallel with parallel:spec[num_cpus]
rake parallel:test[count,pattern,options]              # run test in parallel with parallel:test[num_cpus]
rake restart                                           # Restart app by touching tmp/restart.txt
rake routes                                            # Print out all defined routes in match order, with names

(snip)
```

Rails rake task description starts with an uppercase. On the other hand, the rake task description of parallel_tests starts with lowercase.

This PR will capitalize the beginning of the explanation according to Rails.

```console
% bin/rake -T

(snip)

rake initializers                                      # Print out all defined initializers in the order they are invoked by Rails
rake log:clear                                         # Truncates all/specified *.log files in log/ to zero bytes (specify which logs wit...
rake middleware                                        # Prints out your Rack middleware stack
rake notes                                             # Enumerate all annotations (use notes:optimize, :fixme, :todo for focus)
rake notes:custom                                      # Enumerate a custom annotation, specify with ANNOTATION=CUSTOM
rake parallel:create[count]                            # Create test databases via db:create --> parallel:create[num_cpus]
rake parallel:drop[count]                              # Drop test databases via db:drop --> parallel:drop[num_cpus]
rake parallel:features[count,pattern,options]          # Run features in parallel with parallel:features[num_cpus]
rake parallel:features-spinach[count,pattern,options]  # Run features-spinach in parallel with parallel:features-spinach[num_cpus]
rake parallel:load_schema[count]                       # Load dumped schema for test databases via db:schema:load --> parallel:load_schema...
rake parallel:load_structure[count]                    # Load structure for test databases via db:structure:load --> parallel:load_structu...
rake parallel:migrate[count]                           # Update test databases via db:migrate --> parallel:migrate[num_cpus]
rake parallel:prepare[count]                           # Update test databases by dumping and loading --> parallel:prepare[num_cpus]
rake parallel:rake[command,count]                      # Launch given rake command in parallel
rake parallel:seed[count]                              # Load the seed data from db/seeds.rb via db:seed --> parallel:seed[num_cpus]
rake parallel:setup[count]                             # Setup test databases via db:setup --> parallel:setup[num_cpus]
rake parallel:spec[count,pattern,options]              # Run spec in parallel with parallel:spec[num_cpus]
rake parallel:test[count,pattern,options]              # Run test in parallel with parallel:test[num_cpus]
rake restart                                           # Restart app by touching tmp/restart.txt
rake routes                                            # Print out all defined routes in match order, with names

(snip)
```

parallel_tests does not depend on Rails, but I think that it is a good unification in case to use it with Rails application.