### PR TITLE
Improve verbose + serialize-output usage

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -286,7 +286,6 @@ TODO
 ====
  - fix tests vs cucumber >= 1.2 `unknown option --format`
  - add unit tests for cucumber runtime formatter
- - fix windows bugs / get windows CI green
 
 Authors
 ====

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -78,7 +78,7 @@ module ParallelTests
           cmd = "nice #{cmd}" if options[:nice]
           cmd = "#{cmd} 2>&1" if options[:combine_stderr]
 
-          puts cmd if options[:verbose]
+          puts cmd if options[:verbose] && !options[:serialize_stdout]
 
           execute_command_and_capture_output(env, cmd, options)
         end
@@ -93,6 +93,8 @@ module ParallelTests
           ParallelTests.pids.delete(pid) if pid
           exitstatus = $?.exitstatus
           seed = output[/seed (\d+)/,1]
+
+          output = [cmd, output].join("\n") if options[:verbose] && options[:serialize_stdout]
 
           {:stdout => output, :exit_status => exitstatus, :command => cmd, :seed => seed}
         end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -145,6 +145,13 @@ describe 'CLI' do
     expect(result).to match(/\.{5}.*TEST1/m)
   end
 
+  it "can show simulated output preceded by command when serializing stdout with verbose option" do
+    write 'spec/xxx_spec.rb', 'describe("it"){it("should"){sleep 1; puts "TEST1"}}'
+    result = run_tests "spec --verbose", :type => 'rspec', :add => "--serialize-stdout", export: {'PARALLEL_TEST_HEARTBEAT_INTERVAL' => '0.2'}
+
+    expect(result).to match(/\.{5}.*\nbundle exec rspec spec\/xxx_spec\.rb\nTEST1/m)
+  end
+
   it "can serialize stdout and stderr" do
     write 'spec/xxx_spec.rb', '5.times{describe("it"){it("should"){sleep 0.01; $stderr.puts "errTEST1"; puts "TEST1"}}}'
     write 'spec/xxx2_spec.rb', 'sleep 0.01; 5.times{describe("it"){it("should"){sleep 0.01; $stderr.puts "errTEST2"; puts "TEST2"}}}'

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -396,10 +396,16 @@ describe 'CLI' do
       write "features/fail2.feature", "Feature: xxx\n  Scenario: xxx\n    Given I fail"
       results = run_tests "features", :processes => 3, :type => "cucumber", :fail => true
 
+      failing_scenarios = if Gem.win_platform? && RUBY_VERSION.start_with?("2.4")
+        ["cucumber features/fail1.feature:2 # Scenario: xxx", "cucumber features/fail2.feature:2 # Scenario: xxx"]
+      else
+        ["cucumber features/fail2.feature:2 # Scenario: xxx", "cucumber features/fail1.feature:2 # Scenario: xxx"]
+      end
+
       expect(results).to include <<-EOF.gsub('        ', '')
         Failing Scenarios:
-        cucumber features/fail2.feature:2 # Scenario: xxx
-        cucumber features/fail1.feature:2 # Scenario: xxx
+        #{failing_scenarios[0]}
+        #{failing_scenarios[1]}
 
         3 scenarios (2 failed, 1 passed)
         3 steps (2 failed, 1 passed)

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -41,7 +41,8 @@ describe ParallelTests::Test::Runner do
     end
 
     it "uses given when passed found" do
-      expect(call(["a", "b", "c"], 2, group_by: :found)).to eq([["a", "c"], ["b"]])
+      result = Gem.win_platform? && RUBY_VERSION.start_with?("2.4") ? [["a", "b"], ["c"]] : [["a", "c"], ["b"]]
+      expect(call(["a", "b", "c"], 2, group_by: :found)).to eq(result)
     end
 
     context "when passed no group" do


### PR DESCRIPTION
With this combination of flags, all commands will be printed first, and then all outputs. I think it's more useful to print each command followed by its output in sequence.

#### Before

```
Using recorded test runtime
4 processes for 98 specs, ~ 24 specs per process
bundle exec rspec --color --tty -O .rspec_parallel spec/bug_report_templates_spec.rb spec/requests/memory_spec.rb spec/requests/stylesheets_spec.rb spec/unit/active_admin_spec.rb spec/unit/authorization/index_overriding_spec.rb spec/unit/auto_link_spec.rb spec/unit/batch_actions/resource_spec.rb spec/unit/csv_builder_spec.rb spec/unit/dependency_spec.rb spec/unit/localizers/resource_localizer_spec.rb spec/unit/menu_collection_spec.rb spec/unit/menu_item_spec.rb spec/unit/namespace/register_page_spec.rb spec/unit/namespace/register_resource_spec.rb spec/unit/namespace_spec.rb spec/unit/resource/includes_spec.rb spec/unit/resource/ordering_spec.rb spec/unit/resource_controller/sidebars_spec.rb spec/unit/view_factory_spec.rb spec/unit/view_helpers/form_helper_spec.rb spec/unit/views/components/menu_spec.rb spec/unit/views/components/paginated_collection_spec.rb spec/unit/views/components/sidebar_spec.rb spec/unit/views/index_as_blog_spec.rb spec/unit/views/pages/show_spec.rb
bundle exec rspec --color --tty -O .rspec_parallel spec/requests/default_namespace_spec.rb spec/unit/abstract_view_factory_spec.rb spec/unit/belongs_to_spec.rb spec/unit/controller_filters_spec.rb spec/unit/filters/active_filter_spec.rb spec/unit/filters/filter_form_builder_spec.rb spec/unit/filters/resource_spec.rb spec/unit/menu_spec.rb spec/unit/namespace/authorization_spec.rb spec/unit/pundit_adapter_spec.rb spec/unit/resource/action_items_spec.rb spec/unit/resource/attributes_spec.rb spec/unit/resource_controller/decorators_spec.rb spec/unit/resource_controller_spec.rb spec/unit/resource_registration_spec.rb spec/unit/settings_node_spec.rb spec/unit/view_helpers/display_helper_spec.rb spec/unit/view_helpers/method_or_proc_helper_spec.rb spec/unit/views/components/index_list_spec.rb spec/unit/views/components/menu_item_spec.rb spec/unit/views/components/panel_spec.rb spec/unit/views/components/status_tag_spec.rb spec/unit/views/components/table_for_spec.rb spec/unit/views/components/unsupported_browser_spec.rb spec/unit/views/pages/layout_spec.rb
bundle exec rspec --color --tty -O .rspec_parallel spec/unit/action_builder_spec.rb spec/unit/authorization/authorization_adapter_spec.rb spec/unit/authorization/controller_authorization_spec.rb spec/unit/batch_actions/settings_spec.rb spec/unit/cancan_adapter_spec.rb spec/unit/devise_spec.rb spec/unit/filters/active_spec.rb spec/unit/form_builder_spec.rb spec/unit/generators/install_spec.rb spec/unit/helpers/scope_chain_spec.rb spec/unit/order_clause_spec.rb spec/unit/page_controller_spec.rb spec/unit/resource/naming_spec.rb spec/unit/resource/page_presenters_spec.rb spec/unit/resource/scopes_spec.rb spec/unit/resource_collection_spec.rb spec/unit/resource_spec.rb spec/unit/scope_spec.rb spec/unit/view_helpers/breadcrumbs_spec.rb spec/unit/view_helpers/download_format_links_helper_spec.rb spec/unit/views/components/columns_spec.rb spec/unit/views/components/index_table_for_spec.rb spec/unit/views/components/tabs_spec.rb spec/unit/views/pages/index_spec.rb
bundle exec rspec --color --tty -O .rspec_parallel spec/unit/application_spec.rb spec/unit/asset_registration_spec.rb spec/unit/comments_spec.rb spec/unit/component_spec.rb spec/unit/dsl_spec.rb spec/unit/dynamic_settings_spec.rb spec/unit/helpers/collection_spec.rb spec/unit/page_spec.rb spec/unit/pretty_format_spec.rb spec/unit/resource/menu_spec.rb spec/unit/resource/pagination_spec.rb spec/unit/resource/routes_spec.rb spec/unit/resource/sidebars_spec.rb spec/unit/resource_controller/data_access_spec.rb spec/unit/routing_spec.rb spec/unit/view_helpers/fields_for_spec.rb spec/unit/view_helpers/flash_helper_spec.rb spec/unit/views/components/attributes_table_spec.rb spec/unit/views/components/batch_action_selector_spec.rb spec/unit/views/components/blank_slate_spec.rb spec/unit/views/components/sidebar_section_spec.rb spec/unit/views/components/site_title_spec.rb spec/unit/views/pages/base_spec.rb spec/unit/views/pages/form_spec.rb

Run options:
  include {:focus=>true}
  exclude {:skip=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 39463
..............................................................................................................................................................................................................

Finished in 18.31 seconds (files took 3.71 seconds to load)
206 examples, 0 failures

Randomized with seed 39463

Run options:
  include {:focus=>true}
  exclude {:skip=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 33765
..............................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 25.72 seconds (files took 3.75 seconds to load)
414 examples, 0 failures

Randomized with seed 33765

Run options:
  include {:focus=>true}
  exclude {:skip=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 20343
..................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 27.55 seconds (files took 3.72 seconds to load)
402 examples, 0 failures

Randomized with seed 20343

Run options:
  include {:focus=>true}
  exclude {:skip=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 11912
....................................................................................................................................................................................................................................................................................................

Finished in 42.39 seconds (files took 3.73 seconds to load)
292 examples, 0 failures

Randomized with seed 11912


1314 examples, 0 failures

Took 48 seconds
```

#### After

```
Using recorded test runtime
4 processes for 98 specs, ~ 24 specs per process

bundle exec rspec --color --tty -O .rspec_parallel spec/bug_report_templates_spec.rb spec/unit/abstract_view_factory_spec.rb spec/unit/action_builder_spec.rb spec/unit/cancan_adapter_spec.rb spec/unit/controller_filters_spec.rb spec/unit/devise_spec.rb spec/unit/form_builder_spec.rb spec/unit/helpers/collection_spec.rb spec/unit/localizers/resource_localizer_spec.rb spec/unit/menu_collection_spec.rb spec/unit/menu_spec.rb spec/unit/namespace/authorization_spec.rb spec/unit/page_controller_spec.rb spec/unit/resource/action_items_spec.rb spec/unit/resource/pagination_spec.rb spec/unit/resource/scopes_spec.rb spec/unit/resource/sidebars_spec.rb spec/unit/resource_controller/decorators_spec.rb spec/unit/resource_registration_spec.rb spec/unit/scope_spec.rb spec/unit/view_helpers/form_helper_spec.rb spec/unit/views/components/attributes_table_spec.rb spec/unit/views/components/batch_action_selector_spec.rb spec/unit/views/components/menu_item_spec.rb spec/unit/views/components/tabs_spec.rb
Run options:
  include {:focus=>true}
  exclude {:skip=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 29165
........................................................................................................................................................................................................................................................................................................................................................

Finished in 16.34 seconds (files took 3.69 seconds to load)
344 examples, 0 failures

Randomized with seed 29165

bundle exec rspec --color --tty -O .rspec_parallel spec/requests/default_namespace_spec.rb spec/unit/asset_registration_spec.rb spec/unit/authorization/controller_authorization_spec.rb spec/unit/auto_link_spec.rb spec/unit/batch_actions/settings_spec.rb spec/unit/csv_builder_spec.rb spec/unit/filters/active_filter_spec.rb spec/unit/filters/filter_form_builder_spec.rb spec/unit/filters/resource_spec.rb spec/unit/helpers/scope_chain_spec.rb spec/unit/menu_item_spec.rb spec/unit/namespace/register_page_spec.rb spec/unit/pretty_format_spec.rb spec/unit/resource/includes_spec.rb spec/unit/resource/page_presenters_spec.rb spec/unit/resource_collection_spec.rb spec/unit/resource_controller/sidebars_spec.rb spec/unit/view_factory_spec.rb spec/unit/view_helpers/display_helper_spec.rb spec/unit/view_helpers/flash_helper_spec.rb spec/unit/views/components/sidebar_section_spec.rb spec/unit/views/components/sidebar_spec.rb spec/unit/views/components/unsupported_browser_spec.rb spec/unit/views/pages/form_spec.rb
Run options:
  include {:focus=>true}
  exclude {:skip=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 56101
................................................................................................................................................................................................................................................................................................................................................

Finished in 21.84 seconds (files took 3.67 seconds to load)
336 examples, 0 failures

Randomized with seed 56101

bundle exec rspec --color --tty -O .rspec_parallel spec/requests/memory_spec.rb spec/unit/authorization/authorization_adapter_spec.rb spec/unit/authorization/index_overriding_spec.rb spec/unit/batch_actions/resource_spec.rb spec/unit/belongs_to_spec.rb spec/unit/comments_spec.rb spec/unit/filters/active_spec.rb spec/unit/generators/install_spec.rb spec/unit/namespace/register_resource_spec.rb spec/unit/page_spec.rb spec/unit/pundit_adapter_spec.rb spec/unit/resource/ordering_spec.rb spec/unit/resource/routes_spec.rb spec/unit/resource_controller/data_access_spec.rb spec/unit/resource_controller_spec.rb spec/unit/settings_node_spec.rb spec/unit/view_helpers/breadcrumbs_spec.rb spec/unit/view_helpers/fields_for_spec.rb spec/unit/view_helpers/method_or_proc_helper_spec.rb spec/unit/views/components/columns_spec.rb spec/unit/views/components/index_list_spec.rb spec/unit/views/components/paginated_collection_spec.rb spec/unit/views/index_as_blog_spec.rb spec/unit/views/pages/index_spec.rb spec/unit/views/pages/show_spec.rb
Run options:
  include {:focus=>true}
  exclude {:skip=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 61815
....................................................................................................................................................................................................................................................................................................

Finished in 30.58 seconds (files took 3.73 seconds to load)
292 examples, 0 failures

Randomized with seed 61815

bundle exec rspec --color --tty -O .rspec_parallel spec/requests/stylesheets_spec.rb spec/unit/active_admin_spec.rb spec/unit/application_spec.rb spec/unit/component_spec.rb spec/unit/dependency_spec.rb spec/unit/dsl_spec.rb spec/unit/dynamic_settings_spec.rb spec/unit/namespace_spec.rb spec/unit/order_clause_spec.rb spec/unit/resource/attributes_spec.rb spec/unit/resource/menu_spec.rb spec/unit/resource/naming_spec.rb spec/unit/resource_spec.rb spec/unit/routing_spec.rb spec/unit/view_helpers/download_format_links_helper_spec.rb spec/unit/views/components/blank_slate_spec.rb spec/unit/views/components/index_table_for_spec.rb spec/unit/views/components/menu_spec.rb spec/unit/views/components/panel_spec.rb spec/unit/views/components/site_title_spec.rb spec/unit/views/components/status_tag_spec.rb spec/unit/views/components/table_for_spec.rb spec/unit/views/pages/base_spec.rb spec/unit/views/pages/layout_spec.rb
Run options:
  include {:focus=>true}
  exclude {:skip=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 1709
......................................................................................................................................................................................................................................................................................................................................................

Finished in 34.73 seconds (files took 3.68 seconds to load)
342 examples, 0 failures

Randomized with seed 1709


1314 examples, 0 failures

Took 41 seconds
```