### PR TITLE
Add new command-line options to provide finer control of verbose output.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,8 @@ matrix:
     - rvm: jruby-head
   fast_finish: true
 bundler_args: "--jobs 4"
+# See: https://docs.travis-ci.com/user/languages/ruby/#bundler-20
+# and https://travis-ci.org/grosser/parallel_tests/jobs/528217778
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,4 +74,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.16.5
+   1.17.3

--- a/Readme.md
+++ b/Readme.md
@@ -225,6 +225,8 @@ Options are:
         --allowed-missing            Allowed percentage of missing runtimes (default = 50)
         --unknown-runtime [FLOAT]    Use given number as unknown runtime (otherwise use average time)
         --verbose                    Print more output
+        --verbose-process-command    Print the command that will be executed by each process before it begins, even if --verbose is not set, or if --quiet is set.
+        --verbose-rerun-command      After a process fails, print the command executed by that process, even if --verbose is not set, or if --quiet is set.
         --quiet                      Do not print anything, apart from test output
     -v, --version                    Show Version
     -h, --help                       Show this.

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -124,7 +124,7 @@ module ParallelTests
       failing_sets = test_results.reject { |r| r[:exit_status] == 0 }
       return if failing_sets.none?
 
-      if options[:verbose]
+      if options[:verbose] || options[:verbose_rerun_command]
         puts "\n\nTests have failed for a parallel_test group. Use the following command to run the group again:\n\n"
         failing_sets.each do |failing_set|
           command = failing_set[:command]
@@ -221,6 +221,8 @@ module ParallelTests
         opts.on("--first-is-1", "Use \"1\" as TEST_ENV_NUMBER to not reuse the default test environment") { options[:first_is_1] = true }
         opts.on("--verbose", "Print more output (mutually exclusive with quiet)") { options[:verbose] = true }
         opts.on("--quiet", "Print tests output only (mutually exclusive with verbose)") { options[:quiet] = true }
+        opts.on("--verbose-process-command", "Displays the command that will be executed by each process, even if --verbose is not set, or --quiet is set") { options[:verbose_process_command] = true }
+        opts.on("--verbose-rerun-command", "When there are failures, displays the command executed by each process that failed, even if --verbose is not set, or --quiet is set") { options[:verbose_rerun_command] = true }
         opts.on("-v", "--version", "Show Version") { puts ParallelTests::VERSION; exit }
         opts.on("-h", "--help", "Show this.") { puts opts; exit }
       end.parse!(argv)

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -78,7 +78,7 @@ module ParallelTests
           cmd = "nice #{cmd}" if options[:nice]
           cmd = "#{cmd} 2>&1" if options[:combine_stderr]
 
-          puts cmd if options[:verbose] && !options[:serialize_stdout]
+          puts cmd if report_process_command?(options) && !options[:serialize_stdout]
 
           execute_command_and_capture_output(env, cmd, options)
         end
@@ -94,9 +94,15 @@ module ParallelTests
           exitstatus = $?.exitstatus
           seed = output[/seed (\d+)/,1]
 
-          output = [cmd, output].join("\n") if options[:verbose] && options[:serialize_stdout]
+          if report_process_command?(options) && options[:serialize_stdout]
+            output = [cmd, output].join("\n")
+          end
 
           {:stdout => output, :exit_status => exitstatus, :command => cmd, :seed => seed}
+        end
+
+        private def report_process_command?(options)
+          options[:verbose] || options[:verbose_process_command]
         end
 
         def find_results(test_output)

--- a/spec/fixtures/rails51/Gemfile.lock
+++ b/spec/fixtures/rails51/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    parallel_tests (2.27.1)
+    parallel_tests (2.28.0)
       parallel
 
 GEM
@@ -65,7 +65,7 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
-    parallel (1.13.0)
+    parallel (1.17.0)
     rack (2.0.5)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -119,4 +119,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/spec/fixtures/rails52/Gemfile.lock
+++ b/spec/fixtures/rails52/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    parallel_tests (2.27.1)
+    parallel_tests (2.28.0)
       parallel
 
 GEM
@@ -72,7 +72,7 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
-    parallel (1.13.0)
+    parallel (1.17.0)
     rack (2.0.5)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -127,4 +127,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.16.6
+   1.17.3


### PR DESCRIPTION
--verbose currently displays both the command to be executed by each parallel
process before the tests run, and, on failure of a process, the command
needed to rerun the failing process.

We prefer to display only the latter.

This patch adds flags that can be used instead of --verbose to enable
either the per-process command, or the rerun command, or both.

--verbose-process-command will show the per-process commands, even if
--verbose is not set, or --quiet is set.

--verbose-rerun-command will show the rerun command, even if --verbose
is not set, or --quiet is set.

If --verbose is set, both types of command will be displayed, regardless
of whether the flags for those commands are set or not.