### PR TITLE
Clean file path from cli

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -2,6 +2,7 @@ require 'optparse'
 require 'tempfile'
 require 'parallel_tests'
 require 'shellwords'
+require 'pathname'
 
 module ParallelTests
   class CLI
@@ -239,7 +240,7 @@ module ParallelTests
       files, remaining = extract_file_paths(argv)
       unless options[:execute]
         abort "Pass files or folders to run" unless files.any?
-        options[:files] = files
+        options[:files] = files.map { |file_path| Pathname.new(file_path).cleanpath.to_s }
       end
 
       append_test_options(options, remaining)

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -17,6 +17,10 @@ describe ParallelTests::CLI do
       call(["-n3"])
     end
 
+    it "cleanups file paths" do
+      expect(call(["./test"])).to eq(defaults)
+    end
+
     it "parses execute" do
       expect(call(["--exec", "echo"])).to eq(execute: "echo")
     end
@@ -106,10 +110,10 @@ describe ParallelTests::CLI do
     context "when the -- option separator is used" do
       it "interprets arguments as files/directories" do
         expect(call(%w(-- test))).to eq( files: %w(test))
+        expect(call(%w(-- ./test))).to eq( files: %w(test))
         expect(call(%w(-- test test2))).to eq( files: %w(test test2))
         expect(call(%w(-- --foo test))).to eq( files: %w(--foo test))
         expect(call(%w(-- test --foo test2))).to eq( files: %w(test --foo test2))
-
       end
 
       it "corectly handles arguments with spaces" do


### PR DESCRIPTION
When starts with relative paths, an example:
`bundle exec parallel_rspec ./spec` 

relative paths are passed to the test runner and they do not match the paths in the runtime log.