### PR TITLE
Update suggestion in readme to use the :sql schema format. Support db:structure:dump and load structure in parallel

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -266,7 +266,7 @@ TIPS
    - Builds a HTML report from JSON with support for debug msgs & embedded Base64 images.
 
 ### General
- - [SQL schema format] use :ruby schema format to get faster parallel:prepare`
+ - [SQL schema format] use [the `:sql` schema format](https://guides.rubyonrails.org/active_record_migrations.html#types-of-schema-dumps) to get faster parallel:prepare`
  - [ZSH] use quotes to use rake arguments `rake "parallel:prepare[3]"`
  - [Memcached] use different namespaces<br/>
    e.g. `config.cache_store = ..., namespace: "test_#{ENV['TEST_ENV_NUMBER']}"`


### PR DESCRIPTION
Also added a link to the docs.

UPDATE: It looks these builds are failing because of a flaky spec:

* https://travis-ci.org/grosser/parallel_tests/jobs/621973707?utm_medium=notification&utm_source=github_status
* https://travis-ci.org/grosser/parallel_tests/jobs/621973710?utm_medium=notification&utm_source=github_status