### PR TITLE
Allow for graceful shutdown of child processes

### DIFF
--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -28,6 +28,10 @@ module ParallelTests
       ENV['PARALLEL_PID_FILE'] ||= Tempfile.new('parallel-tests-pidfile').path
     end
 
+    def stop_all_processes
+      pids.all.each { |pid| Process.kill(:INT, pid) }
+    end
+
     # copied from http://github.com/carlhuda/bundler Bundler::SharedHelpers#find_gemfile
     def bundler_enabled?
       return true if Object.const_defined?(:Bundler)

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -6,7 +6,7 @@ require 'shellwords'
 module ParallelTests
   class CLI
     def run(argv)
-      Signal.trap("INT") { Thread.new { ParallelTests.stop_all_processes } }
+      Signal.trap("INT") { handle_interrupt }
 
       options = parse_options!(argv)
 
@@ -25,6 +25,17 @@ module ParallelTests
     end
 
     private
+
+    def handle_interrupt
+      @graceful_shutdown_attempted ||= false
+      Kernel.exit if @graceful_shutdown_attempted
+
+      # The Pid class's synchronize method can't be called directly from a trap
+      # Using Thread workaround https://github.com/ddollar/foreman/issues/332
+      Thread.new { ParallelTests.stop_all_processes }
+
+      @graceful_shutdown_attempted = true
+    end
 
     def execute_in_parallel(items, num_processes, options)
       Tempfile.open 'parallel_tests-lock' do |lock|

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -6,6 +6,8 @@ require 'shellwords'
 module ParallelTests
   class CLI
     def run(argv)
+      Signal.trap("INT") { Thread.new { ParallelTests.stop_all_processes } }
+
       options = parse_options!(argv)
 
       ENV['DISABLE_SPRING'] ||= '1'

--- a/lib/parallel_tests/pids.rb
+++ b/lib/parallel_tests/pids.rb
@@ -25,15 +25,15 @@ module ParallelTests
       pids.count
     end
 
+    def all
+      read
+      pids
+    end
+
     private
 
     def pids
       @pids ||= []
-    end
-
-    def all
-      read
-      pids
     end
 
     def clear

--- a/spec/parallel_tests/pids_spec.rb
+++ b/spec/parallel_tests/pids_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ParallelTests::Pids do
   describe '#add' do
     specify do
       subject.add(789)
-      expect(subject.send(:all)).to eq ([123, 456, 789])
+      expect(subject.all).to eq ([123, 456, 789])
     end
   end
   
@@ -21,11 +21,15 @@ RSpec.describe ParallelTests::Pids do
     specify do
       subject.add(101)
       subject.delete(123)
-      expect(subject.send(:all)).to eq ([456, 101])
+      expect(subject.all).to eq ([456, 101])
     end
   end
 
   describe '#count' do
     specify { expect(subject.count).to eq(2) }
+  end
+
+  describe '#all' do
+    specify { expect(subject.all).to eq([123, 456]) }
   end
 end

--- a/spec/parallel_tests_spec.rb
+++ b/spec/parallel_tests_spec.rb
@@ -183,6 +183,20 @@ describe ParallelTests do
     end
   end
 
+  describe ".stop_all_processes" do
+    it 'kills the running child process' do
+      ParallelTests.pids.send(:clear)
+      Thread.new do
+        ParallelTests::Test::Runner.execute_command('sleep 3', 1, 1, {})
+      end
+      sleep(0.2)
+      expect(ParallelTests.pids.count).to eq(1)
+      ParallelTests.stop_all_processes
+      sleep(0.2)
+      expect(ParallelTests.pids.count).to eq(0)
+    end
+  end
+
   it "has a version" do
     expect(ParallelTests::VERSION).to match(/^\d+\.\d+\.\d+/)
   end


### PR DESCRIPTION
Now that we're keeping track of pids, how about a graceful shutdown approach that sends the kill signal to the children. Let me know what you think.