### PR TITLE
Specify groups argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-Add changes here in your PR
+- Add support for specifying exactly how isolated processes run tests with 'specify-groups' option.
 
 ### Breaking Changes
 

--- a/Readme.md
+++ b/Readme.md
@@ -210,6 +210,14 @@ Options are:
     -i, --isolate                    Do not run any other tests in the group used by --single(-s).
                                      Automatically turned on if --isolate-n is set above 0.
         --isolate-n                  Number of processes for isolated groups. Default to 1 when --isolate is on.
+        --specify-groups [SPECS]     Use 'specify-groups' if you want to specify multiple specs running in multiple
+                                     processes in a specific formation. Commas indicate specs in the same process,
+                                     pipes indicate specs in a new process.
+                                     Ex.
+                                     $ parallel_tests -n 3 . --specify-groups '1_spec.rb,2_spec.rb|3_spec.rb'
+                                       Process 1 will contain 1_spec.rb and 2_spec.rb
+                                       Process 2 will contain 3_spec.rb
+                                       Process 3 will contain all other specs
         --only-group INT[,INT]
     -e, --exec [COMMAND]             execute this code parallel and with ENV['TEST_ENV_NUMBER']
     -o, --test-options '[OPTIONS]'   execute test commands with those options

--- a/Readme.md
+++ b/Readme.md
@@ -212,7 +212,8 @@ Options are:
         --isolate-n                  Number of processes for isolated groups. Default to 1 when --isolate is on.
         --specify-groups [SPECS]     Use 'specify-groups' if you want to specify multiple specs running in multiple
                                      processes in a specific formation. Commas indicate specs in the same process,
-                                     pipes indicate specs in a new process.
+                                     pipes indicate specs in a new process.  Cannot use with --single, --isolate, or
+                                     --isolate-n.  Ex.
                                      Ex.
                                      $ parallel_tests -n 3 . --specify-groups '1_spec.rb,2_spec.rb|3_spec.rb'
                                        Process 1 will contain 1_spec.rb and 2_spec.rb

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -297,7 +297,7 @@ module ParallelTests
       end
 
       not_allowed_with_specify_groups = [:single_process, :isolate, :isolate_count]
-      if options[:specify_groups] && (options.keys & not_allowed_with_specify_groups).any?
+      if options[:specify_groups] && options.keys.find { |k| not_allowed_with_specify_groups.include?(k) }
         raise "Can't pass --specify-groups with any of these keys: --single, --isolate, or --isolate-n"
       end
 

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -208,6 +208,23 @@ module ParallelTests
           "Use 'isolate'  singles with number of processes, default: 1."
         ) { |n| options[:isolate_count] = n }
 
+        gap = "\s" * 37
+        opts.on(
+          "--specify-groups [SPECS]",
+          <<~TEXT
+            Use 'specify-groups' if you want to specify multiple specs running in multiple
+            #{gap}processes in a specific formation. Commas indicate specs in the same process,
+            #{gap}pipes indicate specs in a new process.
+            #{gap}Ex.
+            #{gap}$ parallel_tests -n 3 . --specify-groups '1_spec.rb,2_spec.rb|3_spec.rb'
+            #{gap}\s\sProcess 1 will contain 1_spec.rb and 2_spec.rb
+            #{gap}\s\sProcess 2 will contain 3_spec.rb
+            #{gap}\s\sProcess 3 will contain all other specs
+          TEXT
+        ) do |groups|
+          options[:specify_groups] = groups
+        end
+
         opts.on("--only-group INT[,INT]", Array) { |groups| options[:only_group] = groups.map(&:to_i) }
 
         opts.on("-e", "--exec [COMMAND]", "execute this code parallel and with ENV['TEST_ENV_NUMBER']") { |path| options[:execute] = path }

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -214,8 +214,8 @@ module ParallelTests
           <<~TEXT
             Use 'specify-groups' if you want to specify multiple specs running in multiple
             #{gap}processes in a specific formation. Commas indicate specs in the same process,
-            #{gap}pipes indicate specs in a new process.
-            #{gap}Ex.
+            #{gap}pipes indicate specs in a new process. Cannot use with --single, --isolate, or
+            #{gap}--isolate-n.  Ex.
             #{gap}$ parallel_tests -n 3 . --specify-groups '1_spec.rb,2_spec.rb|3_spec.rb'
             #{gap}\s\sProcess 1 will contain 1_spec.rb and 2_spec.rb
             #{gap}\s\sProcess 2 will contain 3_spec.rb
@@ -294,6 +294,11 @@ module ParallelTests
       allowed = [:filesize, :runtime, :found]
       if !allowed.include?(options[:group_by]) && options[:only_group]
         raise "--group-by #{allowed.join(" or ")} is required for --only-group"
+      end
+
+      not_allowed_with_specify_groups = [:single_process, :isolate, :isolate_count]
+      if options[:specify_groups] && options.keys.find { |k| not_allowed_with_specify_groups.include?(k) }
+        raise "Can't pass --specify-groups with any of these keys: --single, --isolate, or --isolate-n"
       end
 
       options

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -297,7 +297,7 @@ module ParallelTests
       end
 
       not_allowed_with_specify_groups = [:single_process, :isolate, :isolate_count]
-      if options[:specify_groups] && options.keys.find { |k| not_allowed_with_specify_groups.include?(k) }
+      if options[:specify_groups] && (options.keys & not_allowed_with_specify_groups).any?
         raise "Can't pass --specify-groups with any of these keys: --single, --isolate, or --isolate-n"
       end
 

--- a/lib/parallel_tests/grouper.rb
+++ b/lib/parallel_tests/grouper.rb
@@ -35,9 +35,7 @@ module ParallelTests
             raise 'Number of processes separated by pipe must be less than or equal to the total number of processes'
           end
 
-          specified_items_found, items = items.partition do |item, _size|
-            all_specified_tests.any? { |specified_spec| item == specified_spec }
-          end
+          specified_items_found, items = items.partition { |item, _size| all_specified_tests.include?(item) }
 
           specified_specs_not_found = all_specified_tests - specified_items_found.map(&:first)
           if specified_specs_not_found.any?

--- a/lib/parallel_tests/grouper.rb
+++ b/lib/parallel_tests/grouper.rb
@@ -41,7 +41,7 @@ module ParallelTests
 
           specified_specs_not_found = all_specified_tests - specified_items_found.map(&:first)
           if specified_specs_not_found.any?
-            raise "Could not find #{specified_specs_not_found} from --specify-spec-processes in the main selected files & folders"
+            raise "Could not find #{specified_specs_not_found} from --specify-groups in the main selected files & folders"
           end
 
           if specify_test_process_groups.count == num_groups && items.flatten.any?

--- a/lib/parallel_tests/grouper.rb
+++ b/lib/parallel_tests/grouper.rb
@@ -53,11 +53,11 @@ module ParallelTests
 
       def specify_groups(items, num_groups, options, groups)
         specify_test_process_groups = options[:specify_groups].split('|')
-        all_specified_tests = specify_test_process_groups.map { |group| group.split(',') }.flatten
         if specify_test_process_groups.count > num_groups
           raise 'Number of processes separated by pipe must be less than or equal to the total number of processes'
         end
 
+        all_specified_tests = specify_test_process_groups.map { |group| group.split(',') }.flatten
         specified_items_found, items = items.partition { |item, _size| all_specified_tests.include?(item) }
 
         specified_specs_not_found = all_specified_tests - specified_items_found.map(&:first)
@@ -74,6 +74,7 @@ module ParallelTests
           )
         end
 
+        # First order the specify_groups into the main groups array
         specify_test_process_groups.each_with_index do |specify_test_process, i|
           groups[i] = specify_test_process.split(',')
         end
@@ -81,6 +82,7 @@ module ParallelTests
         # Return early here as we've processed the specify_groups tests and those exactly match the items passed in
         return groups if specify_test_process_groups.count == num_groups
 
+        # Now sort the rest of the items into the main groups array
         remaining_groups = groups[specify_test_process_groups.count..-1]
         group_features_by_size(items_to_group(items), remaining_groups)
         # Don't sort all the groups, only sort the ones not specified in specify_groups

--- a/lib/parallel_tests/grouper.rb
+++ b/lib/parallel_tests/grouper.rb
@@ -29,15 +29,13 @@ module ParallelTests
         end
 
         if options[:specify_groups]
-          specify_test_process_groups = options[:specify_groups].split('|')
+          specify_test_process_groups = options[:specify_groups].split('|').map { |g| g.split(',') }
           all_specified_tests = specify_test_process_groups.map { |group| group.split(',') }.flatten
           if specify_test_process_groups.count > num_groups
             raise 'Number of processes separated by pipe must be less than or equal to the total number of processes'
           end
 
-          specified_items_found, items = items.partition do |item, _size|
-            all_specified_tests.any? { |specified_spec| item == specified_spec }
-          end
+          specified_items_found = items.select! { |item, _size| all_specified_tests.include?(item) } || []
 
           specified_specs_not_found = all_specified_tests - specified_items_found.map(&:first)
           if specified_specs_not_found.any?
@@ -45,7 +43,12 @@ module ParallelTests
           end
 
           if specify_test_process_groups.count == num_groups && items.flatten.any?
-            raise "The number of groups in --specify-groups matches the number of groups from -n but there were other specs found in the main selected files & folders not specified in --specify-groups. Make sure -n is larger than the number of processes in --specify-groups if there are other specs that need to be run. The specs that aren't run: #{items.map(&:first)}"
+            raise(
+              "The number of groups in --specify-groups matches the number of groups from -n but there were other specs " \
+              "found in the main selected files & folders not specified in --specify-groups. Make sure -n is larger than the " \
+              "number of processes in --specify-groups if there are other specs that need to be run. The specs that aren't run: " \
+              "#{items.map(&:first)}"
+            )
           end
 
           specify_test_process_groups.each_with_index do |specify_test_process, i|

--- a/lib/parallel_tests/grouper.rb
+++ b/lib/parallel_tests/grouper.rb
@@ -15,6 +15,7 @@ module ParallelTests
       def in_even_groups_by_size(items, num_groups, options = {})
         groups = Array.new(num_groups) { { items: [], size: 0 } }
 
+        return specify_groups(items, num_groups, options, groups) if options[:specify_groups]
         # add all files that should run in a single process to one group
         single_process_patterns = options[:single_process] || []
 
@@ -28,42 +29,11 @@ module ParallelTests
           raise 'Number of isolated processes must be less than total the number of processes'
         end
 
-        if options[:specify_groups]
-          specify_test_process_groups = options[:specify_groups].split('|')
-          all_specified_tests = specify_test_process_groups.map { |group| group.split(',') }.flatten
-          if specify_test_process_groups.count > num_groups
-            raise 'Number of processes separated by pipe must be less than or equal to the total number of processes'
-          end
+        if isolate_count >= num_groups
+          raise 'Number of isolated processes must be less than total the number of processes'
+        end
 
-          specified_items_found, items = items.partition { |item, _size| all_specified_tests.include?(item) }
-
-          specified_specs_not_found = all_specified_tests - specified_items_found.map(&:first)
-          if specified_specs_not_found.any?
-            raise "Could not find #{specified_specs_not_found} from --specify-groups in the main selected files & folders"
-          end
-
-          if specify_test_process_groups.count == num_groups && items.flatten.any?
-            raise(
-              "The number of groups in --specify-groups matches the number of groups from -n but there were other specs " \
-              "found in the main selected files & folders not specified in --specify-groups. Make sure -n is larger than the " \
-              "number of processes in --specify-groups if there are other specs that need to be run. The specs that aren't run: " \
-              "#{items.map(&:first)}"
-            )
-          end
-
-          specify_test_process_groups.each_with_index do |specify_test_process, i|
-            groups[i] = specify_test_process.split(',')
-          end
-
-          return groups if specify_test_process_groups.count == num_groups
-
-          remaining_groups = groups[specify_test_process_groups.count..-1]
-          group_features_by_size(items_to_group(items), remaining_groups)
-          # Don't sort all the groups, only sort the ones not specified in specify_groups
-          sorted_groups = remaining_groups.map { |g| g[:items].sort }
-          groups[specify_test_process_groups.count..-1] = sorted_groups
-          return groups
-        elsif isolate_count >= 1
+        if isolate_count >= 1
           # add all files that should run in a multiple isolated processes to their own groups
           group_features_by_size(items_to_group(single_items), groups[0..(isolate_count - 1)])
           # group the non-isolated by size
@@ -75,10 +45,50 @@ module ParallelTests
           # group all by size
           group_features_by_size(items_to_group(items), groups)
         end
+
         groups.map! { |g| g[:items].sort }
       end
 
       private
+
+      def specify_groups(items, num_groups, options, groups)
+        specify_test_process_groups = options[:specify_groups].split('|')
+        all_specified_tests = specify_test_process_groups.map { |group| group.split(',') }.flatten
+        if specify_test_process_groups.count > num_groups
+          raise 'Number of processes separated by pipe must be less than or equal to the total number of processes'
+        end
+
+        specified_items_found, items = items.partition { |item, _size| all_specified_tests.include?(item) }
+
+        specified_specs_not_found = all_specified_tests - specified_items_found.map(&:first)
+        if specified_specs_not_found.any?
+          raise "Could not find #{specified_specs_not_found} from --specify-groups in the main selected files & folders"
+        end
+
+        if specify_test_process_groups.count == num_groups && items.flatten.any?
+          raise(
+            "The number of groups in --specify-groups matches the number of groups from -n but there were other specs " \
+            "found in the main selected files & folders not specified in --specify-groups. Make sure -n is larger than the " \
+            "number of processes in --specify-groups if there are other specs that need to be run. The specs that aren't run: " \
+            "#{items.map(&:first)}"
+          )
+        end
+
+        specify_test_process_groups.each_with_index do |specify_test_process, i|
+          groups[i] = specify_test_process.split(',')
+        end
+
+        # Return early here as we've processed the specify_groups tests and those exactly match the items passed in
+        return groups if specify_test_process_groups.count == num_groups
+
+        remaining_groups = groups[specify_test_process_groups.count..-1]
+        group_features_by_size(items_to_group(items), remaining_groups)
+        # Don't sort all the groups, only sort the ones not specified in specify_groups
+        sorted_groups = remaining_groups.map { |g| g[:items].sort }
+        groups[specify_test_process_groups.count..-1] = sorted_groups
+
+        groups
+      end
 
       def isolate_count(options)
         if options[:isolate_count] && options[:isolate_count] > 1

--- a/lib/parallel_tests/grouper.rb
+++ b/lib/parallel_tests/grouper.rb
@@ -45,7 +45,7 @@ module ParallelTests
           end
 
           if specify_test_process_groups.count == num_groups && items.flatten.any?
-            raise "The number of groups in --specify-groups matches the number of specs from -n but there were other specs found in the main selected files & folders. Make sure -n is larger than the number of processes in --specify-groups if there are other specs that need to be run. The specs that aren't run: #{items.map(&:first)}"
+            raise "The number of groups in --specify-groups matches the number of groups from -n but there were other specs found in the main selected files & folders not specified in --specify-groups. Make sure -n is larger than the number of processes in --specify-groups if there are other specs that need to be run. The specs that aren't run: #{items.map(&:first)}"
           end
 
           specify_test_process_groups.each_with_index do |specify_test_process, i|

--- a/lib/parallel_tests/grouper.rb
+++ b/lib/parallel_tests/grouper.rb
@@ -43,7 +43,12 @@ module ParallelTests
           end
 
           if specify_test_process_groups.count == num_groups && items.flatten.any?
-            raise "The number of groups in --specify-groups matches the number of groups from -n but there were other specs found in the main selected files & folders not specified in --specify-groups. Make sure -n is larger than the number of processes in --specify-groups if there are other specs that need to be run. The specs that aren't run: #{items.map(&:first)}"
+            raise(
+              "The number of groups in --specify-groups matches the number of groups from -n but there were other specs " \
+              "found in the main selected files & folders not specified in --specify-groups. Make sure -n is larger than the " \
+              "number of processes in --specify-groups if there are other specs that need to be run. The specs that aren't run: " \
+              "#{items.map(&:first)}"
+            )
           end
 
           specify_test_process_groups.each_with_index do |specify_test_process, i|
@@ -52,11 +57,11 @@ module ParallelTests
 
           return groups if specify_test_process_groups.count == num_groups
 
-          regular_group_starting_process = specify_test_process_groups.count
-          group_features_by_size(items_to_group(items), groups[regular_group_starting_process..-1])
+          remaining_groups = groups[specify_test_process_groups.count..-1]
+          group_features_by_size(items_to_group(items), remaining_groups)
           # Don't sort all the groups, only sort the ones not specified in specify_groups
-          sorted_groups = groups[regular_group_starting_process..-1].map { |g| g[:items].sort }
-          groups[regular_group_starting_process..-1] = sorted_groups
+          sorted_groups = remaining_groups.map { |g| g[:items].sort }
+          groups[specify_test_process_groups.count..-1] = sorted_groups
           return groups
         elsif isolate_count >= 1
           # add all files that should run in a multiple isolated processes to their own groups

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -128,6 +128,15 @@ describe ParallelTests::CLI do
       end
     end
 
+    context "specify groups" do
+      it "groups can be just one string" do
+        expect(call(["test", "--specify-groups", 'test'])).to eq(defaults.merge(specify_groups: 'test'))
+      end
+      it "groups can be a string separated by commas and pipes" do
+        expect(call(["test", "--specify-groups", 'test1,test2|test3'])).to eq(defaults.merge(specify_groups: 'test1,test2|test3'))
+      end
+    end
+
     context "when the -- option separator is used" do
       it "interprets arguments as files/directories" do
         expect(call(['--', 'test'])).to eq(files: ['test'])

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -132,6 +132,7 @@ describe ParallelTests::CLI do
       it "groups can be just one string" do
         expect(call(["test", "--specify-groups", 'test'])).to eq(defaults.merge(specify_groups: 'test'))
       end
+
       it "groups can be a string separated by commas and pipes" do
         expect(call(["test", "--specify-groups", 'test1,test2|test3'])).to eq(defaults.merge(specify_groups: 'test1,test2|test3'))
       end

--- a/spec/parallel_tests/grouper_spec.rb
+++ b/spec/parallel_tests/grouper_spec.rb
@@ -75,6 +75,46 @@ describe ParallelTests::Grouper do
         "Number of isolated processes must be less than total the number of processes"
       )
     end
+
+    it "groups specify_groups as specified when specify_groups is just one spec" do
+      expect(call(3, specify_groups: '1')).to eq([["1"], ["2", "5"], ["3", "4"]])
+    end
+
+    it "groups specify_groups as specified when specify_groups is just multiple specs in one process" do
+      expect(call(3, specify_groups: '3,1')).to eq([["3", "1"], ["5"], ["2", "4"]])
+    end
+
+    it "groups specify_groups as specified when specify_groups is multiple specs" do
+      expect(call(3, specify_groups: '1,2|4')).to eq([["1", "2"], ["4"], ["3", "5"]])
+    end
+
+    it "specify_groups aborts when number of specs separated by pipe is out of bounds" do
+      expect do
+        call(3, specify_groups: '1|2|3|4')
+      end.to raise_error(
+        "Number of processes separated by pipe must be less than or equal to the total number of processes"
+      )
+    end
+
+    it "specify_groups aborts when spec passed in doesnt match existing specs" do
+      expect do
+        call(3, specify_groups: '1|2|6')
+      end.to raise_error(
+        "Could not find all specs from --specify-spec-processes in main selected files & folders"
+      )
+    end
+
+    it "specify_groups aborts when spec passed in doesnt match existing specs again" do
+      expect do
+        call(3, specify_groups: '1,6|2')
+      end.to raise_error(
+        "Could not find all specs from --specify-spec-processes in main selected files & folders"
+      )
+    end
+
+    it "specify_groups does not abort when number of specs is equal to number passed in " do
+      expect(call(3, specify_groups: '1|2|3')).to eq([["1"], ["2"], ["3"]])
+    end
   end
 
   describe '.by_scenarios' do

--- a/spec/parallel_tests/grouper_spec.rb
+++ b/spec/parallel_tests/grouper_spec.rb
@@ -100,7 +100,7 @@ describe ParallelTests::Grouper do
       expect do
         call(3, specify_groups: '1|2|6')
       end.to raise_error(
-        "Could not find all specs from --specify-spec-processes in main selected files & folders"
+        "Could not find [\"6\"] from --specify-spec-processes in the main selected files & folders"
       )
     end
 
@@ -108,12 +108,20 @@ describe ParallelTests::Grouper do
       expect do
         call(3, specify_groups: '1,6|2')
       end.to raise_error(
-        "Could not find all specs from --specify-spec-processes in main selected files & folders"
+        "Could not find [\"6\"] from --specify-spec-processes in the main selected files & folders"
       )
     end
 
-    it "specify_groups does not abort when number of specs is equal to number passed in " do
-      expect(call(3, specify_groups: '1|2|3')).to eq([["1"], ["2"], ["3"]])
+    it "specify_groups aborts when number of specs is equal to number passed in" do
+      expect do
+        call(3, specify_groups: '1|2|3')
+      end.to raise_error(
+        "The number of groups in --specify-groups matches the number of specs from -n but there were other specs found in the main selected files & folders. Make sure -n is larger than the number of processes in --specify-groups if there are other specs that need to be run. The specs that aren't run: [\"4\", \"5\"]"
+      )
+    end
+
+    it "specify_groups does not abort when the every single spec is specified in it" do
+      expect(call(3, specify_groups: '1,2|3,4|5')).to eq([["1", "2"], ["3", "4"], ["5"]])
     end
   end
 

--- a/spec/parallel_tests/grouper_spec.rb
+++ b/spec/parallel_tests/grouper_spec.rb
@@ -100,7 +100,7 @@ describe ParallelTests::Grouper do
       expect do
         call(3, specify_groups: '1|2|6')
       end.to raise_error(
-        "Could not find [\"6\"] from --specify-spec-processes in the main selected files & folders"
+        "Could not find [\"6\"] from --specify-groups in the main selected files & folders"
       )
     end
 
@@ -108,7 +108,7 @@ describe ParallelTests::Grouper do
       expect do
         call(3, specify_groups: '1,6|2')
       end.to raise_error(
-        "Could not find [\"6\"] from --specify-spec-processes in the main selected files & folders"
+        "Could not find [\"6\"] from --specify-groups in the main selected files & folders"
       )
     end
 

--- a/spec/parallel_tests/grouper_spec.rb
+++ b/spec/parallel_tests/grouper_spec.rb
@@ -116,7 +116,7 @@ describe ParallelTests::Grouper do
       expect do
         call(3, specify_groups: '1|2|3')
       end.to raise_error(
-        "The number of groups in --specify-groups matches the number of specs from -n but there were other specs found in the main selected files & folders. Make sure -n is larger than the number of processes in --specify-groups if there are other specs that need to be run. The specs that aren't run: [\"4\", \"5\"]"
+        "The number of groups in --specify-groups matches the number of groups from -n but there were other specs found in the main selected files & folders not specified in --specify-groups. Make sure -n is larger than the number of processes in --specify-groups if there are other specs that need to be run. The specs that aren't run: [\"4\", \"5\"]"
       )
     end
 

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -178,6 +178,28 @@ describe ParallelTests::Test::Runner do
 
         expect(valid_combinations).to include(actual)
       end
+
+      it 'groups by size and uses specified groups of specs in specific order in specific processes' do
+        skip if RUBY_PLATFORM == "java"
+        expect(ParallelTests::Test::Runner).to receive(:runtimes)
+          .and_return({ "aaa1" => 1, "aaa2" => 1, "aaa3" => 2, "bbb" => 3, "ccc" => 1, "ddd" => 2, "eee" => 1 })
+        result = call(
+          ["aaa1", "aaa2", "aaa3", "bbb", "ccc", "ddd", "eee"], 4, specify_groups: 'aaa2,aaa1|bbb', group_by: :runtime
+        )
+
+        specify_groups_1, specify_groups_2, *groups = result
+        expect(specify_groups_1).to eq(["aaa2", "aaa1"])
+        expect(specify_groups_2).to eq(["bbb"])
+        actual = groups.map(&:to_set).to_set
+
+        # both eee and ccs are the same size, so either can be in either group
+        valid_combinations = [
+          [["aaa3", "ccc"], ["ddd", "eee"]].map(&:to_set).to_set,
+          [["aaa3", "eee"], ["ddd", "ccc"]].map(&:to_set).to_set
+        ]
+
+        expect(valid_combinations).to include(actual)
+      end
     end
   end
 


### PR DESCRIPTION
At my organization, we heavily use this gem.  We sometimes run with 40-50 parallel processes with giant VMs in AWS.  

Our test suite has a lot of data-intensive tests.  We have plans to refactor these at an architecture level, but at the moment, it is a fact of life. 

When using this gem, its possible for these data-intensive tests to be shuffled so they run alongside each other.  This makes them a bit more flaky, but, more importantly, it makes them take much longer when they are competing with each other for data.

I wanted to use `--single` and `--isolate-n` to help with this issue, however, the specs in `--single` are still shuffled into parallel processes by size. There is not full control over them. So it was still possible for these tests to still collide with each other.

Maybe this is an anti-pattern, but I thought it would be a good idea to create a feature to fully control a subset of parallel processes and which tests run in them (and in what order), while still respecting the other grouping schemes for the other tests.

Let me know if you think this would be a good feature to have! Happy to make edits and such.

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] Update Readme.md when cli options are changed
