### PR TITLE
(option 2) Add new command-line options to provide finer control of verbose output.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,8 @@ matrix:
     - rvm: jruby-head
   fast_finish: true
 bundler_args: "--jobs 4"
+# See: https://docs.travis-ci.com/user/languages/ruby/#bundler-20
+# and https://travis-ci.org/grosser/parallel_tests/jobs/528217778
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,4 +74,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.16.5
+   1.17.3

--- a/Readme.md
+++ b/Readme.md
@@ -226,6 +226,10 @@ Options are:
         --unknown-runtime [FLOAT]    Use given number as unknown runtime (otherwise use average time)
         --verbose                    Print more output
         --quiet                      Do not print anything, apart from test output
+        --report-executed-command    Displays the command that will be executed by each process, even if --verbose is not set, or --quiet is set
+        --no-report-executed-command If --verbose is set, does not display the command that will be executed by each process
+        --report-rerun-command       When there are failures, displays the command executed by each process that failed, even if --verbose is not set, or --quiet is set
+        --no-report-rerun-command    If --verbose is set, does not display the command executed by each process that failed
     -v, --version                    Show Version
     -h, --help                       Show this.
 

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -78,9 +78,17 @@ module ParallelTests
           cmd = "nice #{cmd}" if options[:nice]
           cmd = "#{cmd} 2>&1" if options[:combine_stderr]
 
-          puts cmd if options[:verbose] && !options[:serialize_stdout]
+          puts cmd if report_executed_command?(options) && !options[:serialize_stdout]
 
           execute_command_and_capture_output(env, cmd, options)
+        end
+
+        private def report_executed_command?(options)
+          options[:report_executed_command] || (
+            # check for false explicitly because it should report if the
+            # option is unset
+            options[:verbose] && options[:report_executed_command] != false
+          )
         end
 
         def execute_command_and_capture_output(env, cmd, options)
@@ -94,7 +102,7 @@ module ParallelTests
           exitstatus = $?.exitstatus
           seed = output[/seed (\d+)/,1]
 
-          output = [cmd, output].join("\n") if options[:verbose] && options[:serialize_stdout]
+          output = [cmd, output].join("\n") if report_executed_command?(options) && options[:serialize_stdout]
 
           {:stdout => output, :exit_status => exitstatus, :command => cmd, :seed => seed}
         end

--- a/spec/fixtures/rails51/Gemfile.lock
+++ b/spec/fixtures/rails51/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    parallel_tests (2.27.1)
+    parallel_tests (2.28.0)
       parallel
 
 GEM
@@ -65,7 +65,7 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
-    parallel (1.13.0)
+    parallel (1.17.0)
     rack (2.0.5)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -119,4 +119,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/spec/fixtures/rails52/Gemfile.lock
+++ b/spec/fixtures/rails52/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    parallel_tests (2.27.1)
+    parallel_tests (2.28.0)
       parallel
 
 GEM
@@ -72,7 +72,7 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
-    parallel (1.13.0)
+    parallel (1.17.0)
     rack (2.0.5)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -127,4 +127,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -111,12 +111,75 @@ describe 'CLI' do
     expect(result).to include('Took')
   end
 
-  it "shows command with --verbose" do
-    write 'spec/xxx_spec.rb', 'describe("it"){it("should"){puts "TEST1"}}'
-    write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){expect(1).to eq(1)}}'
-    result = run_tests "spec --verbose", :type => 'rspec'
-    expect(result).to include "bundle exec rspec spec/xxx_spec.rb"
-    expect(result).to include "bundle exec rspec spec/xxx2_spec.rb"
+  # TODO: The integration test feels like the wrong place to test all these
+  # cases. Maybe they could be tested using unit tests like with the
+  # describe ".report_failure_rerun_commmand" block in
+  # parallel_tests/cli_spec.rb, with a minimal integration test to ensure
+  # things are hooked up correctly.
+  context 'command output' do
+    let(:spec_1_command) { 'bundle exec rspec spec/xxx_spec.rb' }
+    let(:spec_2_command) { 'bundle exec rspec spec/xxx2_spec.rb' }
+
+    shared_examples :not_verbose_command do
+      it 'does not output the command to be executed' do
+        expect(result).not_to include spec_1_command
+        expect(result).not_to include spec_2_command
+      end
+    end
+
+    shared_examples :verbose_command do
+      it 'outputs the command to be executed' do
+        expect(result).to include spec_1_command
+        expect(result).to include spec_2_command
+      end
+    end
+
+    before do
+      write 'spec/xxx_spec.rb', 'describe("it"){it("should"){puts "TEST1"}}'
+      write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){expect(1).to eq(1)}}'
+    end
+
+    let(:result) { run_tests('spec', add: flags, type: 'rspec') }
+
+    context 'without --verbose' do
+      context 'without any report-executed-command option' do
+        let(:flags) { '' }
+
+        include_examples :not_verbose_command
+      end
+
+      context 'with --no-report-executed-command' do
+        let(:flags) { '--no-report-executed-command' }
+
+        include_examples :not_verbose_command
+      end
+
+      context 'with --report-executed-command' do
+        let(:flags) { '--report-executed-command' }
+
+        include_examples :verbose_command
+      end
+    end
+
+    context 'with --verbose' do
+      context 'without any report-executed-command option' do
+        let(:flags) { '--verbose' }
+
+        include_examples :verbose_command
+      end
+
+      context 'with --no-report-executed-command' do
+        let(:flags) { '--verbose --no-report-executed-command' }
+
+        include_examples :not_verbose_command
+      end
+
+      context 'with --report-executed-command' do
+        let(:flags) { '--verbose --report-executed-command' }
+
+        include_examples :verbose_command
+      end
+    end
   end
 
   it "fails when tests fail" do
@@ -323,12 +386,86 @@ describe 'CLI' do
   context "RSpec" do
     it_fails_without_any_files "rspec"
 
-    it "captures seed with random failures with --verbose" do
-      write 'spec/xxx_spec.rb', 'describe("it"){it("should"){puts "TEST1"}}'
-      write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){1.should == 2}}'
-      result = run_tests "spec --verbose", :add => "--test-options '--seed 1234'", :fail => true, :type => 'rspec'
-      expect(result).to include("Randomized with seed 1234")
-      expect(result).to include("bundle exec rspec spec/xxx2_spec.rb --seed 1234")
+    context 'with rspec files' do
+      before do
+        write 'spec/xxx_spec.rb', 'describe("it"){it("should"){puts "TEST1"}}'
+        write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){expect(1).to eq(2)}}'
+      end
+
+      it "outputs seed with random failures" do
+        result = run_tests(
+          'spec', add: "--test-options '--seed 1234'", fail: true, type: 'rspec'
+        )
+
+        expect(result).to include("Randomized with seed 1234")
+      end
+
+      let(:cmd_output_regexp) do
+        # The check for TEST1 is to distinguish the executed command output
+        # from the rerun command output.
+        %r{bundle exec rspec --seed 1234 spec/xxx2_spec.*TEST1}m
+      end
+
+      shared_examples :not_verbose_command do
+        it 'does not output the command to be executed' do
+          expect(result).not_to match(cmd_output_regexp)
+        end
+      end
+
+      shared_examples :verbose_command do
+        it 'outputs the command to be executed' do
+          expect(result).to match(cmd_output_regexp)
+        end
+      end
+
+      let(:result) do
+        run_tests(
+          'spec',
+          add: "#{flags} --test-options '--seed 1234'",
+          fail: true,
+          type: 'rspec'
+        )
+      end
+
+      context 'without --verbose' do
+        context 'without any report-executed-command option' do
+          let(:flags) { '' }
+
+          include_examples :not_verbose_command
+        end
+
+        context 'with --no-report-executed-command' do
+          let(:flags) { '--no-report-executed-command' }
+
+          include_examples :not_verbose_command
+        end
+
+        context 'with --report-executed-command' do
+          let(:flags) { '--report-executed-command' }
+
+          include_examples :verbose_command
+        end
+      end
+
+      context 'with --verbose' do
+        context 'without any report-executed-command option' do
+          let(:flags) { '--verbose' }
+
+          include_examples :verbose_command
+        end
+
+        context 'with --no-report-executed-command' do
+          let(:flags) { '--verbose --no-report-executed-command' }
+
+          include_examples :not_verbose_command
+        end
+
+        context 'with --report-executed-command' do
+          let(:flags) { '--verbose --report-executed-command' }
+
+          include_examples :verbose_command
+        end
+      end
     end
   end
 
@@ -453,11 +590,84 @@ describe 'CLI' do
       expect(result).to include("2 processes for 2 features")
     end
 
-    it "captures seed with random failures with --verbose" do
-      write "features/good1.feature", "Feature: xxx\n  Scenario: xxx\n    Given I fail"
-      result = run_tests "features --verbose", :type => "cucumber", :add => '--test-options "--order random:1234"', :fail => true
+    it 'outputs seed with random failures' do
+      write 'features/good1.feature', "Feature: xxx\n  Scenario: xxx\n    Given I fail"
+
+      result = run_tests(
+        'features',
+        add: %q(--test-options "--order random:1234"),
+        fail: true,
+        type: 'cucumber'
+      )
       expect(result).to include("Randomized with seed 1234")
-      expect(result).to match(%r{bundle exec cucumber "?features/good1.feature"? --order random:1234})
+    end
+
+    context 'command output' do
+      let(:cmd_output_regexp) do
+        # The check for Feature: xxx is to distinguish the executed command output
+        # from the rerun command output.
+        %r{bundle exec cucumber "?features/good1.feature"?\nFeature: xxx}
+      end
+
+      shared_examples :not_verbose_command do
+        it 'does not output the command to be executed' do
+          expect(result).not_to match(cmd_output_regexp)
+        end
+      end
+
+      shared_examples :verbose_command do
+        it 'outputs the command to be executed' do
+          expect(result).to match(cmd_output_regexp)
+        end
+      end
+
+      before do
+        write 'features/good1.feature', "Feature: xxx\n  Scenario: xxx\n    Given I fail"
+      end
+
+      let(:result) do
+        run_tests('features', add: flags, fail: true, type: 'cucumber')
+      end
+
+      context 'without --verbose' do
+        context 'without any report-executed-command option' do
+          let(:flags) { '' }
+
+          include_examples :not_verbose_command
+        end
+
+        context 'with --no-report-executed-command' do
+          let(:flags) { '--no-report-executed-command' }
+
+          include_examples :not_verbose_command
+        end
+
+        context 'with --report-executed-command' do
+          let(:flags) { '--report-executed-command' }
+
+          include_examples :verbose_command
+        end
+      end
+
+      context 'with --verbose' do
+        context 'without any report-executed-command option' do
+          let(:flags) { '--verbose' }
+
+          include_examples :verbose_command
+        end
+
+        context 'with --no-report-executed-command' do
+          let(:flags) { '--verbose --no-report-executed-command' }
+
+          include_examples :not_verbose_command
+        end
+
+        context 'with --report-executed-command' do
+          let(:flags) { '--verbose --report-executed-command' }
+
+          include_examples :verbose_command
+        end
+      end
     end
   end
 

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -50,6 +50,42 @@ describe ParallelTests::CLI do
       expect(call(["test", "--verbose"])).to eq(defaults.merge(:verbose => true))
     end
 
+    it "parses --report-executed-command" do
+      expect(call(['test', '--report-executed-command'])).to eq(
+        defaults.merge(report_executed_command: true)
+      )
+    end
+
+    it "parses --no-report-executed-command" do
+      expect(call(['test', '--no-report-executed-command'])).to eq(
+        defaults.merge(report_executed_command: false)
+      )
+    end
+
+    it "fails if both --report-executed-command and --no-report-executed-command are present" do
+      expect do
+        call(["test", "--report-executed-command", "--no-report-executed-command"])
+      end.to raise_error(RuntimeError)
+    end
+
+    it "parses --report-rerun-command" do
+      expect(call(['test', '--report-rerun-command'])).to eq(
+        defaults.merge(report_rerun_command: true)
+      )
+    end
+
+    it "parses --no-report-rerun-command" do
+      expect(call(['test', '--no-report-rerun-command'])).to eq(
+        defaults.merge(report_rerun_command: false)
+      )
+    end
+
+    it "fails if both --report-rerun-command and --no-report-rerun-command are present" do
+      expect do
+        call(["test", "--report-rerun-command", "--no-report-rerun-command"])
+      end.to raise_error(RuntimeError)
+    end
+
     it "parses --quiet" do
       expect(call(["test", "--quiet"])).to eq(defaults.merge(:quiet => true))
     end
@@ -155,6 +191,21 @@ describe ParallelTests::CLI do
   end
 
   describe ".report_failure_rerun_commmand" do
+    let(:single_failure_message) do
+      "\n\nTests have failed for a parallel_test group. Use the " \
+      "following command to run the group again:\n\nfoo\n"
+    end
+    let(:single_failure_args) do
+      { exit_status: 1, command: 'foo', seed: nil, output: 'blah' }
+    end
+    let(:multiple_failure_args) do
+      [
+        single_failure_args,
+        { exit_status: 1, command: 'bar', seed: nil, output: 'blah' },
+        { exit_status: 1, command: 'baz', seed: nil, output: 'blah' }
+      ]
+    end
+
     it "prints nothing if there are no failures" do
       expect($stdout).not_to receive(:puts)
 
@@ -168,14 +219,61 @@ describe ParallelTests::CLI do
 
     shared_examples :not_verbose_rerun do |options|
       it 'prints nothing about rerun commands' do
-          expect {
-            subject.send(:report_failure_rerun_commmand,
-              [
-                {exit_status: 1, command: 'foo', seed: nil, output: 'blah'}
-              ],
-              options
-            )
-          }.to_not output(/Use the following command to run the group again/).to_stdout
+        expect {
+          subject.send(:report_failure_rerun_commmand,
+            [
+              {exit_status: 1, command: 'foo', seed: nil, output: 'blah'}
+            ],
+            options
+          )
+        }.to_not output(/Use the following command to run the group again/).to_stdout
+      end
+    end
+
+    shared_examples :verbose_rerun do |options|
+      it "prints a message and the command if there is a failure" do
+        expect {
+          subject.send(
+            :report_failure_rerun_commmand, [single_failure_args], options
+          )
+        }.to output(single_failure_message).to_stdout
+      end
+
+      it "prints multiple commands if there are multiple failures" do
+        expect {
+          subject.send(
+            :report_failure_rerun_commmand, multiple_failure_args, options
+          )
+        }.to output(/foo\nbar\nbaz/).to_stdout
+      end
+
+      it "only includes failures" do
+        expect {
+          subject.send(:report_failure_rerun_commmand,
+            [
+              {exit_status: 1, command: 'foo --color', seed: nil, output: 'blah'},
+              {exit_status: 0, command: 'bar', seed: nil, output: 'blah'},
+              {exit_status: 1, command: 'baz', seed: nil, output: 'blah'},
+            ],
+            options
+          )
+        }.to output(/foo --color\nbaz/).to_stdout
+      end
+
+      it "prints the command with the seed added by the runner" do
+        seed = 555
+        command = 'rspec --color spec/foo_spec.rb'
+        seed_message = "my seeded command result --seed #{seed}"
+
+        subject.instance_variable_set(:@runner, ParallelTests::Test::Runner)
+        expect(ParallelTests::Test::Runner).to receive(:command_with_seed).with(command, seed).
+          and_return(seed_message)
+        expect {
+          subject.send(
+            :report_failure_rerun_commmand,
+            [{ exit_status: 1, command: command, seed: seed, output: 'blah' }], options
+          )
+        }.to output(/#{seed_message}/).to_stdout
       end
     end
 
@@ -185,62 +283,26 @@ describe ParallelTests::CLI do
       end
 
       context 'with option !verbose' do
-        include_examples :not_verbose_rerun, {verbose: false}
+        context 'when option report_rerun_command is not set' do
+          include_examples :not_verbose_rerun, { verbose: false }
+        end
+
+        context 'when option report_rerun_command is false' do
+          include_examples :not_verbose_rerun, { report_rerun_command: false, verbose: false }
+        end
+
+        context 'when option report_rerun_command is set to true' do
+          include_examples :verbose_rerun, { report_rerun_command: true, verbose: false }
+        end
       end
 
       context 'with option verbose' do
-        it "prints a message and the command if there is a failure" do
-          expect {
-            subject.send(:report_failure_rerun_commmand,
-              [
-                {exit_status: 1, command: 'foo', seed: nil, output: 'blah'}
-              ],
-              {verbose: true}
-            )
-          }.to output("\n\nTests have failed for a parallel_test group. Use the following command to run the group again:\n\nfoo\n").to_stdout
+        context 'when option report_rerun_command is not set' do
+          include_examples :verbose_rerun, { verbose: true }
         end
 
-        it "prints multiple commands if there are multiple failures" do
-          expect {
-            subject.send(:report_failure_rerun_commmand,
-              [
-                {exit_status: 1, command: 'foo', seed: nil, output: 'blah'},
-                {exit_status: 1, command: 'bar', seed: nil, output: 'blah'},
-                {exit_status: 1, command: 'baz', seed: nil, output: 'blah'},
-              ],
-              {verbose: true}
-            )
-          }.to output(/foo\nbar\nbaz/).to_stdout
-        end
-
-        it "only includes failures" do
-          expect {
-            subject.send(:report_failure_rerun_commmand,
-              [
-                {exit_status: 1, command: 'foo --color', seed: nil, output: 'blah'},
-                {exit_status: 0, command: 'bar', seed: nil, output: 'blah'},
-                {exit_status: 1, command: 'baz', seed: nil, output: 'blah'},
-              ],
-              {verbose: true}
-            )
-          }.to output(/foo --color\nbaz/).to_stdout
-        end
-
-        it "prints the command with the seed added by the runner" do
-          command = 'rspec --color spec/foo_spec.rb'
-          seed = 555
-
-          subject.instance_variable_set(:@runner, ParallelTests::Test::Runner)
-          expect(ParallelTests::Test::Runner).to receive(:command_with_seed).with(command, seed).
-            and_return("my seeded command result --seed #{seed}")
-          expect {
-            subject.send(:report_failure_rerun_commmand,
-              [
-                {exit_status: 1, command: command, seed: 555, output: 'blah'},
-              ],
-              {verbose: true}
-            )
-          }.to output(/my seeded command result --seed 555/).to_stdout
+        context 'when option report_rerun_command is false' do
+          include_examples :not_verbose_rerun, { report_rerun_command: false, verbose: true }
         end
       end
     end


### PR DESCRIPTION
This was the approach that I took first, but then discarded in favor of the approach in https://github.com/grosser/parallel_tests/pull/694

I switched because:
 - None of the other command-line switches use the --[no-]option-name style
 - Adding 4 options instead of 2 increased the logical complexity, and number of test cases required
 - There didn't seem to be much value in specifying --verbose and then suppressing some of the --verbose output using negative flags

However, if you disagree with these reasons, then I'm happy to switch back to this track.

==== original summary ====

--verbose currently displays both the command to be executed by each parallel
process before the tests run, and, on failure of a process, the command
needed to rerun the failing process.

We prefer to display only the latter.

This patch adds flags that can be used alone or in combination with
--verbose to fine-tune the output.

--verbose with --no-report-executed-command will show the rerun command
as well as any other output that --verbose controls, but will not
display the per-process commands before the tests start.

--report-executed-command without --verbose will show only the
per-process commands.

--verbose with --no-report-rerun-command will show the per-process
commands and any other output that --verbose controls, but will not show
the rerun commands when tests fail.

--report-rerun-command without --verbose will show only the rerun
commands.