### PR TITLE
Support alternate rails environment names for tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parallel_tests (2.26.0)
+    parallel_tests (2.26.1)
       parallel
 
 GEM
@@ -74,4 +74,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.16.1
+   1.16.5

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -14,7 +14,7 @@ module ParallelTests
 
       def purge_before_load
         if Gem::Version.new(Rails.version) > Gem::Version.new('4.2.0')
-          Rake::Task.task_defined?('db:test:purge') ? 'db:test:purge' : 'app:db:test:purge'
+          Rake::Task.task_defined?('db:purge') ? 'db:purge' : 'app:db:purge'
         end
       end
 

--- a/lib/parallel_tests/version.rb
+++ b/lib/parallel_tests/version.rb
@@ -1,3 +1,3 @@
 module ParallelTests
-  VERSION = Version = '2.26.0'
+  VERSION = Version = '2.26.1'
 end

--- a/spec/fixtures/rails51/Gemfile.lock
+++ b/spec/fixtures/rails51/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    parallel_tests (2.25.0)
+    parallel_tests (2.26.0)
       parallel
 
 GEM

--- a/spec/fixtures/rails52/Gemfile.lock
+++ b/spec/fixtures/rails52/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    parallel_tests (2.25.0)
+    parallel_tests (2.26.0)
       parallel
 
 GEM

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -194,16 +194,16 @@ describe ParallelTests::Tasks do
         stub_const('Rails', double(version: '4.2.8'))
       end
 
-      it "should return db:test:purge when defined" do
-        allow(Rake::Task).to receive(:task_defined?).with('db:test:purge') { true }
+      it "should return db:purge when defined" do
+        allow(Rake::Task).to receive(:task_defined?).with('db:purge') { true }
 
-        expect(ParallelTests::Tasks.purge_before_load).to eq 'db:test:purge'
+        expect(ParallelTests::Tasks.purge_before_load).to eq 'db:purge'
       end
 
-      it "should return app:db:test:purge when db:test:purge is not defined" do
-        allow(Rake::Task).to receive(:task_defined?).with('db:test:purge') { false }
+      it "should return app:db:purge when db:purge is not defined" do
+        allow(Rake::Task).to receive(:task_defined?).with('db:purge') { false }
 
-        expect(ParallelTests::Tasks.purge_before_load).to eq 'app:db:test:purge'
+        expect(ParallelTests::Tasks.purge_before_load).to eq 'app:db:purge'
       end
     end
   end


### PR DESCRIPTION
## Changes

Switches to using [`db:purge`](https://github.com/rails/rails/blob/58999af99fa485f748ab33d4aa4254a4b4a50991/activerecord/lib/active_record/railties/databases.rake#L69) over [`db:test:purge`](https://github.com/rails/rails/blob/58999af99fa485f748ab33d4aa4254a4b4a50991/activerecord/lib/active_record/railties/databases.rake#L380).

`db:purge`:
> desc "Empty the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:purge:all to purge all databases in the config). Without RAILS_ENV it defaults to purging the development and test databases."

`db:test:purge` hardcodes loading configuration for an environment named test. `db:purge` will load the environment for whatever `RAILS_ENV` is set to (or fallback).

Here within parallel_tests `purge_before_load` is used on lines that support passing through alternate env's (`RAILS_ENV=#{ParallelTests::Tasks.rails_env}`).

## Usecase

I'm trying to run parallel_tests in it's own rails environment i'm naming `parallel_test` -- this is so I can specify a few custom environment options directly for parallel runs and so i can run one of tests against a separate environment (and db config) while my parallel test suite is running.

This should be backwards compatible while expanding flexibility.

## Other

Wasn't sure how you are handling versioning so did a patch level bump.
