### PR TITLE
Permit parallel_tests/cucumber running to allow --retry flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 ### Fixed
 
-- None
+- All cucumber options are now pushed to the end of the command invocation
+  - Fixes an issue where the `--retry` flag wouldn't work correctly 
 
 ## v3.7.0 - 2021-04-08
 

--- a/lib/parallel_tests/gherkin/runner.rb
+++ b/lib/parallel_tests/gherkin/runner.rb
@@ -21,16 +21,13 @@ module ParallelTests
           options[:env] ||= {}
           options[:env] = options[:env].merge({ 'AUTOTEST' => '1' }) if $stdout.tty?
 
-          opts = cucumber_opts(options[:test_options])
-          puts "My opts are: #{opts}\n\n"
           cmd = [
             executable,
             (runtime_logging if File.directory?(File.dirname(runtime_log))),
-            opts[0],
             *sanitized_test_files,
-            opts[1]
+            cucumber_opts(options[:test_options])
           ].compact.reject(&:empty?).join(' ')
-          puts "I am running : #{cmd}\n\n"
+          execute_command(cmd, process_number, num_processes, options)
         end
 
         def test_file_name
@@ -70,25 +67,11 @@ module ParallelTests
         end
 
         def cucumber_opts(given)
-          initial =
-            if given =~ (/--profile/) || given =~ (/(^|\s)-p /)
-              given
-            else
-              [given, profile_from_config].compact.join(" ")
-            end
-
-          opts_as_individuals = initial.scan(/\S+\s\S+/)
-          desired_output = ['', '']
-
-          opts_as_individuals.each do |opt|
-            if opt.match?(/--retry \d+/)
-              desired_output[1] = opt
-            else
-              desired_output[0] = "#{desired_output[0]} #{opt}".strip
-            end
+          if given =~ (/--profile/) || given =~ (/(^|\s)-p /)
+            given
+          else
+            [given, profile_from_config].compact.join(" ")
           end
-
-          desired_output
         end
 
         def profile_from_config

--- a/spec/fixtures/rails60/Gemfile.lock
+++ b/spec/fixtures/rails60/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    parallel_tests (3.5.2)
+    parallel_tests (3.7.0)
       parallel
 
 GEM
@@ -121,4 +121,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   2.2.15
+   2.2.19

--- a/spec/fixtures/rails61/Gemfile.lock
+++ b/spec/fixtures/rails61/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    parallel_tests (3.5.2)
+    parallel_tests (3.7.0)
       parallel
 
 GEM
@@ -122,4 +122,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   2.2.15
+   2.2.19

--- a/spec/parallel_tests/gherkin/runner_behaviour.rb
+++ b/spec/parallel_tests/gherkin/runner_behaviour.rb
@@ -74,9 +74,9 @@ shared_examples_for 'gherkin runners' do
 
       it "uses parallel profile" do
         if ParallelTests::WINDOWS
-          should_run_with %r{script/#{runner_name} .*foo bar --profile parallel "xxx"}
+          should_run_with %r{script/#{runner_name} "xxx" .*foo bar --profile parallel}
         else
-          should_run_with %r{script/#{runner_name} .*foo bar --profile parallel xxx}
+          should_run_with %r{script/#{runner_name} xxx .*foo bar --profile parallel}
         end
 
         call(['xxx'], 1, 22, test_options: 'foo bar')
@@ -84,9 +84,9 @@ shared_examples_for 'gherkin runners' do
 
       it "uses given profile via --profile" do
         if ParallelTests::WINDOWS
-          should_run_with %r{script/#{runner_name} .*--profile foo "xxx"$}
+          should_run_with %r{script/#{runner_name} "xxx" .*--profile foo$}
         else
-          should_run_with %r{script/#{runner_name} .*--profile foo xxx$}
+          should_run_with %r{script/#{runner_name} xxx .*--profile foo$}
         end
 
         call(['xxx'], 1, 22, test_options: '--profile foo')
@@ -94,9 +94,9 @@ shared_examples_for 'gherkin runners' do
 
       it "uses given profile via -p" do
         if ParallelTests::WINDOWS
-          should_run_with %r{script/#{runner_name} .*-p foo "xxx"$}
+          should_run_with %r{script/#{runner_name} "xxx" .*-p foo$}
         else
-          should_run_with %r{script/#{runner_name} .*-p foo xxx$}
+          should_run_with %r{script/#{runner_name} xxx .*-p foo$}
         end
 
         call(['xxx'], 1, 22, test_options: '-p foo')


### PR DESCRIPTION
Update running command to pass cucumber profile as the last argument (And permit --retry flag to work).

## Checklist
- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
