### PR TITLE
Raise custom error when runtime log is too small

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Breaking Changes
 
+- Raise a custom `RuntimeLogTooSmallError` exception when the runtime log is too
+  small instead of a generic `RuntimeError`.
+
 ### Added
 
 ### Fixed

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -5,6 +5,8 @@ require 'parallel_tests'
 module ParallelTests
   module Test
     class Runner
+      RuntimeLogTooSmallError = Class.new(StandardError)
+
       class << self
         # --- usually overwritten by other runners
 
@@ -199,7 +201,7 @@ module ParallelTests
             allowed_missing -= 1 unless time = runtimes[test]
             if allowed_missing < 0
               log = options[:runtime_log] || runtime_log
-              raise "Runtime log file '#{log}' does not contain sufficient data to sort #{tests.size} test files, please update or remove it."
+              raise RuntimeLogTooSmallError, "Runtime log file '#{log}' does not contain sufficient data to sort #{tests.size} test files, please update or remove it."
             end
             [test, time]
           end

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -90,7 +90,7 @@ describe ParallelTests::Test::Runner do
 
       it "fails when there is too little log" do
         File.write("tmp/parallel_runtime_test.log", "xxx:123\nyyy:123\naaa:123")
-        expect { call(["aaa", "bbb", "ccc"], 3, group_by: :runtime) }.to raise_error(RuntimeError)
+        expect { call(["aaa", "bbb", "ccc"], 3, group_by: :runtime) }.to raise_error(ParallelTests::Test::Runner::RuntimeLogTooSmallError)
       end
 
       it "groups a lot of missing files when allow-missing is high" do


### PR DESCRIPTION
Currently, we raise a generic `RuntimeError` when the runtime log is too
small. This can make it hard for calling code to handle the situation.
The best that can be done is attempting to match on the string error
message.

This change introduces a custom `RuntimeLogTooSmallError` that calling
code can more easily rescue. This will make it easier for builds to log
when this event occurs or automatically retry with a different grouping
strategy.

This is a breaking change for anyone who was relying on rescuing
`RuntimeError`.

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
