### PR TITLE
Handle line number in file paths

### DIFF
--- a/lib/parallel_tests/cucumber/scenario_line_logger.rb
+++ b/lib/parallel_tests/cucumber/scenario_line_logger.rb
@@ -20,7 +20,7 @@ module ParallelTests
             # We don't accept the feature_element if the current tags are not valid
             return unless @tag_expression.evaluate(scenario_tags)
             # or if it is not at the correct location
-            return unless line_numbers.empty? || line_numbers.include?(test_line)
+            return if line_numbers.any? && !line_numbers.include?(test_line)
 
             @scenarios << [uri, feature_element[:location][:line]].join(":")
           else # :ScenarioOutline
@@ -33,7 +33,7 @@ module ParallelTests
                 test_line = row[:location][:line]
                 next unless line_numbers.empty? || line_numbers.include?(test_line)
 
-                @scenarios << [uri, row[:location][:line]].join(':')
+                @scenarios << [uri, test_line].join(':')
               end
             end
           end

--- a/lib/parallel_tests/cucumber/scenario_line_logger.rb
+++ b/lib/parallel_tests/cucumber/scenario_line_logger.rb
@@ -31,7 +31,7 @@ module ParallelTests
               rows = example[:tableBody].select { |body| body[:type] == :TableRow }
               rows.each do |row|
                 test_line = row[:location][:line]
-                next unless line_numbers.empty? || line_numbers.include?(test_line)
+                next if line_numbers.any? && !line_numbers.include?(test_line)
 
                 @scenarios << [uri, test_line].join(':')
               end

--- a/lib/parallel_tests/cucumber/scenario_line_logger.rb
+++ b/lib/parallel_tests/cucumber/scenario_line_logger.rb
@@ -11,12 +11,17 @@ module ParallelTests
           @tag_expression = tag_expression
         end
 
-        def visit_feature_element(uri, feature_element, feature_tags)
+        def visit_feature_element(uri, feature_element, feature_tags, line_numbers: [])
           scenario_tags = feature_element[:tags].map {|tag| ::Cucumber::Core::Ast::Tag.new(tag[:location], tag[:name])}
           scenario_tags = feature_tags + scenario_tags
           if feature_element[:examples].nil? # :Scenario
+            test_line = feature_element[:location][:line]
+
             # We don't accept the feature_element if the current tags are not valid
             return unless @tag_expression.evaluate(scenario_tags)
+            # or if it is not at the correct location
+            return unless line_numbers.empty? || line_numbers.include?(test_line)
+
             @scenarios << [uri, feature_element[:location][:line]].join(":")
           else # :ScenarioOutline
             feature_element[:examples].each do |example|
@@ -24,7 +29,12 @@ module ParallelTests
               example_tags = scenario_tags + example_tags
               next unless @tag_expression.evaluate(example_tags)
               rows = example[:tableBody].select { |body| body[:type] == :TableRow }
-              rows.each { |row| @scenarios << [uri, row[:location][:line]].join(':') }
+              rows.each do |row|
+                test_line = row[:location][:line]
+                next unless line_numbers.empty? || line_numbers.include?(test_line)
+
+                @scenarios << [uri, row[:location][:line]].join(':')
+              end
             end
           end
         end

--- a/lib/parallel_tests/cucumber/scenarios.rb
+++ b/lib/parallel_tests/cucumber/scenarios.rb
@@ -29,14 +29,9 @@ module ParallelTests
 
           # here we loop on the files map, each file will contain one or more scenario
           features ||= files.map do |path|
-            # Copying the string because it is frozen
-            path = path.dup
-            test_lines = []
-
             # Gather up any line numbers attached to the file path
-            until path.slice(/:\d+$/).nil?
-              test_lines << path.slice!(/:\d+$/).delete(':').to_i
-            end
+            path, *test_lines = path.split(/:(?=\d+)/)
+            test_lines.map!(&:to_i)
 
             # We encode the file and get the content of it
             source = ::Cucumber::Runtime::NormalisedEncodingFile.read(path)
@@ -48,7 +43,7 @@ module ParallelTests
             scanner = ::Gherkin::TokenScanner.new(document.body)
 
             begin
-              # We make an attempt to parse the gherkin document, this could be failed if the document is not well formated
+              # We make an attempt to parse the gherkin document, this could be failed if the document is not well formatted
               result = parser.parse(scanner)
               feature_tags = result[:feature][:tags].map { |tag| ::Cucumber::Core::Ast::Tag.new(tag[:location], tag[:name]) }
 

--- a/spec/parallel_tests/cucumber/scenarios_spec.rb
+++ b/spec/parallel_tests/cucumber/scenarios_spec.rb
@@ -2,10 +2,10 @@ require 'tempfile'
 require 'parallel_tests/cucumber/scenarios'
 
 describe ParallelTests::Cucumber::Scenarios do
-  context 'by default' do
-    let(:feature_file) do
-      Tempfile.new('grouper.feature').tap do |feature|
-        feature.write <<-EOS
+
+  let(:feature_file) do
+    Tempfile.new('grouper.feature').tap do |feature|
+      feature.write <<-EOS
           Feature: Grouping by scenario
 
             Scenario: First
@@ -13,14 +13,30 @@ describe ParallelTests::Cucumber::Scenarios do
 
             Scenario: Second
               Given I don't do anything
-        EOS
-        feature.rewind
-      end
-    end
 
+            Scenario Outline: Third
+              Given I don't do anything
+            Examples:
+              | param   |
+              | value 1 |
+              | value 2 |
+      EOS
+      feature.rewind
+    end
+  end
+
+
+  context 'by default' do
     it 'returns all the scenarios' do
       scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path])
-      expect(scenarios).to eq %W(#{feature_file.path}:3 #{feature_file.path}:6)
+      expect(scenarios).to eq %W(#{feature_file.path}:3 #{feature_file.path}:6 #{feature_file.path}:13 #{feature_file.path}:14)
+    end
+  end
+
+  context 'with line numbers' do
+    it 'only returns scenarios that match the provided lines' do
+      scenarios = ParallelTests::Cucumber::Scenarios.all(["#{feature_file.path}:6:14"])
+      expect(scenarios).to eq %W(#{feature_file.path}:6 #{feature_file.path}:14)
     end
   end
 


### PR DESCRIPTION
File paths can now be used to specify individual tests via line numbers when grouping by scenarios.

- I did not add the functionality to feature grouping because I'm not sure if it even makes sense to specify individual tests but still organize by feature