### PR TITLE
Example of a failing spec when files have a non-Rails default file name

### DIFF
--- a/spec/fixtures/rails60/test/integration/non-default ( filename_test.rb
+++ b/spec/fixtures/rails60/test/integration/non-default ( filename_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/spec/fixtures/rails61/test/integration/non-default ( filename_test.rb
+++ b/spec/fixtures/rails61/test/integration/non-default ( filename_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -32,7 +32,7 @@ describe 'rails' do
           sh "bundle exec rake parallel:prepare"
           sh "bundle exec rails runner User.create", environment: { 'RAILS_ENV' => 'test' } # pollute the db
           out = sh "bundle exec rake parallel:prepare parallel:test"
-          expect(out).to match(/ 2 (tests|runs)/)
+          expect(out).to match(/ 3 (tests|runs)/)
         end
       end
     end


### PR DESCRIPTION
Thank you for your contribution!

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] ~Update Readme.md when cli options are changed~


related to issue [#727](https://github.com/grosser/parallel_tests/issues/727)

Workaround: https://github.com/swiknaba/parallel_tests/commit/bcf155442da4c32225a33bdab77bcf2c5a83f5c4

I'm running this on macOS `11.5.2` (iMac 2020), originally had this issue in 2019 (i.e. obviously with an older version of macOS, probably Mojave, using a MacBook 2017).

## output when the new files are named `foo_test.rb`
```
ry:parallel_tests ry$ ls spec/fixtures/rails61/test/integration/ -al | grep _test
.rw-r--r-- ry staff 118 B Mon Sep 13 21:01:51 2021 foo_test.rb

ry:parallel_tests ry$ ls spec/fixtures/rails60/test/integration/ -al | grep _test
.rw-r--r-- ry staff 118 B Mon Sep 13 21:01:57 2021 foo_test.rb

ry:parallel_tests ry$ rspec spec/rails_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 9932
..

Finished in 47.76 seconds (files took 0.13087 seconds to load)
2 examples, 0 failures
```

## output with "bad" file names
```
ry:parallel_tests ry$ ls spec/fixtures/rails61/test/integration/ -al | grep _test
.rw-r--r-- ry staff 118 B Mon Sep 13 21:09:33 2021 non-default ( filename_test.rb

ry:parallel_tests ry$ ls spec/fixtures/rails60/test/integration/ -al | grep _test
.rw-r--r-- ry staff 118 B Mon Sep 13 21:09:33 2021 non-default ( filename_test.rb


ry:parallel_tests ry$ rspec spec/rails_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 57038
FF

Failures:

  1) rails can create and run rails61
     Failure/Error: raise "FAILED #{command}\n#{result}" if $?.success? == !!options[:fail]
     
     RuntimeError:
       FAILED bundle exec rake parallel:prepare parallel:test
       3 processes for 3 tests, ~ 1 test per process
       -e:1:in `require': cannot load such file -- ./test/integration/non-default ( (LoadError)
       	from -e:1:in `block in <main>'
       	from -e:1:in `each'
       	from -e:1:in `<main>'
       Run options: --seed 46510
     
       # Running:
     
     
     
       Finished in 0.000741s, 0.0000 runs/s, 0.0000 assertions/s.
       0 runs, 0 assertions, 0 failures, 0 errors, 0 skips
       Run options: --seed 11937
     
       # Running:
     
     
     
       Finished in 0.000929s, 0.0000 runs/s, 0.0000 assertions/s.
       0 runs, 0 assertions, 0 failures, 0 errors, 0 skips
       Tests Failed
     
       0 assertions, 0 errors, 0 failures, 0 runs, 0 skips
     
       Took 1 seconds
     # ./spec/rails_spec.rb:12:in `sh'
     # ./spec/rails_spec.rb:34:in `block (5 levels) in <top (required)>'
     # ./spec/rails_spec.rb:21:in `block (4 levels) in <top (required)>'
     # ./spec/rails_spec.rb:20:in `chdir'
     # ./spec/rails_spec.rb:20:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:217:in `block (2 levels) in <top (required)>'

  2) rails can create and run rails60
     Failure/Error: raise "FAILED #{command}\n#{result}" if $?.success? == !!options[:fail]
     
     RuntimeError:
       FAILED bundle exec rake parallel:prepare parallel:test
       3 processes for 3 tests, ~ 1 test per process
       -e:1:in `require': cannot load such file -- ./test/integration/non-default ( (LoadError)
       	from -e:1:in `block in <main>'
       	from -e:1:in `each'
       	from -e:1:in `<main>'
       Run options: --seed 44002
     
       # Running:
     
     
     
       Finished in 0.000742s, 0.0000 runs/s, 0.0000 assertions/s.
       0 runs, 0 assertions, 0 failures, 0 errors, 0 skips
       Run options: --seed 41607
     
       # Running:
     
     
     
       Finished in 0.000813s, 0.0000 runs/s, 0.0000 assertions/s.
       0 runs, 0 assertions, 0 failures, 0 errors, 0 skips
       Tests Failed
     
       0 assertions, 0 errors, 0 failures, 0 runs, 0 skips
     
       Took 1 seconds
     # ./spec/rails_spec.rb:12:in `sh'
     # ./spec/rails_spec.rb:34:in `block (5 levels) in <top (required)>'
     # ./spec/rails_spec.rb:21:in `block (4 levels) in <top (required)>'
     # ./spec/rails_spec.rb:20:in `chdir'
     # ./spec/rails_spec.rb:20:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:217:in `block (2 levels) in <top (required)>'

Finished in 55.4 seconds (files took 0.11683 seconds to load)
2 examples, 2 failures

Failed examples:

rspec ./spec/rails_spec.rb[1:2] # rails can create and run rails61
rspec ./spec/rails_spec.rb[1:1] # rails can create and run rails60
```