### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/parallel_tests.gemspec
+++ b/parallel_tests.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new name, ParallelTests::VERSION do |s|
   s.summary = "Run Test::Unit / RSpec / Cucumber / Spinach in parallel"
   s.authors = ["Michael Grosser"]
   s.email = "michael@grosser.it"
-  s.homepage = "http://github.com/grosser/#{name}"
+  s.homepage = "https://github.com/grosser/#{name}"
   s.metadata = {
     "bug_tracker_uri"   => "https://github.com/grosser/#{name}/issues",
     "documentation_uri" => "https://github.com/grosser/#{name}/blob/v#{s.version}/Readme.md",

--- a/parallel_tests.gemspec
+++ b/parallel_tests.gemspec
@@ -6,6 +6,12 @@ Gem::Specification.new name, ParallelTests::VERSION do |s|
   s.authors = ["Michael Grosser"]
   s.email = "michael@grosser.it"
   s.homepage = "http://github.com/grosser/#{name}"
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/grosser/#{name}/issues",
+    "documentation_uri" => "https://github.com/grosser/#{name}/blob/v#{s.version}/Readme.md",
+    "source_code_uri"   => "https://github.com/grosser/#{name}/tree/v#{s.version}",
+    "wiki_uri"          => "https://github.com/grosser/#{name}/wiki",
+  }
   s.files = Dir["{lib,bin}/**/*"] + ["Readme.md"]
   s.license = "MIT"
   s.executables = ["parallel_spinach", "parallel_cucumber", "parallel_rspec", "parallel_test"]


### PR DESCRIPTION
Add `bug_tracker_uri`, `wiki_uri`, `documentation_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/parallel_tests), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.