### PR TITLE
Fix `parallel:setup` task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Fixed `NoMethodError` exception when running Rake task `parallel:setup`.
+
 ## 3.9.0 - 2022-05-22
 
 ### Added

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -126,7 +126,7 @@ end
 namespace :parallel do
   desc "Setup test databases via db:setup --> parallel:setup[num_cpus]"
   task :setup, :count do |_, args|
-    command = "#{ParallelTests::Tasks.rake_bin} db:setup RAILS_ENV=#{ParallelTests::Tasks.rails_env}"
+    command = [ParallelTests::Tasks.rake_bin, "db:setup", "RAILS_ENV=#{ParallelTests::Tasks.rails_env}"]
     ParallelTests::Tasks.run_in_parallel(ParallelTests::Tasks.suppress_schema_load_output(command), args)
   end
 

--- a/spec/fixtures/rails70/Gemfile.lock
+++ b/spec/fixtures/rails70/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    parallel_tests (3.7.3)
+    parallel_tests (3.9.0)
       parallel
 
 GEM

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -31,6 +31,7 @@ describe 'rails' do
           run ["bundle", "exec", "rake", "db:setup", "parallel:create"]
           # Also test the case where the DBs need to be dropped
           run ["bundle", "exec", "rake", "parallel:drop", "parallel:create"]
+          run ["bundle", "exec", "rake", "parallel:setup"]
           run ["bundle", "exec", "rake", "parallel:prepare"]
           run ["bundle", "exec", "rails", "runner", "User.create"], environment: { 'RAILS_ENV' => 'test' } # pollute the db
           out = run ["bundle", "exec", "rake", "parallel:prepare", "parallel:test"]


### PR DESCRIPTION
Command should be an array of strings, not a single string.

Missed in 7fd751839ee588c5fc8382027a842cf49ad0605c.

Fixes #861

Thank you for your contribution!

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
