### PR TITLE
Option to output feature files to texts grouped by process. 

### DIFF
--- a/lib/parallel_tests/gherkin/runner.rb
+++ b/lib/parallel_tests/gherkin/runner.rb
@@ -28,6 +28,16 @@ module ParallelTests
           execute_command(cmd, process_number, num_processes, options)
         end
 
+        def run_tests_from_file(process_number, num_processes, options)
+          cmd = [
+              executable,
+              (runtime_logging if File.directory?(File.dirname(runtime_log))),
+              cucumber_opts(options[:test_options]),
+              "@features_from_process_#{process_number}.txt"
+          ].compact.reject(&:empty?).join(' ')
+          execute_command(cmd, process_number, num_processes, options)
+        end
+
         def test_file_name
           @test_file_name || 'feature'
         end


### PR DESCRIPTION
@grosser 

First of all. Thank you for your work on this test suite! It has vastly increased the speed of our scripts. 

My changes were made in an effort to solve a few issues we were having running test scripts in parallel with our Ruby/Cucumber/Gherkin test suite. I am open to suggestions and happy to add whatever is necessary to get this included and will do my best to support the functionality. These changes give the user the ability to add the --features_by_process option to their job. Once the tests are parsed and divided up they will be stored in .txt files in the project directory as 'features_from_process_<process_number>.txt'

This solves two issues we were having. By outputting the features to text files we are quickly able to rerun subsets of features should one process fail. Additionally, this can help users with large test suites. We have a large test suite and were unable to run the entirety of the suite on less than 8 cores/processes as the commands generated exceeded the character limit of windows commands. The commands generated will run the tests via the @features_from_process_<process_number>.txt format rather than by listing out the path and names of each feature. 