### PR TITLE
speedup install by using cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         apt-get:  libsqlite3-dev
-    - name: Install dependencies
-      run: |
-        bundle install
+        bundler-cache: true
     - name: Run test
       run: bundle exec rake
       # TODO: this will always show green, fix once https://github.com/actions/toolkit/issues/399 is resolved


### PR DESCRIPTION
did not work 🤷 
```
C:/hostedtoolcache/windows/Ruby/2.5.8/x64/lib/ruby/gems/2.5.0/gems/bundler-2.1.4/lib/bundler/rubygems_integration.rb:374:in `block in replace_bin_path': can't find executable rake for gem rake. rake is not currently included in the bundle, perhaps you meant to add it to your Gemfile? (Gem::Exception)

```