### PR TITLE
Require "set" module in spec/parallel_tests/test/runner_spec.rb

### DIFF
--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "set"
 require "spec_helper"
 require "parallel_tests/test/runner"
 


### PR DESCRIPTION
Fixes the following failure when running the test in isolation:

    $ bundle exec rspec spec/parallel_tests/test/runner_spec.rb

    1) ParallelTests::Test::Runner.test_in_groups when passed runtime groups by size and uses specified groups of specs in specific order in specific processes
       Failure/Error: actual = groups.map(&:to_set).to_set

       NoMethodError:
         undefined method `to_set' for ["ddd", "eee"]:Array

                 actual = groups.map(&:to_set).to_set
                                ^^^^

Thank you for your contribution!

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
