### PR TITLE
Colorize summarized RSpec results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Add changes here in your PR
 
 ### Added
 
-- None
+- Colorize summarized RSpec results.([#787](https://github.com/grosser/parallel_tests/pull/787)).
 
 ### Fixed
 

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -48,6 +48,22 @@ module ParallelTests
           "#{clean} --seed #{seed}"
         end
 
+        # Summarize results from threads and colorize results based on failure and pending counts.
+        #
+        def summarize_results(results)
+          sums = sum_up_results(results)
+          text = super
+          return text unless $stdout.tty?
+          color =
+            if sums['failure'].positive?
+              31 # red
+            elsif sums['pending'].positive?
+              33 # yellow
+            else
+              32 # green
+            end
+          "\e[#{color}m#{text}\e[0m"
+        end
 
         private
 


### PR DESCRIPTION
RSpec colorizes its results based on if there are any failures (red), pending (orange) or none of the above (green).

The method used to summarize the results from the various threads, `summarize_results` was not doing this colorization.

This commit applies the same colorization that RSpec does, utilizing RSpec::Core helpers to do so.

## Before

![Screenshot 2020-11-08 at 10 27 05](https://user-images.githubusercontent.com/180819/98471962-f6954000-21ac-11eb-9d99-87fe4e5e5bc7.png)

![Screenshot 2020-11-08 at 10 17 20](https://user-images.githubusercontent.com/180819/98471965-fac15d80-21ac-11eb-8dfc-8272d0ea32df.png)

![Screenshot 2020-11-08 at 10 14 45](https://user-images.githubusercontent.com/180819/98471969-fe54e480-21ac-11eb-95e8-1b69bcc622a3.png)


## After

![Screenshot 2020-11-08 at 10 10 25](https://user-images.githubusercontent.com/180819/98471971-03199880-21ad-11eb-82b9-7e22525d8d5c.png)

![Screenshot 2020-11-08 at 10 07 12](https://user-images.githubusercontent.com/180819/98471979-0b71d380-21ad-11eb-974c-4804ba3ecedb.png)

![Screenshot 2020-11-08 at 10 12 26](https://user-images.githubusercontent.com/180819/98471984-10cf1e00-21ad-11eb-9d43-f0c6073e62cb.png)


Thank you for your contribution!

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] Update Readme.md when cli options are changed
