### PR TITLE
Install spec/fixtures/**/Gemfile in frozen mode

### DIFF
--- a/spec/fixtures/rails60/Gemfile.lock
+++ b/spec/fixtures/rails60/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    parallel_tests (3.8.0)
+    parallel_tests (3.9.0)
       parallel
 
 GEM

--- a/spec/fixtures/rails61/Gemfile.lock
+++ b/spec/fixtures/rails61/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    parallel_tests (3.8.0)
+    parallel_tests (3.9.0)
       parallel
 
 GEM

--- a/spec/fixtures/rails70/Gemfile.lock
+++ b/spec/fixtures/rails70/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    parallel_tests (3.7.3)
+    parallel_tests (3.9.0)
       parallel
 
 GEM

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -26,6 +26,7 @@ describe 'rails' do
           ENV.delete("RACK_ENV")
 
           run ["bundle", "config", "--local", "path", "vendor/bundle"]
+          run ["bundle", "config", "--local", "frozen", "true"]
           run ["bundle", "install"]
           FileUtils.rm_f(Dir['db/*.sqlite3'])
           run ["bundle", "exec", "rake", "db:setup", "parallel:create"]


### PR DESCRIPTION
Through the use of `bundle install` these files change on a test run if
the parallel_tests version changes.

For example, right now parallel_tests is version 3.8.1 but is specified
as 3.8.0 in spec/fixtures/rails70/Gemfile.lock. Running rspec results in
a undesired change to this file. When submitting pull requests, it is
best practice to avoid unrelated changes, so this slightly slows down a
contributor's workflow.

Use the frozen configuration option to ensure that these files are
always up to date. If they are not, CI will fail with a useful message.

See https://bundler.io/man/bundle-config.1.html

> frozen (BUNDLE_FROZEN): Disallow changes to the Gemfile. When the
> Gemfile is changed and the lockfile has not been updated, running
> Bundler commands will be blocked. Defaults to true when --deployment
> is used.

Thank you for your contribution!

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
