### PR TITLE
Remove redundant File.executable?('/bin/bash') check

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -56,7 +56,7 @@ module ParallelTests
         activate_pipefail = "set -o pipefail"
         remove_ignored_lines = %{(grep -v #{Shellwords.escape(ignore_regex)} || true)}
 
-        if File.executable?('/bin/bash') && system('/bin/bash', '-c', "#{activate_pipefail} 2>/dev/null")
+        if system('/bin/bash', '-c', "#{activate_pipefail} 2>/dev/null")
           shell_command = "#{activate_pipefail} && (#{Shellwords.shelljoin(command)}) | #{remove_ignored_lines}"
           ['/bin/bash', '-c', shell_command]
         else


### PR DESCRIPTION
If /bin/bash does not exist, system will return nil. Avoid checking
twice to reduce the total number of system calls.

https://ruby-doc.org/core-2.5.0/Kernel.html#method-i-system

> system returns true if the command gives zero exit status, false for
> non zero exit status. Returns nil if command execution fails.

Thank you for your contribution!

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
