### PR TITLE
Cucumber flaky test support

### DIFF
--- a/lib/parallel_tests/cucumber/runner.rb
+++ b/lib/parallel_tests/cucumber/runner.rb
@@ -18,20 +18,12 @@ module ParallelTests
         def summarize_results(results)
           output = []
 
-          scenario_groups = results.slice_before(SCENARIOS_RESULTS_BOUNDARY_REGEX)
-
-          failing_scenario_groups, flaky_scenario_groups = scenario_groups.partition { |group| group.first == "Failing Scenarios:" }
-
-          failing_scenarios = failing_scenario_groups.flatten.grep(SCENARIO_REGEX)
-          if failing_scenarios.any?
-            failing_scenarios.unshift("Failing Scenarios:")
-            output << failing_scenarios.join("\n")
-          end
-
-          flaky_scenarios = flaky_scenario_groups.flatten.grep(SCENARIO_REGEX)
-          if flaky_scenarios.any?
-            flaky_scenarios.unshift("Flaky Scenarios:")
-            output << flaky_scenarios.join("\n")
+          scenario_groups = results.slice_before(SCENARIOS_RESULTS_BOUNDARY_REGEX).group_by(&:first)
+          scenario_groups.each do |header, group|
+            scenarios = group.flatten.grep(SCENARIO_REGEX)
+            if scenarios.any?
+              output << ([header] + scenarios).join("\n")
+            end
           end
 
           output << super

--- a/lib/parallel_tests/cucumber/runner.rb
+++ b/lib/parallel_tests/cucumber/runner.rb
@@ -3,7 +3,8 @@ require "parallel_tests/gherkin/runner"
 module ParallelTests
   module Cucumber
     class Runner < ParallelTests::Gherkin::Runner
-      FAILED_SCENARIO_REGEX = /^cucumber features\/.+:\d+/
+      SCENARIOS_RESULTS_BOUNDARY_REGEX = /^(Failing|Flaky) Scenarios:$/
+      SCENARIO_REGEX = /^cucumber features\/.+:\d+/
 
       class << self
         def name
@@ -11,16 +12,26 @@ module ParallelTests
         end
 
         def line_is_result?(line)
-          super || line =~ FAILED_SCENARIO_REGEX
+          super || line =~ SCENARIO_REGEX || line =~ SCENARIOS_RESULTS_BOUNDARY_REGEX
         end
 
         def summarize_results(results)
           output = []
 
-          failing_scenarios = results.grep(FAILED_SCENARIO_REGEX)
+          scenario_groups = results.slice_before(SCENARIOS_RESULTS_BOUNDARY_REGEX)
+
+          failing_scenario_groups, flaky_scenario_groups = scenario_groups.partition { |group| group.first == "Failing Scenarios:" }
+
+          failing_scenarios = failing_scenario_groups.flatten.grep(SCENARIO_REGEX)
           if failing_scenarios.any?
             failing_scenarios.unshift("Failing Scenarios:")
             output << failing_scenarios.join("\n")
+          end
+
+          flaky_scenarios = flaky_scenario_groups.flatten.grep(SCENARIO_REGEX)
+          if flaky_scenarios.any?
+            flaky_scenarios.unshift("Flaky Scenarios:")
+            output << flaky_scenarios.join("\n")
           end
 
           output << super

--- a/lib/parallel_tests/gherkin/runner.rb
+++ b/lib/parallel_tests/gherkin/runner.rb
@@ -44,7 +44,7 @@ module ParallelTests
         # 1 scenario (1 failed)
         # 1 step (1 failed)
         def summarize_results(results)
-          sort_order = %w[scenario step failed undefined skipped pending passed]
+          sort_order = %w[scenario step failed flaky undefined skipped pending passed]
 
           %w[scenario step].map do |group|
             group_results = results.grep(/^\d+ #{group}/)

--- a/spec/parallel_tests/cucumber/runner_spec.rb
+++ b/spec/parallel_tests/cucumber/runner_spec.rb
@@ -22,6 +22,16 @@ describe ParallelTests::Cucumber::Runner do
         ]
         expect(call(results)).to eq("Failing Scenarios:\ncucumber features/failure:1\ncucumber features/failure:2\ncucumber features/failure:3\ncucumber features/failure:4\ncucumber features/failure:5\ncucumber features/failure:6\n\n")
       end
+
+      it "collates flaky scenarios separately" do
+        results = [
+          "Failing Scenarios:", "cucumber features/failure:1", "cucumber features/failure:2",
+          "Flaky Scenarios:", "cucumber features/failure:3", "cucumber features/failure:4",
+          "Failing Scenarios:", "cucumber features/failure:5", "cucumber features/failure:6",
+          "Flaky Scenarios:", "cucumber features/failure:7", "cucumber features/failure:8",
+        ]
+        expect(call(results)).to eq("Failing Scenarios:\ncucumber features/failure:1\ncucumber features/failure:2\ncucumber features/failure:5\ncucumber features/failure:6\n\nFlaky Scenarios:\ncucumber features/failure:3\ncucumber features/failure:4\ncucumber features/failure:7\ncucumber features/failure:8\n\n")
+      end
     end
   end
 

--- a/spec/parallel_tests/gherkin/runner_behaviour.rb
+++ b/spec/parallel_tests/gherkin/runner_behaviour.rb
@@ -175,10 +175,11 @@ shared_examples_for 'gherkin runners' do
 
     it "sums up results for scenarios and steps separately from each other" do
       results = [
-        "7 scenarios (3 failed, 4 passed)", "33 steps (3 failed, 2 skipped, 28 passed)", "4 scenarios (4 passed)",
-        "40 steps (40 passed)", "1 scenario (1 passed)", "1 step (1 passed)"
+        "7 scenarios (2 failed, 1 flaky, 4 passed)", "33 steps (3 failed, 2 skipped, 28 passed)",
+        "4 scenarios (4 passed)", "40 steps (40 passed)",
+        "1 scenario (1 passed)", "1 step (1 passed)"
       ]
-      expect(call(results)).to eq("12 scenarios (3 failed, 9 passed)\n74 steps (3 failed, 2 skipped, 69 passed)")
+      expect(call(results)).to eq("12 scenarios (2 failed, 1 flaky, 9 passed)\n74 steps (3 failed, 2 skipped, 69 passed)")
     end
 
     it "adds same results with plurals" do


### PR DESCRIPTION
Cucumber has added flaky test support via the `--retry n` command line option, so let's teach parallel_tests about it, too.