### PR TITLE
Remove obsolete export statement filter in lib/parallel_tests/cli.rb

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -140,7 +140,6 @@ module ParallelTests
         puts "\n\nTests have failed for a parallel_test group. Use the following command to run the group again:\n\n"
         failing_sets.each do |failing_set|
           command = failing_set[:command]
-          command = command.gsub(/;export [A-Z_]+;/, ' ') # remove ugly export statements
           command = @runner.command_with_seed(command, failing_set[:seed]) if failing_set[:seed]
           puts command
         end


### PR DESCRIPTION
Obsolete since e36fa9f8235844afabba624eb58549ad58ddc9ef.

The subprocesses were switched to using IO.popen which passes
environment variables. The subprocess command no longer includes export.

Thank you for your contribution!

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
