### PR TITLE
fix prepare rake task

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -123,12 +123,10 @@ namespace :parallel do
     ParallelTests::Tasks.check_for_pending_migrations
     if defined?(ActiveRecord::Base) && [:ruby, :sql].include?(ActiveRecord::Base.schema_format)
       # fast: dump once, load in parallel
-      if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1.0')
-        Rake::Task["db:schema:dump"].invoke
-      else
-        type = (ActiveRecord::Base.schema_format == :ruby ? "schema" : "structure")
-        Rake::Task["db:#{type}:dump"].invoke
-      end
+      type = "schema" if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1.0')
+      type ||= ActiveRecord::Base.schema_format == :ruby ? "schema" : "structure"
+
+      Rake::Task["db:#{type}:dump"].invoke
 
       # remove database connection to prevent "database is being accessed by other users"
       ActiveRecord::Base.remove_connection if ActiveRecord::Base.configurations.any?


### PR DESCRIPTION
Fix https://github.com/grosser/parallel_tests/pull/803

Fix for a bug in the code, `type` variable was only defined for rails version `< 6.1`, for 6.1 or above it was failing with this error

![image](https://user-images.githubusercontent.com/12532597/110293829-5bdc2f00-7fef-11eb-90f1-20683a84e18e.png)


## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
