### PR TITLE
Avoid using a shell for subprocesses during tests

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -55,9 +55,8 @@ module ParallelTests
         remove_ignored_lines = %{(grep -v "#{ignore_regex}" || test 1)}
 
         if File.executable?('/bin/bash') && system('/bin/bash', '-c', "#{activate_pipefail} 2>/dev/null && test 1")
-          # We need to shell escape single quotes (' becomes '"'"') because
-          # run_in_parallel wraps command in single quotes
-          %{/bin/bash -c '"'"'#{activate_pipefail} && (#{command}) | #{remove_ignored_lines}'"'"'}
+          shell_command = "#{activate_pipefail} && (#{command}) | #{remove_ignored_lines}"
+          %(/bin/bash -c #{Shellwords.escape(shell_command)})
         else
           command
         end

--- a/spec/parallel_tests/rspec/runtime_logger_spec.rb
+++ b/spec/parallel_tests/rspec/runtime_logger_spec.rb
@@ -90,7 +90,7 @@ describe ParallelTests::RSpec::RuntimeLogger do
 
       system(
         { 'TEST_ENV_NUMBER' => '1' },
-        "rspec spec -I #{Bundler.root.join("lib")} --format ParallelTests::RSpec::RuntimeLogger --out runtime.log 2>&1"
+        "rspec", "spec", "-I", Bundler.root.join("lib").to_s, "--format", "ParallelTests::RSpec::RuntimeLogger", "--out", "runtime.log"
       ) || raise("nope")
 
       result = File.read("runtime.log")
@@ -122,7 +122,7 @@ describe ParallelTests::RSpec::RuntimeLogger do
 
       system(
         { 'TEST_ENV_NUMBER' => '1' },
-        "rspec spec -I #{Bundler.root.join("lib")} --format ParallelTests::RSpec::RuntimeLogger --out runtime.log 2>&1"
+        "rspec", "spec", "-I", Bundler.root.join("lib").to_s, "--format", "ParallelTests::RSpec::RuntimeLogger", "--out", "runtime.log"
       ) || raise("nope")
 
       result = File.read("runtime.log")

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -92,7 +92,7 @@ describe ParallelTests::Tasks do
       # Explictly run as a parameter to /bin/sh to simulate how
       # the command will be run by parallel_test --exec
       # This also tests shell escaping of single quotes
-      result = `/bin/sh -c '#{ParallelTests::Tasks.suppress_output(command, grep)}'`
+      result = IO.popen(['/bin/sh', '-c', ParallelTests::Tasks.suppress_output(command, grep)], &:read)
       [result, $?.success?]
     end
 

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -264,7 +264,7 @@ describe ParallelTests::Test::Runner do
 
     it "finds test files nested in symlinked folders" do
       with_files(['a/a_test.rb', 'b/b_test.rb']) do |root|
-        `ln -s #{root}/a #{root}/b/link`
+        File.symlink("#{root}/a", "#{root}/b/link")
         expect(call(["#{root}/b"]).sort).to eq(
           [
             "#{root}/b/b_test.rb",
@@ -277,7 +277,7 @@ describe ParallelTests::Test::Runner do
     it "finds test files but ignores those in symlinked folders" do
       skip if RUBY_PLATFORM == "java" || Gem.win_platform?
       with_files(['a/a_test.rb', 'b/b_test.rb']) do |root|
-        `ln -s #{root}/a #{root}/b/link`
+        File.symlink("#{root}/a", "#{root}/b/link")
         expect(call(["#{root}/b"], symlinks: false).sort).to eq(["#{root}/b/b_test.rb"])
       end
     end

--- a/spec/parallel_tests/test/runtime_logger_spec.rb
+++ b/spec/parallel_tests/test/runtime_logger_spec.rb
@@ -2,13 +2,13 @@
 require 'spec_helper'
 
 describe ParallelTests::Test::RuntimeLogger do
-  def sh(command)
-    result = `#{command} 2>&1`
+  def run(command)
+    result = IO.popen(command, err: [:child, :out], &:read)
     raise "FAILED: #{result}" unless $?.success?
   end
 
   def run_tests
-    sh "ruby #{Bundler.root}/bin/parallel_test test -n 2"
+    run ["ruby", "#{Bundler.root}/bin/parallel_test", "test", "-n", "2"]
   end
 
   it "writes a correct log on minitest-5" do

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -5,11 +5,8 @@ require 'spec_helper'
 describe 'rails' do
   let(:test_timeout) { 800 } # this can take very long on fresh bundle ...
 
-  def sh(command, options = {})
-    result = ''
-    IO.popen(options.fetch(:environment, {}), command, err: [:child, :out]) do |io|
-      result = io.read
-    end
+  def run(command, options = {})
+    result = IO.popen(options.fetch(:environment, {}), command, err: [:child, :out], &:read)
     raise "FAILED #{command}\n#{result}" if $?.success? == !!options[:fail]
     result
   end
@@ -28,15 +25,15 @@ describe 'rails' do
           ENV.delete("RAILS_ENV")
           ENV.delete("RACK_ENV")
 
-          sh "bundle config --local path vendor/bundle"
-          sh "bundle install"
+          run ["bundle", "config", "--local", "path", "vendor/bundle"]
+          run ["bundle", "install"]
           FileUtils.rm_f(Dir['db/*.sqlite3'])
-          sh "bundle exec rake db:setup parallel:create --trace 2>&1"
+          run ["bundle", "exec", "rake", "db:setup", "parallel:create"]
           # Also test the case where the DBs need to be dropped
-          sh "bundle exec rake parallel:drop parallel:create"
-          sh "bundle exec rake parallel:prepare"
-          sh "bundle exec rails runner User.create", environment: { 'RAILS_ENV' => 'test' } # pollute the db
-          out = sh "bundle exec rake parallel:prepare parallel:test"
+          run ["bundle", "exec", "rake", "parallel:drop", "parallel:create"]
+          run ["bundle", "exec", "rake", "parallel:prepare"]
+          run ["bundle", "exec", "rails", "runner", "User.create"], environment: { 'RAILS_ENV' => 'test' } # pollute the db
+          out = run ["bundle", "exec", "rake", "parallel:prepare", "parallel:test"]
           expect(out).to match(/ 2 (tests|runs)/)
         end
       end


### PR DESCRIPTION
Treat subprocesses commands as an array of strings. This avoid the need
to include a shell in the subprocess. Instead, the commands execute
directly. As well, there is no need to parse or format shell
syntax (such as string quoting).

Thank you for your contribution!

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
