### PR TITLE
Always execute a Rake subtask using the same Rake executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Added
 
+- Changed Rake subtasks to always use the same Rake executable as the parent
+  process.
+
 ### Fixed
 
 ## 3.9.1 - 2022-05-23


### PR DESCRIPTION
Rather than trying to find a suitable Rake executable, assume the
currently running Rake is the user's preferred executable. It will allow
for the most correctness in the subprocess environment.

For documentation on $0, see:
https://ruby-doc.org/core-3.1.2/doc/globals_rdoc.html

> Contains the name of the script being executed.

Thank you for your contribution!

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
