### PR TITLE
Changed subprocesses to execute without a shell.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- None
+- Changed subprocesses to execute without a shell.
 
 ### Added
 

--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -76,7 +76,7 @@ module ParallelTests
     end
 
     def with_ruby_binary(command)
-      WINDOWS ? "#{RUBY_BINARY} -- #{command}" : command
+      WINDOWS ? [RUBY_BINARY, '--', command] : [command]
     end
 
     def wait_for_other_processes_to_finish

--- a/lib/parallel_tests/cucumber/runner.rb
+++ b/lib/parallel_tests/cucumber/runner.rb
@@ -35,8 +35,8 @@ module ParallelTests
         end
 
         def command_with_seed(cmd, seed)
-          clean = cmd.sub(/\s--order\s+random(:\d+)?\b/, '')
-          "#{clean} --order random:#{seed}"
+          clean = remove_command_arguments(cmd, '--order')
+          [*clean, '--order', "random:#{seed}"]
         end
       end
     end

--- a/lib/parallel_tests/cucumber/scenarios.rb
+++ b/lib/parallel_tests/cucumber/scenarios.rb
@@ -4,7 +4,6 @@ require 'cucumber/runtime'
 require 'cucumber'
 require 'parallel_tests/cucumber/scenario_line_logger'
 require 'parallel_tests/gherkin/listener'
-require 'shellwords'
 
 begin
   gem "cuke_modeler", "~> 3.0"
@@ -20,7 +19,7 @@ module ParallelTests
         def all(files, options = {})
           # Parse tag expression from given test options and ignore tag pattern. Refer here to understand how new tag expression syntax works - https://github.com/cucumber/cucumber/tree/master/tag-expressions
           tags = []
-          words = options[:test_options].to_s.shellsplit
+          words = options[:test_options] || []
           words.each_with_index { |w, i| tags << words[i + 1] if ["-t", "--tags"].include?(w) }
           if ignore = options[:ignore_tag_pattern]
             tags << "not (#{ignore})"

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -7,8 +7,7 @@ module ParallelTests
       DEV_NULL = (WINDOWS ? "NUL" : "/dev/null")
       class << self
         def run_tests(test_files, process_number, num_processes, options)
-          exe = executable # expensive, so we cache
-          cmd = [exe, options[:test_options], color, spec_opts, *test_files].compact.join(" ")
+          cmd = [*executable, *options[:test_options], *color, *spec_opts, *test_files]
           execute_command(cmd, process_number, num_processes, options)
         end
 
@@ -16,9 +15,9 @@ module ParallelTests
           if File.exist?("bin/rspec")
             ParallelTests.with_ruby_binary("bin/rspec")
           elsif ParallelTests.bundler_enabled?
-            "bundle exec rspec"
+            ["bundle", "exec", "rspec"]
           else
-            "rspec"
+            ["rspec"]
           end
         end
 
@@ -48,8 +47,8 @@ module ParallelTests
         # --order rand:1234
         # --order random:1234
         def command_with_seed(cmd, seed)
-          clean = cmd.sub(/\s--(seed\s+\d+|order\s+rand(om)?(:\d+)?)\b/, '')
-          "#{clean} --seed #{seed}"
+          clean = remove_command_arguments(cmd, '--seed', '--order')
+          [*clean, '--seed', seed]
         end
 
         # Summarize results from threads and colorize results based on failure and pending counts.
@@ -71,19 +70,13 @@ module ParallelTests
 
         private
 
-        # so it can be stubbed....
-        def run(cmd)
-          `#{cmd}`
-        end
-
         def color
-          '--color --tty' if $stdout.tty?
+          ['--color', '--tty'] if $stdout.tty?
         end
 
         def spec_opts
           options_file = ['.rspec_parallel', 'spec/parallel_spec.opts', 'spec/spec.opts'].detect { |f| File.file?(f) }
-          return unless options_file
-          "-O #{options_file}"
+          ["-O", options_file] if options_file
         end
       end
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -385,7 +385,7 @@ describe 'CLI' do
     write "test/xxx_test.rb", 'puts "Test output: YES"'
     result = run_tests(["test"], processes: 2, type: 'test', add: ['--verbose'])
     expect(result).to include "Test output: YES"
-    expect(result).to include "[test/xxx_test.rb]"
+    expect(result).to include "\\[test/xxx_test.rb\\]"
     expect(result).not_to include Dir.pwd
   end
 
@@ -487,7 +487,7 @@ describe 'CLI' do
       write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){1.should == 2}}'
       result = run_tests ["spec", "--verbose"], add: ["--test-options", "--seed 1234"], fail: true, type: 'rspec'
       expect(result).to include("Randomized with seed 1234")
-      expect(result).to include("bundle exec rspec spec/xxx2_spec.rb --seed 1234")
+      expect(result).to include("bundle exec rspec --seed 1234 spec/xxx2_spec.rb")
     end
   end
 

--- a/spec/parallel_tests/cucumber/runner_spec.rb
+++ b/spec/parallel_tests/cucumber/runner_spec.rb
@@ -37,20 +37,20 @@ describe ParallelTests::Cucumber::Runner do
   end
 
   describe ".command_with_seed" do
-    def call(part)
-      ParallelTests::Cucumber::Runner.command_with_seed("cucumber#{part}", 555)
+    def call(*args)
+      ParallelTests::Cucumber::Runner.command_with_seed(['cucumber', *args], 555)
     end
 
     it "adds the randomized seed" do
-      expect(call("")).to eq("cucumber --order random:555")
+      expect(call).to eq(["cucumber", "--order", "random:555"])
     end
 
     it "does not duplicate existing random command" do
-      expect(call(" --order random good1.feature")).to eq("cucumber good1.feature --order random:555")
+      expect(call("--order", "random", "good1.feature")).to eq(["cucumber", "good1.feature", "--order", "random:555"])
     end
 
     it "does not duplicate existing random command with seed" do
-      expect(call(" --order random:123 good1.feature")).to eq("cucumber good1.feature --order random:555")
+      expect(call("--order", "random:123", "good1.feature")).to eq(["cucumber", "good1.feature", "--order", "random:555"])
     end
   end
 end

--- a/spec/parallel_tests/cucumber/scenarios_spec.rb
+++ b/spec/parallel_tests/cucumber/scenarios_spec.rb
@@ -87,59 +87,59 @@ describe ParallelTests::Cucumber::Scenarios do
     end
 
     it 'Single Feature Tag: colours' do
-      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: "-t @colours")
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: ["-t", "@colours"])
       expect(scenarios.length).to eq 7
     end
 
     it 'Single Scenario Tag: white' do
-      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: "-t @white")
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: ["-t", "@white"])
       expect(scenarios.length).to eq 2
     end
 
     it 'Multiple Scenario Tags 1: black && white' do
-      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: "-t '@black and @white'")
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: ["-t", "@black and @white"])
       expect(scenarios.length).to eq 1
     end
 
     it 'Multiple Scenario Tags 2: black || white scenarios' do
-      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: "-t '@black or @white'")
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: ["-t", "@black or @white"])
       expect(scenarios.length).to eq 3
     end
 
     it 'Scenario Outline Tag: red' do
-      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: "-t @red")
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: ["-t", "@red"])
       expect(scenarios.length).to eq 4
     end
 
     it 'Example Tag: blue' do
-      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: "-t @blue")
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: ["-t", "@blue"])
       expect(scenarios.length).to eq 3
     end
 
     it 'Multiple Example Tags 1: blue && green' do
-      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: "-t '@blue and @green'")
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: ["-t", "@blue and @green"])
       expect(scenarios.length).to eq 1
     end
 
     it 'Multiple Example Tags 2: blue || green' do
-      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: "-t '@blue or @green'")
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: ["-t", "@blue or @green"])
       expect(scenarios.length).to eq 4
     end
 
     it 'Single Negative Feature Tag: !colours' do
-      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: "-t 'not @colours'")
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: ["-t", "not @colours"])
       expect(scenarios.length).to eq 0
     end
 
     it 'Single Negative Scenario Tag: !black' do
-      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: "-t 'not @black'")
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: ["-t", "not @black"])
       expect(scenarios.length).to eq 5
     end
 
     it 'Multiple Negative Scenario Tags And: !(black && white)' do
       scenarios = ParallelTests::Cucumber::Scenarios.all(
         [feature_file.path],
-        test_options: "-t 'not (@black and @white)'"
+        test_options: ["-t", "not (@black and @white)"]
       )
       expect(scenarios.length).to eq 6
     end
@@ -147,25 +147,25 @@ describe ParallelTests::Cucumber::Scenarios do
     it 'Multiple Negative Scenario Tags Or: !(black || red)' do
       scenarios = ParallelTests::Cucumber::Scenarios.all(
         [feature_file.path],
-        test_options: "-t 'not (@black or @red)'"
+        test_options: ["-t", "not (@black or @red)"]
       )
       expect(scenarios.length).to eq 1
     end
 
     it 'Negative Scenario Outline Tag: !red' do
-      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: "-t 'not @red'")
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: ["-t", "not @red"])
       expect(scenarios.length).to eq 3
     end
 
     it 'Negative Example Tag: !blue' do
-      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: "-t 'not @blue'")
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: ["-t", "not @blue"])
       expect(scenarios.length).to eq 4
     end
 
     it 'Multiple Negative Example Tags 1: !blue && !green' do
       scenarios = ParallelTests::Cucumber::Scenarios.all(
         [feature_file.path],
-        test_options: "-t 'not @blue and not @green'"
+        test_options: ["-t", "not @blue and not @green"]
       )
       expect(scenarios.length).to eq 3
     end
@@ -173,20 +173,20 @@ describe ParallelTests::Cucumber::Scenarios do
     it 'Multiple Negative Example Tags 2: !blue || !green) ' do
       scenarios = ParallelTests::Cucumber::Scenarios.all(
         [feature_file.path],
-        test_options: "-t 'not @blue or not @green'"
+        test_options: ["-t", "not @blue or not @green"]
       )
       expect(scenarios.length).to eq 6
     end
 
     it 'Scenario and Example Mixed Tags: black || green' do
-      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: "-t '@black or @green'")
+      scenarios = ParallelTests::Cucumber::Scenarios.all([feature_file.path], test_options: ["-t", "@black or @green"])
       expect(scenarios.length).to eq 4
     end
 
     it 'Positive and Negative Mixed Tags: red && !blue' do
       scenarios = ParallelTests::Cucumber::Scenarios.all(
         [feature_file.path],
-        test_options: "-t '@red and not @blue'"
+        test_options: ["-t", "@red and not @blue"]
       )
       expect(scenarios.length).to eq 1
     end
@@ -194,7 +194,7 @@ describe ParallelTests::Cucumber::Scenarios do
     it 'Multiple Positive and Negative Mixed Tags: (white && black) || (red && !blue)' do
       scenarios = ParallelTests::Cucumber::Scenarios.all(
         [feature_file.path],
-        test_options: "--tags '(not @white and @black) or (@red and not @green)'"
+        test_options: ["--tags", "(not @white and @black) or (@red and not @green)"]
       )
       expect(scenarios.length).to eq 3
     end
@@ -227,7 +227,7 @@ describe ParallelTests::Cucumber::Scenarios do
     it 'Scenario Mixed tags: black && !blue with Ignore Tag Pattern Multiple Tags: red || white' do
       scenarios = ParallelTests::Cucumber::Scenarios.all(
         [feature_file.path],
-        test_options: "-t '@black and not @blue'", ignore_tag_pattern: "@red or @white"
+        test_options: ["-t", "@black and not @blue"], ignore_tag_pattern: "@red or @white"
       )
       expect(scenarios.length).to eq 1
     end

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -6,27 +6,27 @@ describe ParallelTests::Tasks do
   describe ".parse_args" do
     it "should return the count" do
       args = { count: 2 }
-      expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "", "", ""])
+      expect(ParallelTests::Tasks.parse_args(args)).to eq([2, nil, nil, nil])
     end
 
     it "should default to the prefix" do
       args = { count: "models" }
-      expect(ParallelTests::Tasks.parse_args(args)).to eq([nil, "models", "", ""])
+      expect(ParallelTests::Tasks.parse_args(args)).to eq([nil, "models", nil, nil])
     end
 
     it "should return the count and pattern" do
       args = { count: 2, pattern: "models" }
-      expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "models", "", ""])
+      expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "models", nil, nil])
     end
 
     it "should return the count, pattern, and options" do
       args = { count: 2, pattern: "plain", options: "-p default" }
-      expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "plain", "-p default", ""])
+      expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "plain", "-p default", nil])
     end
 
     it "should return the count, pattern, and options" do
       args = { count: 2, pattern: "plain", options: "-p default --group-by steps" }
-      expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "plain", "-p default --group-by steps", ""])
+      expect(ParallelTests::Tasks.parse_args(args)).to eq([2, "plain", "-p default --group-by steps", nil])
     end
 
     it "should return the count, pattern, test options, and pass-through options" do
@@ -61,22 +61,30 @@ describe ParallelTests::Tasks do
     end
 
     it "runs command in parallel" do
-      expect(ParallelTests::Tasks).to receive(:system).with(/#{full_path} --exec 'echo'$/).and_return true
+      expect(ParallelTests::Tasks).to receive(:system)
+        .with(*ParallelTests.with_ruby_binary(full_path), '--exec', 'echo')
+        .and_return true
       ParallelTests::Tasks.run_in_parallel("echo")
     end
 
     it "runs command with :count option" do
-      expect(ParallelTests::Tasks).to receive(:system).with(/#{full_path} --exec 'echo' -n 123$/).and_return true
+      expect(ParallelTests::Tasks).to receive(:system)
+        .with(*ParallelTests.with_ruby_binary(full_path), '--exec', 'echo', '-n', 123)
+        .and_return true
       ParallelTests::Tasks.run_in_parallel("echo", count: 123)
     end
 
     it "runs without -n with blank :count option" do
-      expect(ParallelTests::Tasks).to receive(:system).with(/#{full_path} --exec 'echo'$/).and_return true
+      expect(ParallelTests::Tasks).to receive(:system)
+        .with(*ParallelTests.with_ruby_binary(full_path), '--exec', 'echo')
+        .and_return true
       ParallelTests::Tasks.run_in_parallel("echo", count: "")
     end
 
     it "runs command with :non_parallel option" do
-      expect(ParallelTests::Tasks).to receive(:system).with(/#{full_path} --exec 'echo' --non-parallel$/).and_return true
+      expect(ParallelTests::Tasks).to receive(:system)
+        .with(*ParallelTests.with_ruby_binary(full_path), '--exec', 'echo', '--non-parallel')
+        .and_return true
       ParallelTests::Tasks.run_in_parallel("echo", non_parallel: true)
     end
 

--- a/spec/parallel_tests_spec.rb
+++ b/spec/parallel_tests_spec.rb
@@ -185,7 +185,7 @@ describe ParallelTests do
     it 'kills the running child process', unless: Gem.win_platform? do
       ParallelTests.with_pid_file do
         Thread.new do
-          ParallelTests::Test::Runner.execute_command('sleep 3', 1, 1, {})
+          ParallelTests::Test::Runner.execute_command(['sleep', '3'], 1, 1, {})
         end
         sleep(0.2)
         expect(ParallelTests.pids.count).to eq(1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,15 +51,18 @@ module SpecHelper
     end
   end
 
-  def should_run_with(regex)
+  def should_run_with(command, *args)
     expect(ParallelTests::Test::Runner).to receive(:execute_command) do |a, _b, _c, _d|
-      expect(a).to match(regex)
+      expect(a.first(command.length)).to eq(command)
+      args.each do |arg|
+        expect(a).to include(arg)
+      end
     end
   end
 
-  def should_not_run_with(regex)
+  def should_not_run_with(arg)
     expect(ParallelTests::Test::Runner).to receive(:execute_command) do |a, _b, _c, _d|
-      expect(a).to_not match(regex)
+      expect(a).to_not include(arg)
     end
   end
 end


### PR DESCRIPTION
Treat subprocess commands as an array of strings. This avoid the need to
include a shell in the subprocess. Instead, the commands execute
directly. As well, there is less need to parse or format shell
syntax (such as string quoting).

Continue to handle IO redirection through IO.popen.

As a caution, this may be considered a backward incompatible change if
users are relying on injecting shell features through the CLI. I don't
expect this to be an issue in practice, but am raising it just in case.
It would be best to apply a major version bump before release to
maintain semantic versioning.

Thank you for your contribution!

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
