### PR TITLE
Option to prefix the test env number to the output

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -213,6 +213,8 @@ Options are:
           '_spec.rb$' - matches rspec files
           '_(test|spec).rb$' - matches test or spec files
         --serialize-stdout           Serialize stdout output, nothing will be written until everything is done
+        --prefix-output-with-test-env-number
+                                     Prefixes test env number to the output when not using --serialize-stdout
         --combine-stderr             Combine stderr into stdout, useful in conjunction with --serialize-stdout
         --non-parallel               execute same commands but do not in parallel, needs --exec
         --no-symlinks                Do not traverse symbolic links to find test files

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -204,6 +204,7 @@ module ParallelTests
           TEXT
           ) { |pattern| options[:suffix] = /#{pattern}/ }
         opts.on("--serialize-stdout", "Serialize stdout output, nothing will be written until everything is done") { options[:serialize_stdout] = true }
+        opts.on("--prefix-output-with-test-env-number", "Prefixes test env number to the output when not using --serialize-stdout") { options[:prefix_output_with_test_env_number] = true }
         opts.on("--combine-stderr", "Combine stderr into stdout, useful in conjunction with --serialize-stdout") { options[:combine_stderr] = true }
         opts.on("--non-parallel", "execute same commands but do not in parallel, needs --exec") { options[:non_parallel] = true }
         opts.on("--no-symlinks", "Do not traverse symbolic links to find test files") { options[:symlinks] = false }

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -146,7 +146,6 @@ module ParallelTests
 
         # read output of the process and print it in chunks
         def capture_output(out, env, options={})
-          puts "THE OPTIONS: #{options.inspect}"
           result = ""
           loop do
             begin

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -442,6 +442,24 @@ EOF
       end
     end
 
+    it "adds test env number to stdout with :prefix_output_with_test_env_number" do
+      run_with_file("puts 123") do |path|
+        expect($stdout).to receive(:print).with("[TEST GROUP 2] 123\n")
+        result = call("ruby #{path}", 1, 4, :prefix_output_with_test_env_number => true)
+        expect(result[:stdout].chomp).to eq '123'
+        expect(result[:exit_status]).to eq 0
+      end
+    end
+
+    it "does not add test env number to stdout without :prefix_output_with_test_env_number" do
+      run_with_file("puts 123") do |path|
+        expect($stdout).to receive(:print).with("123\n")
+        result = call("ruby #{path}", 1, 4, :prefix_output_with_test_env_number => false)
+        expect(result[:stdout].chomp).to eq '123'
+        expect(result[:exit_status]).to eq 0
+      end
+    end
+
     it "returns correct exit status" do
       run_with_file("puts 123; exit 5") do |path|
         result = call("ruby #{path}", 1, 4, {})


### PR DESCRIPTION
This makes it possible to match up output lines when running without --serialize-stdout. This is useful to debug tests that hang when running in parallel by giving real-time feedback and being able to link that feedback to certain potentially problematic tests.