### PR TITLE
Simulate output for CI after the first parallel thread finishes

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -44,7 +44,6 @@ module ParallelTests
 
           test_results = Parallel.map(items, :in_threads => num_processes) do |item|
             result = yield(item)
-            puts if progress_indicator && progress_indicator.alive?
             reprint_output(result, lock.path) if options[:serialize_stdout]
             result
           end
@@ -97,6 +96,7 @@ module ParallelTests
 
     def reprint_output(result, lockfile)
       lock(lockfile) do
+        $stdout.puts
         $stdout.puts result[:stdout]
         $stdout.flush
       end

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -45,7 +45,6 @@ module ParallelTests
           Parallel.map(items, :in_threads => num_processes) do |item|
             result = yield(item)
             if progress_indicator && progress_indicator.alive?
-              progress_indicator.exit
               puts
             end
             reprint_output(result, lock.path) if options[:serialize_stdout]

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -44,9 +44,7 @@ module ParallelTests
 
           Parallel.map(items, :in_threads => num_processes) do |item|
             result = yield(item)
-            if progress_indicator && progress_indicator.alive?
-              puts
-            end
+            puts if progress_indicator && progress_indicator.alive?
             reprint_output(result, lock.path) if options[:serialize_stdout]
             result
           end

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -42,12 +42,14 @@ module ParallelTests
         ParallelTests.with_pid_file do
           progress_indicator = simulate_output_for_ci if options[:serialize_stdout]
 
-          Parallel.map(items, :in_threads => num_processes) do |item|
+          test_results = Parallel.map(items, :in_threads => num_processes) do |item|
             result = yield(item)
             puts if progress_indicator && progress_indicator.alive?
             reprint_output(result, lock.path) if options[:serialize_stdout]
             result
           end
+          progress_indicator.exit if progress_indicator && progress_indicator.alive?
+          test_results
         end
       end
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -143,7 +143,7 @@ describe 'CLI' do
     write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){sleep 1; puts "TEST2"}}'
     result = run_tests "spec", :type => 'rspec', :add => "--serialize-stdout", export: {'PARALLEL_TEST_HEARTBEAT_INTERVAL' => '0.1'}
 
-    expect(result).to match(/\.{5}.*TEST1.*\.{5}.*TEST2/m)
+    expect(result).to match(/\.{4}.*TEST1.*\.{4}.*TEST2/m)
   end
 
   it "can show simulated output preceded by command when serializing stdout with verbose option" do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -140,9 +140,10 @@ describe 'CLI' do
 
   it "can show simulated output when serializing stdout" do
     write 'spec/xxx_spec.rb', 'describe("it"){it("should"){sleep 1; puts "TEST1"}}'
+    write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){sleep 2; puts "TEST2"}}'
     result = run_tests "spec", :type => 'rspec', :add => "--serialize-stdout", export: {'PARALLEL_TEST_HEARTBEAT_INTERVAL' => '0.2'}
 
-    expect(result).to match(/\.{5}.*TEST1/m)
+    expect(result).to match(/\.{5}.*TEST1.*\.{5}TEST2/m)
   end
 
   it "can show simulated output preceded by command when serializing stdout with verbose option" do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -143,7 +143,7 @@ describe 'CLI' do
     write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){sleep 2; puts "TEST2"}}'
     result = run_tests "spec", :type => 'rspec', :add => "--serialize-stdout", export: {'PARALLEL_TEST_HEARTBEAT_INTERVAL' => '0.2'}
 
-    expect(result).to match(/\.{5}.*TEST1.*\.{5}TEST2/m)
+    expect(result).to match(/\.{5}.*TEST1.*\.{5}.*TEST2/m)
   end
 
   it "can show simulated output preceded by command when serializing stdout with verbose option" do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -139,9 +139,9 @@ describe 'CLI' do
   end
 
   it "can show simulated output when serializing stdout" do
-    write 'spec/xxx_spec.rb', 'describe("it"){it("should"){sleep 1; puts "TEST1"}}'
-    write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){sleep 2; puts "TEST2"}}'
-    result = run_tests "spec", :type => 'rspec', :add => "--serialize-stdout", export: {'PARALLEL_TEST_HEARTBEAT_INTERVAL' => '0.2'}
+    write 'spec/xxx_spec.rb', 'describe("it"){it("should"){sleep 0.5; puts "TEST1"}}'
+    write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){sleep 1; puts "TEST2"}}'
+    result = run_tests "spec", :type => 'rspec', :add => "--serialize-stdout", export: {'PARALLEL_TEST_HEARTBEAT_INTERVAL' => '0.1'}
 
     expect(result).to match(/\.{5}.*TEST1.*\.{5}.*TEST2/m)
   end


### PR DESCRIPTION
I'm having a problem when running parallel tests with the `--serialize-stdout` flag, where our CI times out due to receiving no stdout _after_ the first parallel thread finishes, but before other threads are finished. 

The [simulate_output_for_ci](https://github.com/grosser/parallel_tests/blob/06656a00f5a18a5703e7728ed8614827d3ec0409/lib/parallel_tests/cli.rb#L334-L342) method (from issue #512) fixes this issue up to the point when the first parallel thread finishes by printing a dot (`.`) to stdout every 60 seconds, but does not continue printing output after the first parallel thread finishes. I am proposing the dots should continue being printed to stdout until all parallel threads are finished.

An example of when this problem might occur. My CI times out after 5 minutes without output. I run `parallel_rspec -n 2 spec` and unfortunately get two very uneven groups of tests. The first group finishes in 6 minutes and does not time out because a dot is printed to stdout every 60 seconds up to that point. The second group takes 12 minutes total, but the CI times out 5 minutes after the first group finished due to no output in that time.

Unfortunately, I don't know how to write the code to make this happen, but in TDD fashion I believe I have written a failing test to illustrate the problem (more specifically, I have modified an existing test). This test can be used to develop the solution. As soon as it is passing the feature will be complete.

I would be happy to help write the code for this feature if it helps, but I would need some assistance getting started.

Thank you for all you do on this project. I really appreciate your time.