### PR TITLE
support progress bar formatters

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -212,6 +212,7 @@ module ParallelTests
         opts.on("--serialize-stdout", "Serialize stdout output, nothing will be written until everything is done") { options[:serialize_stdout] = true }
         opts.on("--prefix-output-with-test-env-number", "Prefixes test env number to the output when not using --serialize-stdout") { options[:prefix_output_with_test_env_number] = true }
         opts.on("--combine-stderr", "Combine stderr into stdout, useful in conjunction with --serialize-stdout") { options[:combine_stderr] = true }
+        opts.on("--progress-bar-compatible", "Serialize stdout output, but write immediately and rewrite on the fly") { options[:progress_bar_compatible] = true; options[:combine_stderr] = false }
         opts.on("--non-parallel", "execute same commands but do not in parallel, needs --exec") { options[:non_parallel] = true }
         opts.on("--no-symlinks", "Do not traverse symbolic links to find test files") { options[:symlinks] = false }
         opts.on('--ignore-tags [PATTERN]', 'When counting steps ignore scenarios with tags that match this pattern')  { |arg| options[:ignore_tag_pattern] = arg }

--- a/lib/parallel_tests/output_rewriter.rb
+++ b/lib/parallel_tests/output_rewriter.rb
@@ -1,0 +1,24 @@
+require 'parallel_tests'
+
+module ParallelTests
+  class OutputRewriter
+    CURSOR_UP_CHARACTER = "\033[A"
+
+    $output_rewrite_mutex = Mutex.new
+    $output_by_group = []
+
+    def self.rewrite(new_group_output:, group_index:)
+      $output_rewrite_mutex.synchronize do
+        number_of_lines_to_overwrite = $output_by_group.sum { |s| s.to_s.count("\n") }
+
+        $output_by_group[group_index] = new_group_output
+
+        result = CURSOR_UP_CHARACTER * number_of_lines_to_overwrite
+        $output_by_group.each { |group_output| result += group_output.to_s }
+
+        $stdout.print result
+        $stdout.flush
+      end
+    end
+  end
+end

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -1,4 +1,5 @@
 require 'parallel_tests'
+require 'parallel_tests/output_rewriter'
 
 module ParallelTests
   module Test
@@ -158,7 +159,10 @@ module ParallelTests
                 read = read.force_encoding(Encoding.default_internal)
               end
               result << read
-              unless options[:serialize_stdout]
+
+              if options[:progress_bar_compatible]
+                ParallelTests::OutputRewriter.rewrite(new_group_output: result, group_index: env['TEST_ENV_NUMBER'].to_i)
+              elsif !options[:serialize_stdout]
                 message = read
                 message = "[TEST GROUP #{env['TEST_ENV_NUMBER']}] #{message}" if options[:prefix_output_with_test_env_number]
                 $stdout.print message


### PR DESCRIPTION
## What does this PR add?
new command line option `--progress-bar-compatible` that makes parallel_tests work nice with [fuubar](https://github.com/thekompanee/fuubar) formatter for rspec

## Why do we need it?
I tried to use [fuubar](https://github.com/thekompanee/fuubar) with parallel_tests, but it doesn't look good: all progress bars are displayed concurrently on the same line. This PR adds an option that makes parallel_tests display every progress bar separately. 

I thought that it might be possible to implement a generic solution that will work with any progress bar-like formatters in all supported test framework, but now I doubt it. I think that it will be complicated to achieve unless there will be a clear way to distinguish between the progress bar itself and other output that should be stored and displayed after all threads of parallel_tests finish execution. **I want this option to act like `--serialize-stdout`, but it should display progress bars immediately and refresh them constantly**

## TODO
- Fix blinking of progress bars. I'm probably not using the best way to rewrite content of the terminal. 
![Screen-Recording-2020-03-21-at-00 21 10](https://user-images.githubusercontent.com/4324068/77213949-045a6000-6b0d-11ea-8006-d7443a0a8ab2.gif)

- Fix malformed output if there are pending or failing examples
![image](https://user-images.githubusercontent.com/4324068/77213848-a463b980-6b0c-11ea-8011-6cd3dc9df288.png)

- Don't use ruby's global variables for output storage and mutex
- Add tests

### Any advice or guidance will be much appreciated

