### PR TITLE
When specs fail say "Specs Failed" instead of "Tests Failed"

### DIFF
--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -4,9 +4,12 @@ module ParallelTests
   module RSpec
     class Runner < ParallelTests::Test::Runner
       DEV_NULL = (WINDOWS ? "NUL" : "/dev/null")
-      NAME = 'RSpec'
 
       class << self
+        def name
+          'Spec'
+        end
+
         def run_tests(test_files, process_number, num_processes, options)
           exe = executable # expensive, so we cache
           cmd = [exe, options[:test_options], color, spec_opts, *test_files].compact.join(" ")

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -3,13 +3,11 @@ require 'parallel_tests'
 module ParallelTests
   module Test
     class Runner
-      NAME = 'Test'
-
       class << self
         # --- usually overwritten by other runners
 
         def name
-          NAME
+          'Test'
         end
 
         def runtime_log

--- a/spec/parallel_tests/rspec/runner_spec.rb
+++ b/spec/parallel_tests/rspec/runner_spec.rb
@@ -4,6 +4,10 @@ require "parallel_tests/rspec/runner"
 describe ParallelTests::RSpec::Runner do
   test_tests_in_groups(ParallelTests::RSpec::Runner, '_spec.rb')
 
+  describe '.name' do
+    it { expect(ParallelTests::RSpec::Runner.name).to eq("Spec") }
+  end
+
   describe '.run_tests' do
     before do
       allow(File).to receive(:file?).with('spec/spec.opts').and_return false

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -5,6 +5,10 @@ describe ParallelTests::Test::Runner do
   test_tests_in_groups(ParallelTests::Test::Runner, '_test.rb')
   test_tests_in_groups(ParallelTests::Test::Runner, '_spec.rb')
 
+  describe ".name" do
+    it { expect(ParallelTests::Test::Runner.name).to eq("Test") }
+  end
+
   describe ".run_tests" do
     def call(*args)
       ParallelTests::Test::Runner.run_tests(*args)


### PR DESCRIPTION
`ParallelTests::Test::Runner.name` was using `NAME` instead of `self.class::NAME` so it was using "Test" instead of "RSpec", but "Spec" will read better.