### PR TITLE
Fix typo in README documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -113,7 +113,7 @@ Rspec: Add to your `.rspec_parallel` (or `.rspec`) :
     --format progress
     --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log
 
-To use a custom logfile location (default: `tmp/parallel_runtime_spec.log`), use the CLI: `parallel_test spec -t rspec --runtime-log my.log`
+To use a custom logfile location (default: `tmp/parallel_runtime_rspec.log`), use the CLI: `parallel_test spec -t rspec --runtime-log my.log`
 
 ### Test::Unit & Minitest 4/5
 


### PR DESCRIPTION
Just noticed this typo and [checked the code](https://github.com/grosser/parallel_tests/blob/master/lib/parallel_tests/rspec/runner.rb#L30) to confirm that `tmp/parallel_runtime_rspec.log` is correct.