### PR TITLE
(deprecation) switched from 'bundle show' to 'bundle info', get rid o…

### DIFF
--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -18,7 +18,7 @@ module ParallelTests
           when File.exist?("bin/rspec")
             ParallelTests.with_ruby_binary("bin/rspec")
           when ParallelTests.bundler_enabled?
-            cmd = (run("bundle show rspec-core") =~ %r{Could not find gem.*} ? "spec" : "rspec")
+            cmd = (run("bundle info rspec-core") =~ %r{Could not find gem.*} ? "spec" : "rspec")
             "bundle exec #{cmd}"
           else
             %w[spec rspec].detect{|cmd| system "#{cmd} --version > #{DEV_NULL} 2>&1" }

--- a/spec/parallel_tests/rspec/runner_spec.rb
+++ b/spec/parallel_tests/rspec/runner_spec.rb
@@ -55,7 +55,7 @@ describe ParallelTests::RSpec::Runner do
       expect(File).to receive(:file?).with('spec/parallel_spec.opts').and_return true
 
       allow(ParallelTests).to receive(:bundler_enabled?).and_return true
-      allow(ParallelTests::RSpec::Runner).to receive(:run).with("bundle show rspec-core").and_return "/foo/bar/rspec-core-2.4.2"
+      allow(ParallelTests::RSpec::Runner).to receive(:run).with("bundle info rspec-core").and_return "/foo/bar/rspec-core-2.4.2"
 
       should_run_with %r{rspec\s+(--color --tty )?-O spec/parallel_spec.opts}
       call('xxx', 1, 22, {})


### PR DESCRIPTION
…f deprecation-warning

Running with current version of bundler gives following message:
```[DEPRECATED] use 'bundle info rspec-core' instead of 'bundle show rspec-core'```

As far as i can see the command is used to decide if we should use 'spec' or 'rspec'. The output of 'bundle info' changed slightly but only in case of success. In case of failure the output stays the same so i think it should be safe to just migrate.  :)