### PR TITLE
add additional verbosity options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -224,8 +224,10 @@ Options are:
         --runtime-log [PATH]         Location of previously recorded test runtimes
         --allowed-missing            Allowed percentage of missing runtimes (default = 50)
         --unknown-runtime [FLOAT]    Use given number as unknown runtime (otherwise use average time)
-        --verbose                    Print more output
-        --quiet                      Do not print anything, apart from test output
+        --verbose                    Print debug output
+        --verbose-process-command    Print the command that will be executed by each process before it begins
+        --verbose-rerun-command      After a process fails, print the command executed by that process
+        --quiet                      Print only test output
     -v, --version                    Show Version
     -h, --help                       Show this.
 

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -124,7 +124,7 @@ module ParallelTests
       failing_sets = test_results.reject { |r| r[:exit_status] == 0 }
       return if failing_sets.none?
 
-      if options[:verbose]
+      if options[:verbose] || options[:verbose_rerun_command]
         puts "\n\nTests have failed for a parallel_test group. Use the following command to run the group again:\n\n"
         failing_sets.each do |failing_set|
           command = failing_set[:command]
@@ -219,8 +219,10 @@ module ParallelTests
         opts.on("--allowed-missing [INT]", Integer, "Allowed percentage of missing runtimes (default = 50)") { |percent| options[:allowed_missing_percent] = percent }
         opts.on("--unknown-runtime [FLOAT]", Float, "Use given number as unknown runtime (otherwise use average time)") { |time| options[:unknown_runtime] = time }
         opts.on("--first-is-1", "Use \"1\" as TEST_ENV_NUMBER to not reuse the default test environment") { options[:first_is_1] = true }
-        opts.on("--verbose", "Print more output (mutually exclusive with quiet)") { options[:verbose] = true }
-        opts.on("--quiet", "Print tests output only (mutually exclusive with verbose)") { options[:quiet] = true }
+        opts.on("--verbose", "Print debug output") { options[:verbose] = true }
+        opts.on("--verbose-process-command", "Displays only the command that will be executed by each process") { options[:verbose_process_command] = true }
+        opts.on("--verbose-rerun-command", "When there are failures, displays the command executed by each process that failed") { options[:verbose_rerun_command] = true }
+        opts.on("--quiet", "Print only tests output") { options[:quiet] = true }
         opts.on("-v", "--version", "Show Version") { puts ParallelTests::VERSION; exit }
         opts.on("-h", "--help", "Show this.") { puts opts; exit }
       end.parse!(argv)

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -78,7 +78,7 @@ module ParallelTests
           cmd = "nice #{cmd}" if options[:nice]
           cmd = "#{cmd} 2>&1" if options[:combine_stderr]
 
-          puts cmd if options[:verbose] && !options[:serialize_stdout]
+          puts cmd if report_process_command?(options) && !options[:serialize_stdout]
 
           execute_command_and_capture_output(env, cmd, options)
         end
@@ -94,7 +94,9 @@ module ParallelTests
           exitstatus = $?.exitstatus
           seed = output[/seed (\d+)/,1]
 
-          output = [cmd, output].join("\n") if options[:verbose] && options[:serialize_stdout]
+          if report_process_command?(options) && options[:serialize_stdout]
+            output = [cmd, output].join("\n")
+          end
 
           {:stdout => output, :exit_status => exitstatus, :command => cmd, :seed => seed}
         end
@@ -234,6 +236,12 @@ module ParallelTests
             "**{,/*/**}/*"
           end
           Dir[File.join(folder, pattern)].uniq
+        end
+
+        private
+
+        def report_process_command?(options)
+          options[:verbose] || options[:verbose_process_command]
         end
       end
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -60,6 +60,9 @@ describe 'CLI' do
     end
   end
 
+  let(:printed_commands) { "specs per process\nbundle exec rspec" }
+  let(:printed_rerun) { "run the group again:\n\nbundle exec rspec" }
+
   it "runs tests in parallel" do
     write 'spec/xxx_spec.rb', 'describe("it"){it("should"){puts "TEST1"}}'
     write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){puts "TEST2"}}'
@@ -111,12 +114,28 @@ describe 'CLI' do
     expect(result).to include('Took')
   end
 
-  it "shows command with --verbose" do
+  it "shows command and rerun with --verbose" do
     write 'spec/xxx_spec.rb', 'describe("it"){it("should"){puts "TEST1"}}'
-    write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){expect(1).to eq(1)}}'
-    result = run_tests "spec --verbose", :type => 'rspec'
+    write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){expect(1).to eq(2)}}'
+    result = run_tests "spec --verbose", :type => 'rspec', :fail => true
+    expect(result).to include printed_commands
+    expect(result).to include printed_rerun
     expect(result).to include "bundle exec rspec spec/xxx_spec.rb"
     expect(result).to include "bundle exec rspec spec/xxx2_spec.rb"
+  end
+
+  it "shows only rerun with --verbose-rerun-command" do
+    write 'spec/xxx_spec.rb', 'describe("it"){it("should"){expect(1).to eq(2)}}'
+    result = run_tests "spec --verbose-rerun-command", :type => 'rspec', :fail => true
+    expect(result).to include printed_rerun
+    expect(result).to_not include printed_commands
+  end
+
+  it "shows only process with --verbose-process-command" do
+    write 'spec/xxx_spec.rb', 'describe("it"){it("should"){expect(1).to eq(2)}}'
+    result = run_tests "spec --verbose-process-command", :type => 'rspec', :fail => true
+    expect(result).to_not include printed_rerun
+    expect(result).to include printed_commands
   end
 
   it "fails when tests fail" do


### PR DESCRIPTION
replaces https://github.com/grosser/parallel_tests/pull/694 

--verbose currently displays both the command to be executed by each parallel
process before the tests run, and, on failure of a process, the command
needed to rerun the failing process.

We prefer to display only the latter.

This patch adds flags that can be used instead of --verbose to enable
either the per-process command, or the rerun command, or both.

--verbose-process-command will show the per-process commands, even if
--verbose is not set, or --quiet is set.

--verbose-rerun-command will show the rerun command, even if --verbose
is not set, or --quiet is set.

If --verbose is set, both types of command will be displayed, regardless
of whether the flags for those commands are set or not.

@alboyadjian