### PR TITLE
Trim trailing white space throughout the project

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,6 @@ Thank you for your contribution!
 ## Checklist
 - [ ] Feature branch is up-to-date with `master` (if not - rebase it).
 - [ ] Added tests.
-- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
+- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
   code introduces user-observable changes.
 - [ ] Update Readme.md when cli options are changed

--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,7 @@ test:
 
 ### Setup environment from scratch (create db and loads schema, useful for CI)
     rake parallel:setup
-    
+
 ### Drop all test databases
     rake parallel:drop
 
@@ -193,15 +193,15 @@ Setup for non-rails
  - use `ENV['TEST_ENV_NUMBER']` inside your tests to select separate db/memcache/etc. (docker compose: expose it)
 
  - Only run a subset of files / folders:
- 
+
     `parallel_test test/bar test/baz/foo_text.rb`
 
  - Pass test-options and files via `--`:
- 
+
     `parallel_rspec -- -t acceptance -f progress -- spec/foo_spec.rb spec/acceptance`
-    
+
  - Pass in test options, by using the -o flag (wrap everything in quotes):
- 
+
     `parallel_cucumber -n 2 -o '-p foo_profile --tags @only_this_tag or @only_that_tag --format summary'`
 
 Options are:


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all
in one go, it helps keep future diffs cleaner by avoiding spurious white
space changes on unrelated lines.

Thank you for your contribution!

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
