### PR TITLE
Force RAILS_ENV to be "test" in rake tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- None
+- RAILS_ENV cannot be specified for rake tasks (#776).
 
 ### Added
 
@@ -12,7 +12,7 @@
 
 ### Fixed
 
-- None
+- Rake tasks will no longer run against development environment when using a Spring-ified rake binstub (#776).
 
 ## 3.1.0 - 2020-07-23
 

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -5,7 +5,7 @@ module ParallelTests
   module Tasks
     class << self
       def rails_env
-        ENV['RAILS_ENV'] || 'test'
+        'test'
       end
 
       def rake_bin

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -35,13 +35,13 @@ describe ParallelTests::Tasks do
   end
 
   describe ".rails_env" do
-    it "should be test when nothing was set" do
+    it "should be test" do
       expect(ParallelTests::Tasks.rails_env).to eq("test")
     end
 
-    it "should be whatever was set" do
+    it "should disregard whatever was set" do
       ENV["RAILS_ENV"] = "foo"
-      expect(ParallelTests::Tasks.rails_env).to eq("foo")
+      expect(ParallelTests::Tasks.rails_env).to eq("test")
     end
   end
 


### PR DESCRIPTION
After #732, if you're using the SQL schema format, `parallel:prepare` now calls `db:purge db:structure:load` where it used to call `db:test:prepare`. The old task forced using the test environment, however the new tasks make no assumptions about the environment. Therefore, when combined with a Spring-ified rake binstub, where Spring defaults to the development environment, when `parallel:prepare` calls `db:purge db:structure:load`, they're running in the development environment against the development database, instead of in the test environment against the test database.

Now the environment is forced to be "test" in all rake tasks regardless of the RAILS_ENV that might have been set, whether by Spring or the user. This has the side-effect of removing the ability to run the tasks in a test-like environment that's named something other than "test".

I believe this fixes #768.

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
