### PR TITLE
Alwasy use expanded canonical paths

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -18,7 +18,7 @@ module ParallelTests
       end
 
       def load_lib
-        $LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), '..'))
+        $LOAD_PATH << File.expand_path('..', __dir__)
         require "parallel_tests"
       end
 
@@ -231,7 +231,7 @@ namespace :parallel do
 
       type = 'features' if test_framework == 'spinach'
       # Using the relative path to find the binary allow to run a specific version of it
-      executable = File.join(File.dirname(__FILE__), '..', '..', 'bin', 'parallel_test')
+      executable = File.expand_path('../../bin/parallel_test', __dir__)
 
       command =
         "#{ParallelTests.with_ruby_binary(Shellwords.escape(executable))} #{type} " \

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -26,7 +26,7 @@ describe 'CLI' do
   end
 
   def bin_folder
-    "#{__dir__}/../bin"
+    File.expand_path('../bin', __dir__)
   end
 
   def executable(options = {})


### PR DESCRIPTION
In the event of a error or spec failure, it is often easier to debug a
problem when the path is expanded to its canonical form rather than
being many dots. These paths can sometimes appear in an error.

Thank you for your contribution!

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
