### PR TITLE
Update formatter to use Cucumber events API instead of deprecated API

### DIFF
--- a/lib/parallel_tests/gherkin/runtime_logger.rb
+++ b/lib/parallel_tests/gherkin/runtime_logger.rb
@@ -18,7 +18,9 @@ module ParallelTests
         end
 
         config.on_event :test_run_finished do |_|
-          @io.puts @example_times.map { |file, time| "#{file}:#{time}" }
+          lock_output do
+            @io.puts @example_times.map { |file, time| "#{file}:#{time}" }
+          end
         end
       end
     end


### PR DESCRIPTION
This PR updates the Gherkin runtime_logger formatter to use the new Cucumber events API. This shouldn't affect application behaviour but will fix the deprecation warnings brought up in [this issue against Cucumber](https://github.com/cucumber/cucumber-ruby/issues/1294).