### PR TITLE
Parallel::Test::Runner.sort_by_runtime: improved error message

### DIFF
--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -173,7 +173,10 @@ module ParallelTests
           tests.sort!
           tests.map! do |test|
             allowed_missing -= 1 unless time = runtimes[test]
-            raise "Too little runtime info" if allowed_missing < 0
+            if allowed_missing < 0
+              log = options[:runtime_log] || runtime_log
+              raise "Runtime log file '#{log}' does not cointain sufficient data to sort #{tests.size} test files, please update it."
+            end
             [test, time]
           end
 


### PR DESCRIPTION
Using [forking_test_runner](https://github.com/grosser/forking_test_runner), took me a while to understand what `Too little runtime info` meant, so trying to make it more explicit.

/cc @grosser 

### Risks
Low. Just updating error message.