### PR TITLE
Remove redundant File.exists? checks in specs

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -16,7 +16,7 @@ describe 'CLI' do
 
   def write(file, content)
     path = "#{folder}/#{file}"
-    ensure_folder File.dirname(path)
+    FileUtils.mkpath File.dirname(path)
     File.write(path, content)
     path
   end
@@ -33,12 +33,8 @@ describe 'CLI' do
     "ruby #{bin_folder}/parallel_#{options[:type] || 'test'}"
   end
 
-  def ensure_folder(folder)
-    FileUtils.mkpath(folder) unless File.exist?(folder)
-  end
-
   def run_tests(test_folder, options = {})
-    ensure_folder folder
+    FileUtils.mkpath folder
     processes = "-n #{options[:processes] || 2}" unless options[:processes] == false
     command = "#{executable(options)} #{test_folder} #{processes} #{options[:add]}"
     result = ''
@@ -57,7 +53,7 @@ describe 'CLI' do
   def self.it_runs_the_default_folder_if_it_exists(type, test_folder)
     it "runs the default folder if it exists" do
       full_path_to_test_folder = File.join(folder, test_folder)
-      ensure_folder full_path_to_test_folder
+      FileUtils.mkpath full_path_to_test_folder
       results = run_tests("", fail: false, type: type)
       expect(results).to_not include("Pass files or folders to run")
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,7 +44,7 @@ module SpecHelper
     Dir.mktmpdir do |root|
       files.each do |file|
         parent = "#{root}/#{File.dirname(file)}"
-        FileUtils.mkpath(parent) unless File.exist?(parent)
+        FileUtils.mkpath(parent)
         FileUtils.touch(File.join(root, file))
       end
       yield root


### PR DESCRIPTION
FileUtils.mkpath already checks if a directory exists before creating
it, so there is no need to do so again. Avoid the extra system call when
it is unnecessary.

Thank you for your contribution!

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
