### PR TITLE
test against Gemfile.lock to use bundler or not

### DIFF
--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -55,7 +55,7 @@ module ParallelTests
       current = File.expand_path(Dir.pwd)
 
       until !File.directory?(current) || current == previous
-        filename = File.join(current, "Gemfile")
+        filename = File.join(current, "Gemfile.lock")
         return true if File.exist?(filename)
         current, previous = File.expand_path("..", current), current
       end

--- a/spec/parallel_tests_spec.rb
+++ b/spec/parallel_tests_spec.rb
@@ -51,18 +51,18 @@ describe ParallelTests do
       end
     end
 
-    it "is true when there is a Gemfile" do
+    it "is true when there is a Gemfile.lock" do
       use_temporary_directory do
-        FileUtils.touch("Gemfile")
+        FileUtils.touch("Gemfile.lock")
         expect(ParallelTests.send(:bundler_enabled?)).to eq(true)
       end
     end
 
-    it "is true when there is a Gemfile in the parent directory" do
+    it "is true when there is a Gemfile.lock in the parent directory" do
       use_temporary_directory do
         FileUtils.mkdir "nested"
         Dir.chdir "nested" do
-          FileUtils.touch(File.join("..", "Gemfile"))
+          FileUtils.touch(File.join("..", "Gemfile.lock"))
           expect(ParallelTests.send(:bundler_enabled?)).to eq(true)
         end
       end


### PR DESCRIPTION
We heve many project containing a Gemfile, but we do not use bundler.  So I thought cecking against Gemfile.lock could be a more accurate way to check if bundler is indeed used or not.  Since those using bundler ececute a bunkder install as the very first step, which generates the Gemfile.lock.

Open for suggestions on tis.

Thx