### PR TITLE
Add note about using the spring-commands-parallel-tests gem to automatically patch and enable Spring

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -273,7 +273,7 @@ TIPS
  - Debug errors that only happen with multiple files using `--verbose` and [cleanser](https://github.com/grosser/cleanser)
  - `export PARALLEL_TEST_PROCESSORS=13` to override default processor count
  - Shell alias: `alias prspec='parallel_rspec -m 2 --'`
- - [Spring] to use spring you have to [patch it](https://github.com/grosser/parallel_tests/wiki/Spring)
+ - [Spring] Add the [spring-commands-parallel-tests](https://github.com/DocSpring/spring-commands-parallel-tests) gem to your `Gemfile` to get `parallel_tests` working with Spring.
  - `--first-is-1` will make the first environment be `1`, so you can test while running your full suite.<br/>
    `export PARALLEL_TEST_FIRST_IS_1=true` will provide the same result
  - [email_spec and/or action_mailer_cache_delivery](https://github.com/grosser/parallel_tests/wiki)


### PR DESCRIPTION
It took me a while to figure out why I couldn't get Spring to work, so I wanted to add this to the Readme and make it a bit clearer.

See https://github.com/grosser/parallel_tests/issues/729#issuecomment-562836419

EDIT: Actually I've realized that I am able to patch Spring to fix the database issue, and also set the default value of `DISABLE_SPRING` to `"0"` in my [`spring-commands-parallel-tests` gem](https://github.com/DocSpring/spring-commands-parallel-tests) (since this code runs before parallel_tests.) So I might just update the README with instructions to use this gem, if that's ok!