### PR TITLE
Remove spaces in --only-group flag documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -210,7 +210,7 @@ Options are:
     -i, --isolate                    Do not run any other tests in the group used by --single(-s).
                                      Automatically turned on if --isolate-n is set above 0.
         --isolate-n                  Number of processes for isolated groups. Default to 1 when --isolate is on.
-        --only-group INT[, INT]
+        --only-group INT[,INT]
     -e, --exec [COMMAND]             execute this code parallel and with ENV['TEST_ENV_NUMBER']
     -o, --test-options '[OPTIONS]'   execute test commands with those options
     -t, --type [TYPE]                test(default) / rspec / cucumber / spinach

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -208,7 +208,7 @@ module ParallelTests
           options[:isolate_count] = n
         end
 
-        opts.on("--only-group INT[, INT]", Array) { |groups| options[:only_group] = groups.map(&:to_i) }
+        opts.on("--only-group INT[,INT]", Array) { |groups| options[:only_group] = groups.map(&:to_i) }
 
         opts.on("-e", "--exec [COMMAND]", "execute this code parallel and with ENV['TEST_ENV_NUMBER']") { |path| options[:execute] = path }
         opts.on("-o", "--test-options '[OPTIONS]'", "execute test commands with those options") { |arg| options[:test_options] = arg.lstrip }


### PR DESCRIPTION
[optparse documentation](https://ruby-doc.org/stdlib-2.6.6/libdoc/optparse/rdoc/OptionParser.html) says that Array type flags are "Strings separated by ',' (e.g. 1,2,3)". And indeed `--only-group 1, 2, 3` only tests group 1.



## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [-] Added tests.
- [-] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] Update Readme.md when cli options are changed
