### PR TITLE
Use ParallelTests.with_ruby_binary only for bin/parallel_* binaries

### DIFF
--- a/lib/parallel_tests/gherkin/runner.rb
+++ b/lib/parallel_tests/gherkin/runner.rb
@@ -20,7 +20,7 @@ module ParallelTests
           options[:env] = options[:env].merge({'AUTOTEST' => '1'}) if $stdout.tty? # display color when we are in a terminal
 
           cmd = [
-            ParallelTests.with_ruby_binary(executable),
+            executable,
             (runtime_logging if File.directory?(File.dirname(runtime_log))),
             cucumber_opts(options[:test_options]),
             *sanitized_test_files
@@ -100,11 +100,11 @@ module ParallelTests
         def determine_executable
           case
           when File.exist?("bin/#{name}")
-            "bin/#{name}"
+            ParallelTests.with_ruby_binary("bin/#{name}")
           when ParallelTests.bundler_enabled?
             "bundle exec #{name}"
           when File.file?("script/#{name}")
-            "script/#{name}"
+            ParallelTests.with_ruby_binary("script/#{name}")
           else
             "#{name}"
           end

--- a/lib/parallel_tests/gherkin/runner.rb
+++ b/lib/parallel_tests/gherkin/runner.rb
@@ -20,7 +20,7 @@ module ParallelTests
           options[:env] = options[:env].merge({'AUTOTEST' => '1'}) if $stdout.tty? # display color when we are in a terminal
 
           cmd = [
-            executable,
+            ParallelTests.with_ruby_binary(executable),
             (runtime_logging if File.directory?(File.dirname(runtime_log))),
             cucumber_opts(options[:test_options]),
             *sanitized_test_files

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -8,7 +8,7 @@ module ParallelTests
 
       class << self
         def run_tests(test_files, process_number, num_processes, options)
-          exe = ParallelTests.with_ruby_binary(executable) # expensive, so we cache
+          exe = executable # expensive, so we cache
           cmd = [exe, options[:test_options], color, spec_opts, *test_files].compact.join(" ")
           execute_command(cmd, process_number, num_processes, options)
         end
@@ -16,7 +16,7 @@ module ParallelTests
         def determine_executable
           cmd = case
           when File.exist?("bin/rspec")
-            "bin/rspec"
+            ParallelTests.with_ruby_binary("bin/rspec")
           when ParallelTests.bundler_enabled?
             cmd = (run("bundle show rspec-core") =~ %r{Could not find gem.*} ? "spec" : "rspec")
             "bundle exec #{cmd}"

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -8,7 +8,7 @@ module ParallelTests
 
       class << self
         def run_tests(test_files, process_number, num_processes, options)
-          exe = executable # expensive, so we cache
+          exe = ParallelTests.with_ruby_binary(executable) # expensive, so we cache
           cmd = [exe, options[:test_options], color, spec_opts, *test_files].compact.join(" ")
           execute_command(cmd, process_number, num_processes, options)
         end

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -16,8 +16,7 @@ module ParallelTests
       def run_in_parallel(cmd, options={})
         count = " -n #{options[:count]}" unless options[:count].to_s.empty?
         executable = File.expand_path("../../../bin/parallel_test", __FILE__)
-        command = "#{Shellwords.escape executable} --exec '#{cmd}'#{count}#{' --non-parallel' if options[:non_parallel]}"
-        command =  ParallelTests.with_ruby_binary(command)
+        command = "#{ParallelTests.with_ruby_binary(Shellwords.escape(executable))} --exec '#{cmd}'#{count}#{' --non-parallel' if options[:non_parallel]}"
         abort unless system(command)
       end
 
@@ -160,11 +159,10 @@ namespace :parallel do
       end
       executable = File.join(File.dirname(__FILE__), '..', '..', 'bin', 'parallel_test')
 
-      command = "#{Shellwords.escape executable} #{type} --type #{test_framework} " \
+      command = "#{ParallelTests.with_ruby_binary(Shellwords.escape(executable))} #{type} --type #{test_framework} " \
         "-n #{count} "                     \
         "--pattern '#{pattern}' "          \
         "--test-options '#{options}'"
-      command =  ParallelTests.with_ruby_binary(command)
       abort unless system(command) # allow to chain tasks e.g. rake parallel:spec parallel:features
     end
   end

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -15,7 +15,7 @@ module ParallelTests
 
       def run_in_parallel(cmd, options={})
         count = " -n #{options[:count]}" unless options[:count].to_s.empty?
-        command = "#{Shellwords.escape('parallel_test')} --exec '#{cmd}'#{count}#{' --non-parallel' if options[:non_parallel]}"
+        command = "parallel_test --exec '#{cmd}'#{count}#{' --non-parallel' if options[:non_parallel]}"
         abort unless system(command)
       end
 
@@ -157,7 +157,7 @@ namespace :parallel do
         type = 'features'
       end
 
-      command = "#{Shellwords.escape('parallel_test')} #{type} --type #{test_framework} " \
+      command = "parallel_test #{type} --type #{test_framework} " \
         "-n #{count} "                     \
         "--pattern '#{pattern}' "          \
         "--test-options '#{options}'"

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -15,8 +15,7 @@ module ParallelTests
 
       def run_in_parallel(cmd, options={})
         count = " -n #{options[:count]}" unless options[:count].to_s.empty?
-        executable = File.expand_path("../../../bin/parallel_test", __FILE__)
-        command = "#{ParallelTests.with_ruby_binary(Shellwords.escape(executable))} --exec '#{cmd}'#{count}#{' --non-parallel' if options[:non_parallel]}"
+        command = "#{Shellwords.escape('parallel_test')} --exec '#{cmd}'#{count}#{' --non-parallel' if options[:non_parallel]}"
         abort unless system(command)
       end
 
@@ -157,9 +156,8 @@ namespace :parallel do
       if test_framework == 'spinach'
         type = 'features'
       end
-      executable = File.join(File.dirname(__FILE__), '..', '..', 'bin', 'parallel_test')
 
-      command = "#{ParallelTests.with_ruby_binary(Shellwords.escape(executable))} #{type} --type #{test_framework} " \
+      command = "#{Shellwords.escape('parallel_test')} #{type} --type #{test_framework} " \
         "-n #{count} "                     \
         "--pattern '#{pattern}' "          \
         "--test-options '#{options}'"

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -15,7 +15,9 @@ module ParallelTests
 
       def run_in_parallel(cmd, options={})
         count = " -n #{options[:count]}" unless options[:count].to_s.empty?
-        command = "parallel_test --exec '#{cmd}'#{count}#{' --non-parallel' if options[:non_parallel]}"
+        # Using the relative path to find the binary allow to run a specific version of it
+        executable = File.expand_path("../../../bin/parallel_test", __FILE__)
+        command = "#{ParallelTests.with_ruby_binary(Shellwords.escape(executable))} --exec '#{cmd}'#{count}#{' --non-parallel' if options[:non_parallel]}"
         abort unless system(command)
       end
 
@@ -156,8 +158,10 @@ namespace :parallel do
       if test_framework == 'spinach'
         type = 'features'
       end
+      # Using the relative path to find the binary allow to run a specific version of it
+      executable = File.join(File.dirname(__FILE__), '..', '..', 'bin', 'parallel_test')
 
-      command = "parallel_test #{type} --type #{test_framework} " \
+      command = "#{ParallelTests.with_ruby_binary(Shellwords.escape(executable))} #{type} --type #{test_framework} " \
         "-n #{count} "                     \
         "--pattern '#{pattern}' "          \
         "--test-options '#{options}'"

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -26,7 +26,7 @@ module ParallelTests
 
         def run_tests(test_files, process_number, num_processes, options)
           require_list = test_files.map { |file| file.sub(" ", "\\ ") }.join(" ")
-          cmd = "#{executable} -Itest -e '%w[#{require_list}].each { |f| require %{./\#{f}} }' -- #{options[:test_options]}"
+          cmd = "#{ParallelTests.with_ruby_binary(executable)} -Itest -e '%w[#{require_list}].each { |f| require %{./\#{f}} }' -- #{options[:test_options]}"
           execute_command(cmd, process_number, num_processes, options)
         end
 
@@ -76,7 +76,6 @@ module ParallelTests
           )
           cmd = "nice #{cmd}" if options[:nice]
           cmd = "#{cmd} 2>&1" if options[:combine_stderr]
-          cmd = ParallelTests.with_ruby_binary(cmd)
 
           puts cmd if options[:verbose]
 

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -26,7 +26,7 @@ module ParallelTests
 
         def run_tests(test_files, process_number, num_processes, options)
           require_list = test_files.map { |file| file.sub(" ", "\\ ") }.join(" ")
-          cmd = "#{ParallelTests.with_ruby_binary(executable)} -Itest -e '%w[#{require_list}].each { |f| require %{./\#{f}} }' -- #{options[:test_options]}"
+          cmd = "#{executable} -Itest -e '%w[#{require_list}].each { |f| require %{./\#{f}} }' -- #{options[:test_options]}"
           execute_command(cmd, process_number, num_processes, options)
         end
 

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -49,22 +49,22 @@ describe ParallelTests::Tasks do
     end
 
     it "runs command in parallel" do
-      expect(ParallelTests::Tasks).to receive(:system).with("#{full_path} --exec 'echo'").and_return true
+      expect(ParallelTests::Tasks).to receive(:system).with("parallel_test --exec 'echo'").and_return true
       ParallelTests::Tasks.run_in_parallel("echo")
     end
 
     it "runs command with :count option" do
-      expect(ParallelTests::Tasks).to receive(:system).with("#{full_path} --exec 'echo' -n 123").and_return true
+      expect(ParallelTests::Tasks).to receive(:system).with("parallel_test --exec 'echo' -n 123").and_return true
       ParallelTests::Tasks.run_in_parallel("echo", :count => 123)
     end
 
     it "runs without -n with blank :count option" do
-      expect(ParallelTests::Tasks).to receive(:system).with("#{full_path} --exec 'echo'").and_return true
+      expect(ParallelTests::Tasks).to receive(:system).with("parallel_test --exec 'echo'").and_return true
       ParallelTests::Tasks.run_in_parallel("echo", :count => "")
     end
 
     it "runs command with :non_parallel option" do
-      expect(ParallelTests::Tasks).to receive(:system).with("#{full_path} --exec 'echo' --non-parallel").and_return true
+      expect(ParallelTests::Tasks).to receive(:system).with("parallel_test --exec 'echo' --non-parallel").and_return true
       ParallelTests::Tasks.run_in_parallel("echo", :non_parallel => true)
     end
 

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -49,22 +49,22 @@ describe ParallelTests::Tasks do
     end
 
     it "runs command in parallel" do
-      expect(ParallelTests::Tasks).to receive(:system).with("parallel_test --exec 'echo'").and_return true
+      expect(ParallelTests::Tasks).to receive(:system).with("#{full_path} --exec 'echo'").and_return true
       ParallelTests::Tasks.run_in_parallel("echo")
     end
 
     it "runs command with :count option" do
-      expect(ParallelTests::Tasks).to receive(:system).with("parallel_test --exec 'echo' -n 123").and_return true
+      expect(ParallelTests::Tasks).to receive(:system).with("#{full_path} --exec 'echo' -n 123").and_return true
       ParallelTests::Tasks.run_in_parallel("echo", :count => 123)
     end
 
     it "runs without -n with blank :count option" do
-      expect(ParallelTests::Tasks).to receive(:system).with("parallel_test --exec 'echo'").and_return true
+      expect(ParallelTests::Tasks).to receive(:system).with("#{full_path} --exec 'echo'").and_return true
       ParallelTests::Tasks.run_in_parallel("echo", :count => "")
     end
 
     it "runs command with :non_parallel option" do
-      expect(ParallelTests::Tasks).to receive(:system).with("parallel_test --exec 'echo' --non-parallel").and_return true
+      expect(ParallelTests::Tasks).to receive(:system).with("#{full_path} --exec 'echo' --non-parallel").and_return true
       ParallelTests::Tasks.run_in_parallel("echo", :non_parallel => true)
     end
 


### PR DESCRIPTION
This change fixes rake tasks on Windows. The only place where adding
ruby binary is necessary for bin/parallel_* binaries. For all other
cases it may leads to some ambiguous command lines like
`ruby.exe ruby rake` which don't work.