### PR TITLE
replace deprecated db:structure by db:schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Add changes here in your PR
 
 ### Fixed
 
-- None
+- replace deprecated db:structure by db:schema (#801).
 
 ## 3.3.0 - 2020-09-16
 

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -123,8 +123,12 @@ namespace :parallel do
     ParallelTests::Tasks.check_for_pending_migrations
     if defined?(ActiveRecord::Base) && [:ruby, :sql].include?(ActiveRecord::Base.schema_format)
       # fast: dump once, load in parallel
-      type = (ActiveRecord::Base.schema_format == :ruby ? "schema" : "structure")
-      Rake::Task["db:#{type}:dump"].invoke
+      if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1.0')
+        Rake::Task["db:schema:dump"].invoke
+      else
+        type = (ActiveRecord::Base.schema_format == :ruby ? "schema" : "structure")
+        Rake::Task["db:#{type}:dump"].invoke
+      end
 
       # remove database connection to prevent "database is being accessed by other users"
       ActiveRecord::Base.remove_connection if ActiveRecord::Base.configurations.any?
@@ -163,6 +167,7 @@ namespace :parallel do
   end
 
   # load the structure from the structure.sql file
+  # (faster for rails < 6.1, deprecated after and only configured by `ActiveRecord::Base.schema_format`)
   desc "Load structure for test databases via db:schema:load --> parallel:load_structure[num_cpus]"
   task :load_structure, :count do |_, args|
     ParallelTests::Tasks.run_in_parallel(

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -163,11 +163,11 @@ namespace :parallel do
   end
 
   # load the structure from the structure.sql file
-  desc "Load structure for test databases via db:structure:load --> parallel:load_structure[num_cpus]"
+  desc "Load structure for test databases via db:schema:load --> parallel:load_structure[num_cpus]"
   task :load_structure, :count do |_, args|
     ParallelTests::Tasks.run_in_parallel(
       "#{ParallelTests::Tasks.rake_bin} #{ParallelTests::Tasks.purge_before_load} " \
-      "db:structure:load RAILS_ENV=#{ParallelTests::Tasks.rails_env} DISABLE_DATABASE_ENVIRONMENT_CHECK=1", args
+      "db:schema:load RAILS_ENV=#{ParallelTests::Tasks.rails_env} DISABLE_DATABASE_ENVIRONMENT_CHECK=1", args
     )
   end
 

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -172,7 +172,7 @@ namespace :parallel do
   task :load_structure, :count do |_, args|
     ParallelTests::Tasks.run_in_parallel(
       "#{ParallelTests::Tasks.rake_bin} #{ParallelTests::Tasks.purge_before_load} " \
-      "db:schema:load RAILS_ENV=#{ParallelTests::Tasks.rails_env} DISABLE_DATABASE_ENVIRONMENT_CHECK=1", args
+      "db:structure:load RAILS_ENV=#{ParallelTests::Tasks.rails_env} DISABLE_DATABASE_ENVIRONMENT_CHECK=1", args
     )
   end
 

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -123,8 +123,7 @@ namespace :parallel do
     ParallelTests::Tasks.check_for_pending_migrations
     if defined?(ActiveRecord::Base) && [:ruby, :sql].include?(ActiveRecord::Base.schema_format)
       # fast: dump once, load in parallel
-      type = (ActiveRecord::Base.schema_format == :ruby ? "schema" : "structure")
-      Rake::Task["db:#{type}:dump"].invoke
+      Rake::Task["db:schema:dump"].invoke
 
       # remove database connection to prevent "database is being accessed by other users"
       ActiveRecord::Base.remove_connection if ActiveRecord::Base.configurations.any?
@@ -160,15 +159,6 @@ namespace :parallel do
     command = "#{ParallelTests::Tasks.rake_bin} #{ParallelTests::Tasks.purge_before_load} " \
       "db:schema:load RAILS_ENV=#{ParallelTests::Tasks.rails_env} DISABLE_DATABASE_ENVIRONMENT_CHECK=1"
     ParallelTests::Tasks.run_in_parallel(ParallelTests::Tasks.suppress_schema_load_output(command), args)
-  end
-
-  # load the structure from the structure.sql file
-  desc "Load structure for test databases via db:schema:load --> parallel:load_structure[num_cpus]"
-  task :load_structure, :count do |_, args|
-    ParallelTests::Tasks.run_in_parallel(
-      "#{ParallelTests::Tasks.rake_bin} #{ParallelTests::Tasks.purge_before_load} " \
-      "db:schema:load RAILS_ENV=#{ParallelTests::Tasks.rails_env} DISABLE_DATABASE_ENVIRONMENT_CHECK=1", args
-    )
   end
 
   desc "Load the seed data from db/seeds.rb via db:seed --> parallel:seed[num_cpus]"

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -123,7 +123,8 @@ namespace :parallel do
     ParallelTests::Tasks.check_for_pending_migrations
     if defined?(ActiveRecord::Base) && [:ruby, :sql].include?(ActiveRecord::Base.schema_format)
       # fast: dump once, load in parallel
-      Rake::Task["db:schema:dump"].invoke
+      type = (ActiveRecord::Base.schema_format == :ruby ? "schema" : "structure")
+      Rake::Task["db:#{type}:dump"].invoke
 
       # remove database connection to prevent "database is being accessed by other users"
       ActiveRecord::Base.remove_connection if ActiveRecord::Base.configurations.any?
@@ -159,6 +160,15 @@ namespace :parallel do
     command = "#{ParallelTests::Tasks.rake_bin} #{ParallelTests::Tasks.purge_before_load} " \
       "db:schema:load RAILS_ENV=#{ParallelTests::Tasks.rails_env} DISABLE_DATABASE_ENVIRONMENT_CHECK=1"
     ParallelTests::Tasks.run_in_parallel(ParallelTests::Tasks.suppress_schema_load_output(command), args)
+  end
+
+  # load the structure from the structure.sql file
+  desc "Load structure for test databases via db:schema:load --> parallel:load_structure[num_cpus]"
+  task :load_structure, :count do |_, args|
+    ParallelTests::Tasks.run_in_parallel(
+      "#{ParallelTests::Tasks.rake_bin} #{ParallelTests::Tasks.purge_before_load} " \
+      "db:schema:load RAILS_ENV=#{ParallelTests::Tasks.rails_env} DISABLE_DATABASE_ENVIRONMENT_CHECK=1", args
+    )
   end
 
   desc "Load the seed data from db/seeds.rb via db:seed --> parallel:seed[num_cpus]"


### PR DESCRIPTION
fix https://github.com/grosser/parallel_tests/issues/801

deprecation explanation in Rails 6.1 (will be removed in Rails 6.2): https://blog.saeloun.com/2020/09/30/rails-deprecates-db-structure-commands.html

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
