### PR TITLE
Run default test folder if no arguments passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Added
 
-- None
+- Run default test folder if no arguments are passed.
 
 ### Fixed
 

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -274,7 +274,11 @@ module ParallelTests
 
       files, remaining = extract_file_paths(argv)
       unless options[:execute]
-        abort "Pass files or folders to run" unless files.any?
+        unless files.any?
+          default_test_folder = @runner.default_test_folder
+          files = [default_test_folder] if File.exist?(default_test_folder)
+          abort "Pass files or folders to run" unless files.any?
+        end
         options[:files] = files.map { |file_path| Pathname.new(file_path).cleanpath.to_s }
       end
 

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -274,10 +274,10 @@ module ParallelTests
 
       files, remaining = extract_file_paths(argv)
       unless options[:execute]
-        unless files.any?
+        if files.empty?
           default_test_folder = @runner.default_test_folder
           files = [default_test_folder] if File.directory?(default_test_folder)
-          abort "Pass files or folders to run" unless files.any?
+          abort "Pass files or folders to run" if files.empty?
         end
         options[:files] = files.map { |file_path| Pathname.new(file_path).cleanpath.to_s }
       end

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -276,7 +276,7 @@ module ParallelTests
       unless options[:execute]
         unless files.any?
           default_test_folder = @runner.default_test_folder
-          files = [default_test_folder] if File.exist?(default_test_folder)
+          files = [default_test_folder] if File.directory?(default_test_folder)
           abort "Pass files or folders to run" unless files.any?
         end
         options[:files] = files.map { |file_path| Pathname.new(file_path).cleanpath.to_s }

--- a/lib/parallel_tests/cucumber/runner.rb
+++ b/lib/parallel_tests/cucumber/runner.rb
@@ -12,6 +12,10 @@ module ParallelTests
           'cucumber'
         end
 
+        def default_test_folder
+          'features'
+        end
+
         def line_is_result?(line)
           super || line =~ SCENARIO_REGEX || line =~ SCENARIOS_RESULTS_BOUNDARY_REGEX
         end

--- a/lib/parallel_tests/gherkin/runner.rb
+++ b/lib/parallel_tests/gherkin/runner.rb
@@ -34,6 +34,10 @@ module ParallelTests
           @test_file_name || 'feature'
         end
 
+        def default_test_folder
+          'features'
+        end
+
         def test_suffix
           /\.feature$/
         end

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -26,6 +26,10 @@ module ParallelTests
           "tmp/parallel_runtime_rspec.log"
         end
 
+        def default_test_folder
+          "spec"
+        end
+
         def test_file_name
           "spec"
         end

--- a/lib/parallel_tests/spinach/runner.rb
+++ b/lib/parallel_tests/spinach/runner.rb
@@ -9,6 +9,10 @@ module ParallelTests
           'spinach'
         end
 
+        def default_test_folder
+          'features'
+        end
+
         def runtime_logging
           # Not Yet Supported
           ""

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -15,6 +15,10 @@ module ParallelTests
           /_(test|spec).rb$/
         end
 
+        def default_test_folder
+          "test"
+        end
+
         def test_file_name
           "test"
         end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -54,8 +54,14 @@ describe 'CLI' do
     result
   end
 
-  def self.it_fails_without_any_files(type)
-    it "fails without any files" do
+  def self.it_runs_the_default_folder_if_it_exists(type, test_folder)
+    it "runs the default folder if it exists" do
+      full_path_to_test_folder = File.join(folder, test_folder)
+      ensure_folder full_path_to_test_folder
+      results = run_tests("", fail: false, type: type)
+      expect(results).to_not include("Pass files or folders to run")
+
+      FileUtils.remove_dir(full_path_to_test_folder, true)
       results = run_tests("", fail: true, type: type)
       expect(results).to include("Pass files or folders to run")
     end
@@ -402,7 +408,7 @@ describe 'CLI' do
   end
 
   context "RSpec" do
-    it_fails_without_any_files "rspec"
+    it_runs_the_default_folder_if_it_exists "rspec", "spec"
 
     it "captures seed with random failures with --verbose" do
       write 'spec/xxx_spec.rb', 'describe("it"){it("should"){puts "TEST1"}}'
@@ -426,7 +432,7 @@ describe 'CLI' do
       expect(result).to include('test_xxx') # verbose output of every test
     end
 
-    it_fails_without_any_files "test"
+    it_runs_the_default_folder_if_it_exists "test", "test"
   end
 
   context "Cucumber" do
@@ -480,7 +486,7 @@ describe 'CLI' do
       expect(result.scan(/YOUR TEST ENV IS \d?!/).sort).to eq(["YOUR TEST ENV IS !", "YOUR TEST ENV IS 2!"])
     end
 
-    it_fails_without_any_files "cucumber"
+    it_runs_the_default_folder_if_it_exists "cucumber", "features"
 
     it "collates failing scenarios" do
       write "features/pass.feature", "Feature: xxx\n  Scenario: xxx\n    Given I pass"
@@ -596,7 +602,7 @@ describe 'CLI' do
       expect(result.scan(/YOUR TEST ENV IS \d?!/).sort).to eq(["YOUR TEST ENV IS !", "YOUR TEST ENV IS 2!"])
     end
 
-    it_fails_without_any_files "spinach"
+    it_runs_the_default_folder_if_it_exists "spinach", "features"
   end
 
   describe "graceful shutdown" do

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -13,9 +13,9 @@ describe ParallelTests::CLI do
       subject.send(:parse_options!, *args)
     end
 
-    it "fails without file" do
-      expect(subject).to receive(:abort).with("Pass files or folders to run")
-      call(["-n3"])
+    it "does not fail without file" do
+      expect(subject).not_to receive(:abort)
+      call(["-n3", "-t", "rspec"])
     end
 
     it "cleanups file paths" do


### PR DESCRIPTION
Sometimes, since I'm used to how `rspec` works, I run `parallel_rspec` and I expect it to run all specs.

However, it currently gives the error:

> Pass files or folders to run

This PR proposes to make it work like other test runners, and run all tests by default.

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
