### PR TITLE
allow running test files with multiple spaces

### DIFF
--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -24,7 +24,7 @@ module ParallelTests
         end
 
         def run_tests(test_files, process_number, num_processes, options)
-          require_list = test_files.map { |file| file.sub(" ", "\\ ") }.join(" ")
+          require_list = test_files.map { |file| file.gsub(" ", "\\ ") }.join(" ")
           cmd = "#{executable} -Itest -e '%w[#{require_list}].each { |f| require %{./\#{f}} }' -- #{options[:test_options]}"
           execute_command(cmd, process_number, num_processes, options)
         end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -465,6 +465,12 @@ describe 'CLI' do
     )
   end
 
+  it "can run with uncommon file names" do
+    skip if RUBY_PLATFORM == "java" # just too slow ...
+    write "test/long ( stuff ) _test.rb", "puts 'hey'"
+    expect(run_tests("test", processes: 2)).to include("hey")
+  end
+
   context "RSpec" do
     it_runs_the_default_folder_if_it_exists "rspec", "spec"
 


### PR DESCRIPTION
replaces https://github.com/grosser/parallel_tests/pull/831
fixes #727
 
@swiknaba