### PR TITLE
Add parallel:rollback rake task

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -116,6 +116,11 @@ namespace :parallel do
     ParallelTests::Tasks.run_in_parallel("rake db:migrate RAILS_ENV=#{ParallelTests::Tasks.rails_env}", args)
   end
 
+  desc "Rollback test databases via db:rollback --> parallel:rollback[num_cpus]"
+  task :rollback, :count do |_,args|
+    ParallelTests::Tasks.run_in_parallel("rake db:rollback RAILS_ENV=#{ParallelTests::Tasks.rails_env}", args)
+  end
+
   # just load the schema (good for integration server <-> no development db)
   desc "Load dumped schema for test databases via db:schema:load --> parallel:load_schema[num_cpus]"
   task :load_schema, :count do |_,args|


### PR DESCRIPTION
Heya heya. I use `parallel_tests` heavily during development, because we have some large test suites, and I like to continuously verify that I didn't break anything as I go. This means I use `rake parallel:migrate` during feature development, which means I inevitably will need `rake parallel:rollback` when I screw things up. :)

This happened today, thus this PR.