### PR TITLE
Add switch to log results to JSON file

### DIFF
--- a/lib/parallel_tests/cucumber/runner.rb
+++ b/lib/parallel_tests/cucumber/runner.rb
@@ -15,7 +15,7 @@ module ParallelTests
           super || line =~ SCENARIO_REGEX || line =~ SCENARIOS_RESULTS_BOUNDARY_REGEX
         end
 
-        def summarize_results(results)
+        def summarize_results(results, consolidated_results)
           output = []
 
           scenario_groups = results.slice_before(SCENARIOS_RESULTS_BOUNDARY_REGEX).group_by(&:first)
@@ -28,7 +28,11 @@ module ParallelTests
 
           output << super
 
-          output.join("\n\n")
+          consolidated_results[:summary] = {
+            message: output.join("\n\n")
+          }
+
+          consolidated_results[:summary][:message]
         end
 
         def command_with_seed(cmd, seed)

--- a/lib/parallel_tests/gherkin/runner.rb
+++ b/lib/parallel_tests/gherkin/runner.rb
@@ -43,10 +43,10 @@ module ParallelTests
         # cucumber has 2 result lines per test run, that cannot be added
         # 1 scenario (1 failed)
         # 1 step (1 failed)
-        def summarize_results(results)
+        def summarize_results(results, consolidated_results)
           sort_order = %w[scenario step failed flaky undefined skipped pending passed]
 
-          %w[scenario step].map do |group|
+          message = %w[scenario step].map do |group|
             group_results = results.grep(/^\d+ #{group}/)
             next if group_results.empty?
 
@@ -58,6 +58,12 @@ module ParallelTests
             end
             "#{sums[0]} (#{sums[1..-1].join(", ")})"
           end.compact.join("\n")
+
+          consolidated_results[:summary] = {
+            message: message
+          }
+
+          consolidated_results[:summary][:message]
         end
 
         def cucumber_opts(given)

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -114,9 +114,15 @@ module ParallelTests
           end
         end
 
-        def summarize_results(results)
+        def summarize_results(results, consolidated_results)
           sums = sum_up_results(results)
-          sums.sort.map{|word, number|  "#{number} #{word}#{'s' if number != 1}" }.join(', ')
+          message = sums.sort.map{|word, number|  "#{number} #{word}#{'s' if number != 1}" }.join(', ')
+
+          consolidated_results[:summary] = sums.merge({
+            message: message
+          })
+
+          consolidated_results[:summary][:message]
         end
 
         # remove old seed and add new seed

--- a/spec/parallel_tests/cucumber/runner_spec.rb
+++ b/spec/parallel_tests/cucumber/runner_spec.rb
@@ -20,7 +20,7 @@ describe ParallelTests::Cucumber::Runner do
           "Failing Scenarios:", "cucumber features/failure:3", "cucumber features/failure:4",
           "Failing Scenarios:", "cucumber features/failure:5", "cucumber features/failure:6"
         ]
-        expect(call(results)).to eq("Failing Scenarios:\ncucumber features/failure:1\ncucumber features/failure:2\ncucumber features/failure:3\ncucumber features/failure:4\ncucumber features/failure:5\ncucumber features/failure:6\n\n")
+        expect(call(results, {})).to eq("Failing Scenarios:\ncucumber features/failure:1\ncucumber features/failure:2\ncucumber features/failure:3\ncucumber features/failure:4\ncucumber features/failure:5\ncucumber features/failure:6\n\n")
       end
 
       it "collates flaky scenarios separately" do
@@ -30,7 +30,7 @@ describe ParallelTests::Cucumber::Runner do
           "Failing Scenarios:", "cucumber features/failure:5", "cucumber features/failure:6",
           "Flaky Scenarios:", "cucumber features/failure:7", "cucumber features/failure:8",
         ]
-        expect(call(results)).to eq("Failing Scenarios:\ncucumber features/failure:1\ncucumber features/failure:2\ncucumber features/failure:5\ncucumber features/failure:6\n\nFlaky Scenarios:\ncucumber features/failure:3\ncucumber features/failure:4\ncucumber features/failure:7\ncucumber features/failure:8\n\n")
+        expect(call(results, {})).to eq("Failing Scenarios:\ncucumber features/failure:1\ncucumber features/failure:2\ncucumber features/failure:5\ncucumber features/failure:6\n\nFlaky Scenarios:\ncucumber features/failure:3\ncucumber features/failure:4\ncucumber features/failure:7\ncucumber features/failure:8\n\n")
       end
     end
   end

--- a/spec/parallel_tests/gherkin/runner_behaviour.rb
+++ b/spec/parallel_tests/gherkin/runner_behaviour.rb
@@ -179,7 +179,7 @@ shared_examples_for 'gherkin runners' do
         "4 scenarios (4 passed)", "40 steps (40 passed)",
         "1 scenario (1 passed)", "1 step (1 passed)"
       ]
-      expect(call(results)).to eq("12 scenarios (2 failed, 1 flaky, 9 passed)\n74 steps (3 failed, 2 skipped, 69 passed)")
+      expect(call(results, {})).to eq("12 scenarios (2 failed, 1 flaky, 9 passed)\n74 steps (3 failed, 2 skipped, 69 passed)")
     end
 
     it "adds same results with plurals" do
@@ -187,7 +187,7 @@ shared_examples_for 'gherkin runners' do
         "1 scenario (1 passed)", "2 steps (2 passed)",
         "2 scenarios (2 passed)", "7 steps (7 passed)"
       ]
-      expect(call(results)).to eq("3 scenarios (3 passed)\n9 steps (9 passed)")
+      expect(call(results, {})).to eq("3 scenarios (3 passed)\n9 steps (9 passed)")
     end
 
     it "adds non-similar results" do
@@ -195,11 +195,11 @@ shared_examples_for 'gherkin runners' do
         "1 scenario (1 passed)", "1 step (1 passed)",
         "2 scenarios (1 failed, 1 pending)", "2 steps (1 failed, 1 pending)"
       ]
-      expect(call(results)).to eq("3 scenarios (1 failed, 1 pending, 1 passed)\n3 steps (1 failed, 1 pending, 1 passed)")
+      expect(call(results, {})).to eq("3 scenarios (1 failed, 1 pending, 1 passed)\n3 steps (1 failed, 1 pending, 1 passed)")
     end
 
     it "does not pluralize 1" do
-      expect(call(["1 scenario (1 passed)", "1 step (1 passed)"])).to eq("1 scenario (1 passed)\n1 step (1 passed)")
+      expect(call(["1 scenario (1 passed)", "1 step (1 passed)"], {})).to eq("1 scenario (1 passed)\n1 step (1 passed)")
     end
   end
 

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -316,23 +316,23 @@ EOF
     end
 
     it "adds results" do
-      expect(call(['1 foo 3 bar','2 foo 5 bar'])).to eq('8 bars, 3 foos')
+      expect(call(['1 foo 3 bar','2 foo 5 bar'], {})).to eq('8 bars, 3 foos')
     end
 
     it "adds results with braces" do
-      expect(call(['1 foo(s) 3 bar(s)','2 foo 5 bar'])).to eq('8 bars, 3 foos')
+      expect(call(['1 foo(s) 3 bar(s)','2 foo 5 bar'], {})).to eq('8 bars, 3 foos')
     end
 
     it "adds same results with plurals" do
-      expect(call(['1 foo 3 bar','2 foos 5 bar'])).to eq('8 bars, 3 foos')
+      expect(call(['1 foo 3 bar','2 foos 5 bar'], {})).to eq('8 bars, 3 foos')
     end
 
     it "adds non-similar results" do
-      expect(call(['1 xxx 2 yyy','1 xxx 2 zzz'])).to eq('2 xxxs, 2 yyys, 2 zzzs')
+      expect(call(['1 xxx 2 yyy','1 xxx 2 zzz'], {})).to eq('2 xxxs, 2 yyys, 2 zzzs')
     end
 
     it "does not pluralize 1" do
-      expect(call(['1 xxx 2 yyy'])).to eq('1 xxx, 2 yyys')
+      expect(call(['1 xxx 2 yyy'], {})).to eq('1 xxx, 2 yyys')
     end
   end
 


### PR DESCRIPTION
The --consolidated-results switch causes results like tests per process, time taken, and total failures
to be logged to a JSON file at the path supplied.