### PR TITLE
Fix Invalid gemspec in parallel_tests.gemspec: cannot load such file -- ./lib/parallel_tests/version

### DIFF
--- a/parallel_tests.gemspec
+++ b/parallel_tests.gemspec
@@ -1,5 +1,5 @@
 name = "parallel_tests"
-require "./lib/#{name}/version"
+require_relative "lib/#{name}/version"
 
 Gem::Specification.new name, ParallelTests::VERSION do |s|
   s.summary = "Run Test::Unit / RSpec / Cucumber / Spinach in parallel"


### PR DESCRIPTION
Hello!

I've forked `parallel_tests` and like to use a [local git repo with Bundler](https://bundler.io/v1.16/bundle_config.html#LOCAL-GIT-REPOS) to test some changes. Unfortunately Bundler is crashing with this error:

```
Invalid gemspec in [/Users/ndbroadbent/code/parallel_tests/parallel_tests.gemspec]: cannot load such file -- ./lib/parallel_tests/version
```

I was able to fix the issue by changing this require call to use `require_relative`.