### PR TITLE
Set PARALLEL_TESTS to 1 when parallel_tests is running, so we can add some conditional logic

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -97,7 +97,19 @@ at_exit do
     undo_something
   end
 end
+```
 
+Check if tests are being run in parallel
+========================================
+
+`parallel_tests` sets the `PARALLEL_TESTS` environment variable to `1`, so you can tell when tests are being run in parallel.
+
+```Ruby
+config.before(:suite) do
+  if ENV['PARALLEL_TESTS']
+    # Only do something when running tests in parallel
+  end
+end
 ```
 
 Even test group run-times

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -10,6 +10,7 @@ module ParallelTests
 
       options = parse_options!(argv)
 
+      ENV['PARALLEL_TESTS'] = '1'
       ENV['DISABLE_SPRING'] ||= '1'
 
       num_processes = ParallelTests.determine_number_of_processes(options[:count])


### PR DESCRIPTION
This would be really useful, similar to how most CI services set `CI=true`. 

In my case, I have a "cleanup" task that deletes some files and folders, but I need to turn this off when running tests in parallel. I also use this to turn off SimpleCov when running tests in parallel.

UPDATE: It looks [the build is failing because of a flaky spec](https://travis-ci.org/grosser/parallel_tests/jobs/622000367?utm_medium=notification&utm_source=github_status).