### PR TITLE
Simplify use of command "test" in subprocesses

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -55,9 +55,9 @@ module ParallelTests
       # - simple system "set -o pipefail" returns nil even though set -o pipefail exists with 0
       def suppress_output(command, ignore_regex)
         activate_pipefail = "set -o pipefail"
-        remove_ignored_lines = %{(grep -v "#{ignore_regex}" || test 1)}
+        remove_ignored_lines = %{(grep -v "#{ignore_regex}" || true)}
 
-        if File.executable?('/bin/bash') && system('/bin/bash', '-c', "#{activate_pipefail} 2>/dev/null && test 1")
+        if File.executable?('/bin/bash') && system('/bin/bash', '-c', "#{activate_pipefail} 2>/dev/null")
           shell_command = "#{activate_pipefail} && (#{command}) | #{remove_ignored_lines}"
           %(/bin/bash -c #{Shellwords.escape(shell_command)})
         else

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -106,7 +106,7 @@ describe ParallelTests::Tasks do
 
     context "with pipefail supported" do
       before :all do
-        unless system("/bin/bash", "-c", "set -o pipefail 2>/dev/null && test 1")
+        unless system("/bin/bash", "-c", "set -o pipefail 2>/dev/null")
           skip "pipefail is not supported on your system"
         end
       end
@@ -120,11 +120,11 @@ describe ParallelTests::Tasks do
       end
 
       it "should fail if command fails and the pattern matches" do
-        expect(call("echo 123 && test", "123")).to eq(["", false])
+        expect(call("echo 123 && false", "123")).to eq(["", false])
       end
 
       it "should fail if command fails and the pattern fails" do
-        expect(call("echo 124 && test", "123")).to eq(["124\n", false])
+        expect(call("echo 124 && false", "123")).to eq(["124\n", false])
       end
     end
 
@@ -132,7 +132,7 @@ describe ParallelTests::Tasks do
       before do
         expect(ParallelTests::Tasks).to receive(:system).with(
           '/bin/bash', '-c',
-          'set -o pipefail 2>/dev/null && test 1'
+          'set -o pipefail 2>/dev/null'
         ).and_return false
       end
 
@@ -141,7 +141,7 @@ describe ParallelTests::Tasks do
       end
 
       it "should not filter and fail" do
-        expect(call("echo 123 && test", "123")).to eq(["123\n", false])
+        expect(call("echo 123 && false", "123")).to eq(["123\n", false])
       end
     end
   end


### PR DESCRIPTION
`|| test 1` is equivalent to `true` which always returns a exit status
of 0. Using true is more explicit. See: https://linux.die.net/man/1/true

`&& test 1` is equivalent to using the exit status of the preceding
command, so just use it and avoid the extra syntax.

`&& test` is equivalent to `false` which always returns a exit status of
1. Using false is more explicit. See: https://linux.die.net/man/1/false

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
