### PR TITLE
Rake task passes through additional arguments

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -65,10 +65,10 @@ module ParallelTests
         end
       end
 
-      # parallel:spec[:count, :pattern, :options]
+      # parallel:spec[:count, :pattern, :options, :pass_through]
       def parse_args(args)
         # order as given by user
-        args = [args[:count], args[:pattern], args[:options]]
+        args = [args[:count], args[:pattern], args[:options], args[:pass_through]]
 
         # count given or empty ?
         # parallel:spec[2,models,options]
@@ -77,8 +77,9 @@ module ParallelTests
         num_processes = count.to_i unless count.to_s.empty?
         pattern = args.shift
         options = args.shift
+        pass_through = args.shift
 
-        [num_processes, pattern.to_s, options.to_s]
+        [num_processes, pattern.to_s, options.to_s, pass_through.to_s]
       end
     end
   end
@@ -152,11 +153,11 @@ namespace :parallel do
 
   ['test', 'spec', 'features', 'features-spinach'].each do |type|
     desc "Run #{type} in parallel with parallel:#{type}[num_cpus]"
-    task type, [:count, :pattern, :options] do |t, args|
+    task type, [:count, :pattern, :options, :pass_through] do |t, args|
       ParallelTests::Tasks.check_for_pending_migrations
       ParallelTests::Tasks.load_lib
 
-      count, pattern, options = ParallelTests::Tasks.parse_args(args)
+      count, pattern, options, pass_through = ParallelTests::Tasks.parse_args(args)
       test_framework = {
         'spec' => 'rspec',
         'test' => 'test',
@@ -173,7 +174,8 @@ namespace :parallel do
       command = "#{ParallelTests.with_ruby_binary(Shellwords.escape(executable))} #{type} --type #{test_framework} " \
         "-n #{count} "                     \
         "--pattern '#{pattern}' "          \
-        "--test-options '#{options}'"
+        "--test-options '#{options}' "     \
+        "#{pass_through}"
       abort unless system(command) # allow to chain tasks e.g. rake parallel:spec parallel:features
     end
   end

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -5,27 +5,32 @@ describe ParallelTests::Tasks do
   describe ".parse_args" do
     it "should return the count" do
       args = {:count => 2}
-      expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "", ""])
+      expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "", "", ""])
     end
 
     it "should default to the prefix" do
       args = {:count => "models"}
-      expect(ParallelTests::Tasks.parse_args(args)).to eq([nil, "models", ""])
+      expect(ParallelTests::Tasks.parse_args(args)).to eq([nil, "models", "", ""])
     end
 
     it "should return the count and pattern" do
       args = {:count => 2, :pattern => "models"}
-      expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "models", ""])
+      expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "models", "", ""])
     end
 
     it "should return the count, pattern, and options" do
       args = {:count => 2, :pattern => "plain", :options => "-p default"}
-      expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "plain", "-p default"])
+      expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "plain", "-p default", ""])
     end
 
     it "should return the count, pattern, and options" do
       args = {:count => 2, :pattern => "plain", :options => "-p default --group-by steps"}
-      expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "plain", "-p default --group-by steps"])
+      expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "plain", "-p default --group-by steps", ""])
+    end
+
+    it "should return the count, pattern, test options, and pass-through options" do
+      args = {:count => 2, :pattern => "plain", :options => "-p default --group-by steps", :pass_through => "--runtime-log /path/to/log"}
+      expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "plain", "-p default --group-by steps", "--runtime-log /path/to/log"])
     end
   end
 


### PR DESCRIPTION
We needed our rake task to use the alternate runtime log option which the CLI provides, but we did not want to plumb through one specific option. Instead we surfaced a pass-through field which allows the rake user to specify any number of arbitrary options to pass along to the CLI.

This allows us to have our rake task specify a different runtime-log.