### PR TITLE
Adding --highest-exit-status which returns the highest exit status from test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
     - name: Setup OS dependencies
       uses: MSP-Greg/setup-ruby-pkgs@v1
       with:
+        bundler: 2.2.15
         ruby-version: ${{ matrix.ruby }}
         apt-get:  libsqlite3-dev
     - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Added
 
-- None
+- Added `--highest-exit-status` option to return the highest exit status to allow sub-processes to send things other than 1
 
 ### Fixed
 

--- a/Readme.md
+++ b/Readme.md
@@ -202,22 +202,21 @@ Options are:
     -p, --pattern [PATTERN]          run tests matching this regex pattern
         --exclude-pattern [PATTERN]  exclude tests matching this regex pattern
         --group-by [TYPE]            group tests by:
-          found - order of finding files
-          steps - number of cucumber/spinach steps
-          scenarios - individual cucumber scenarios
-          filesize - by size of the file
-          runtime - info from runtime log
-          default - runtime when runtime log is filled otherwise filesize
+                                     found - order of finding files
+                                     steps - number of cucumber/spinach steps
+                                     scenarios - individual cucumber scenarios
+                                     filesize - by size of the file
+                                     runtime - info from runtime log
+                                     default - runtime when runtime log is filled otherwise filesize
     -m, --multiply-processes [FLOAT] use given number as a multiplier of processes to run
     -s, --single [PATTERN]           Run all matching files in the same process
-    -i, --isolate                    Do not run any other tests in the group used by --single(-s).
-                                     Automatically turned on if --isolate-n is set above 0.
-        --isolate-n                  Number of processes for isolated groups. Default to 1 when --isolate is on.
+    -i, --isolate                    Do not run any other tests in the group used by --single(-s)
+        --isolate-n [PROCESSES]      Use 'isolate'  singles with number of processes, default: 1.
+        --highest-exit-status        Exit with the highest exit status provided by test run(s)
         --specify-groups [SPECS]     Use 'specify-groups' if you want to specify multiple specs running in multiple
                                      processes in a specific formation. Commas indicate specs in the same process,
-                                     pipes indicate specs in a new process.  Cannot use with --single, --isolate, or
+                                     pipes indicate specs in a new process. Cannot use with --single, --isolate, or
                                      --isolate-n.  Ex.
-                                     Ex.
                                      $ parallel_tests -n 3 . --specify-groups '1_spec.rb,2_spec.rb|3_spec.rb'
                                        Process 1 will contain 1_spec.rb and 2_spec.rb
                                        Process 2 will contain 3_spec.rb
@@ -227,8 +226,8 @@ Options are:
     -o, --test-options '[OPTIONS]'   execute test commands with those options
     -t, --type [TYPE]                test(default) / rspec / cucumber / spinach
         --suffix [PATTERN]           override built in test file pattern (should match suffix):
-          '_spec.rb$' - matches rspec files
-          '_(test|spec).rb$' - matches test or spec files
+                                     '_spec.rb$' - matches rspec files
+                                     '_(test|spec).rb$' - matches test or spec files
         --serialize-stdout           Serialize stdout output, nothing will be written until everything is done
         --prefix-output-with-test-env-number
                                      Prefixes test env number to the output when not using --serialize-stdout


### PR DESCRIPTION
## Description

This change-sets adds a `--retain-exit-status` which returns the highest exit status from a test run failure rather than always exiting with 1 when running in parallel.

The use-case for this is test suites that use exit statuses to communicate additional information besides failure such as marking a suite as unstable.

This treats an exit status of 1 as a generic failure which is the default for most suites, and treats any error above 1 as being preferred when present.

This change is backwards compatible for existing test suites that use parallel_tests.

Thank you for your contribution!

## Checklist

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] Update Readme.md when cli options are changed
