### PR TITLE
Fix missing v3.7.1 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@
 
 ### Fixed
 
+- None
+
+## v3.7.1 - 2021-08-14
+
+### Breaking Changes
+
+- None
+
+### Added
+
+- None
+
+### Fixed
+
 - All cucumber options are now pushed to the end of the command invocation
   - Fixes an issue where the `--retry` flag wouldn't work correctly 
 


### PR DESCRIPTION
Changelog entry was missing v3.7.1 entry and seems that `Unreleased` section is contained this change