### PR TITLE
Fix rails command

### DIFF
--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -251,7 +251,7 @@ namespace :parallel do
       executable = File.expand_path('../../bin/parallel_test', __dir__)
 
       command = [*ParallelTests.with_ruby_binary(executable), type, '--type', test_framework]
-      command += ['-n', count] if count
+      command += ['-n', count.to_s] if count
       command += ['--pattern', pattern] if pattern
       command += ['--test-options', options] if options
       command << pass_through if pass_through

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -16,27 +16,58 @@ describe 'rails' do
     next if RUBY_VERSION >= "3.1.0" && rails < "rails70" # https://github.com/rails/rails/issues/43998
     next if RUBY_VERSION < "2.7.0" && rails >= "rails70"
 
-    it "can create and run #{rails}" do
-      skip 'rails fixtures are not set up for java' if RUBY_PLATFORM == "java"
+    context "without num_cpus" do
+      it "can create and run #{rails}" do
+        skip 'rails fixtures are not set up for java' if RUBY_PLATFORM == "java"
 
-      Dir.chdir("spec/fixtures/#{rails}") do
-        Bundler.with_unbundled_env do
-          # unset travis things
-          ENV.delete("RAILS_ENV")
-          ENV.delete("RACK_ENV")
+        Dir.chdir("spec/fixtures/#{rails}") do
+          Bundler.with_unbundled_env do
+            # unset travis things
+            ENV.delete("RAILS_ENV")
+            ENV.delete("RACK_ENV")
 
-          run ["bundle", "config", "--local", "path", "vendor/bundle"]
-          run ["bundle", "config", "--local", "frozen", "true"]
-          run ["bundle", "install"]
-          FileUtils.rm_f(Dir['db/*.sqlite3'])
-          run ["bundle", "exec", "rake", "db:setup", "parallel:create"]
-          # Also test the case where the DBs need to be dropped
-          run ["bundle", "exec", "rake", "parallel:drop", "parallel:create"]
-          run ["bundle", "exec", "rake", "parallel:setup"]
-          run ["bundle", "exec", "rake", "parallel:prepare"]
-          run ["bundle", "exec", "rails", "runner", "User.create"], environment: { 'RAILS_ENV' => 'test' } # pollute the db
-          out = run ["bundle", "exec", "rake", "parallel:prepare", "parallel:test"]
-          expect(out).to match(/ 2 (tests|runs)/)
+            run ["bundle", "config", "--local", "path", "vendor/bundle"]
+            run ["bundle", "config", "--local", "frozen", "true"]
+            run ["bundle", "install"]
+            FileUtils.rm_f(Dir['db/*.sqlite3'])
+            run ["bundle", "exec", "rake", "db:setup", "parallel:create"]
+            # Also test the case where the DBs need to be dropped
+            run ["bundle", "exec", "rake", "parallel:drop", "parallel:create"]
+            run ["bundle", "exec", "rake", "parallel:setup"]
+            run ["bundle", "exec", "rake", "parallel:prepare"]
+            run ["bundle", "exec", "rails", "runner", "User.create"], environment: { 'RAILS_ENV' => 'test' } # pollute the db
+            out = run ["bundle", "exec", "rake", "parallel:prepare", "parallel:test"]
+            expect(out).to match(/ 2 (tests|runs)/)
+          end
+        end
+      end
+    end
+
+    context "with num_cpus" do
+      it "can create and run #{rails}" do
+        skip 'rails fixtures are not set up for java' if RUBY_PLATFORM == "java"
+
+        num_cpus = 2
+
+        Dir.chdir("spec/fixtures/#{rails}") do
+          Bundler.with_unbundled_env do
+            # unset travis things
+            ENV.delete("RAILS_ENV")
+            ENV.delete("RACK_ENV")
+
+            run ["bundle", "config", "--local", "path", "vendor/bundle"]
+            run ["bundle", "config", "--local", "frozen", "true"]
+            run ["bundle", "install"]
+            FileUtils.rm_f(Dir['db/*.sqlite3'])
+            run ["bundle", "exec", "rake", "db:setup[#{num_cpus}]", "parallel:create[#{num_cpus}]"]
+            # Also test the case where the DBs need to be dropped
+            run ["bundle", "exec", "rake", "parallel:drop[#{num_cpus}]", "parallel:create[#{num_cpus}]"]
+            run ["bundle", "exec", "rake", "parallel:setup[#{num_cpus}]"]
+            run ["bundle", "exec", "rake", "parallel:prepare[#{num_cpus}]"]
+            run ["bundle", "exec", "rails", "runner", "User.create"], environment: { 'RAILS_ENV' => 'test' } # pollute the db
+            out = run ["bundle", "exec", "rake", "parallel:prepare[#{num_cpus}]", "parallel:test[#{num_cpus}]"]
+            expect(out).to match(/ 2 (tests|runs)/)
+          end
         end
       end
     end


### PR DESCRIPTION
When execute rails command to run tests with `num_cpus`, it fails:
```
$ bin/rails parallel:spec[2]

rails aborted!
TypeError: no implicit conversion of Integer into String
/home/my_app/vendor/bundle/ruby/3.0.0/gems/parallel_tests-3.10.0/lib/parallel_tests/tasks.rb:259:in `system'
/home/my_app/vendor/bundle/ruby/3.0.0/gems/parallel_tests-3.10.0/lib/parallel_tests/tasks.rb:259:in `block (3 levels) in <top (required)>'

...
```
This is because `Kernel.#system` only accepts `String` as an argument, but giving it `Integer`.
https://github.com/grosser/parallel_tests/blob/3f265ffc94dc82f78f9954957b0b26c9d0a7989e/lib/parallel_tests/tasks.rb#L253-L259

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
