### PR TITLE
Use bundle info instead of bundle show for newer Bundler versions

### DIFF
--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -18,7 +18,10 @@ module ParallelTests
           when File.exist?("bin/rspec")
             ParallelTests.with_ruby_binary("bin/rspec")
           when ParallelTests.bundler_enabled?
-            cmd = (run("bundle show rspec-core") =~ %r{Could not find gem.*} ? "spec" : "rspec")
+            installed_version = Gem::Version.new(run("bundle -v").gsub(/\A\D+/, ""))
+            first_info_version = Gem::Version.new("2.0.0")
+            bundler_cmd = (installed_version >= first_info_version ? "info" : "show")
+            cmd = (run("bundle #{bundler_cmd} rspec-core") =~ %r{Could not find gem.*} ? "spec" : "rspec")
             "bundle exec #{cmd}"
           else
             %w[spec rspec].detect{|cmd| system "#{cmd} --version > #{DEV_NULL} 2>&1" }

--- a/spec/parallel_tests/rspec/runner_spec.rb
+++ b/spec/parallel_tests/rspec/runner_spec.rb
@@ -55,7 +55,8 @@ describe ParallelTests::RSpec::Runner do
       expect(File).to receive(:file?).with('spec/parallel_spec.opts').and_return true
 
       allow(ParallelTests).to receive(:bundler_enabled?).and_return true
-      allow(ParallelTests::RSpec::Runner).to receive(:run).with("bundle show rspec-core").and_return "/foo/bar/rspec-core-2.4.2"
+      allow(ParallelTests::RSpec::Runner).to receive(:run).with("bundle -v").and_return "Bundler version 2.0.2"
+      allow(ParallelTests::RSpec::Runner).to receive(:run).with("bundle info rspec-core").and_return "/foo/bar/rspec-core-2.4.2"
 
       should_run_with %r{rspec\s+(--color --tty )?-O spec/parallel_spec.opts}
       call('xxx', 1, 22, {})


### PR DESCRIPTION
Bundler gives a deprecation warning for `bundle show` for newer versions, saying one should use `bundle info` instead. These warnings show up - one per process - when running parallel_tests. It seems the deprecations were enabled by default from Bundler version 2.1.0, but the `bundle info` command has been available since 1.15, so it seems reasonable to make the switch somewhere between these versions. I chose 2.0.0 since it's nice and even.

Another solution would of course be to drop support for 1.14 and earlier, and always use `bundle info`. I'm have no idea how many people that would actually leave behind.

Also, when trying to reproduce this, I couldn't even get to the relevant code to run when using bundler, when rspec-core is missing. It just gives an early error saying the gem is missing, so I'm not completely convinced that this code will ever run anything other than `bundle exec rspec`. But there is probably some combination of versions of things where it will do that. In any case, this fix will get rid of the deprecation warning.