### PR TITLE
bring back env replacement behavior

### DIFF
--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -86,12 +86,16 @@ module ParallelTests
         end
 
         def execute_command(cmd, process_number, num_processes, options)
+          number = test_env_number(process_number, options).to_s
           env = (options[:env] || {}).merge(
-            "TEST_ENV_NUMBER" => test_env_number(process_number, options).to_s,
+            "TEST_ENV_NUMBER" => number,
             "PARALLEL_TEST_GROUPS" => num_processes.to_s,
             "PARALLEL_PID_FILE" => ParallelTests.pid_file_path
           )
           cmd = ["nice", *cmd] if options[:nice]
+
+          # being able to run with for example `-output foo-$TEST_ENV_NUMBER` worked originally and is convenient
+          cmd.map! { |c| c.gsub("$TEST_ENV_NUMBER", number).gsub("${TEST_ENV_NUMBER}", number) }
 
           puts Shellwords.shelljoin(cmd) if report_process_command?(options) && !options[:serialize_stdout]
 

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -201,7 +201,7 @@ describe ParallelTests::CLI do
     end
   end
 
-  describe ".report_failure_rerun_commmand" do
+  describe ".report_failure_rerun_command" do
     let(:single_failed_command) { [{ exit_status: 1, command: ['foo'], seed: nil, output: 'blah' }] }
 
     it "prints nothing if there are no failures" do

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -581,6 +581,14 @@ describe ParallelTests::Test::Runner do
       end
     end
 
+    it "allows using TEST_ENV_NUMBER in arguments" do
+      run_with_file("puts ARGV") do |path|
+        result = call(["ruby", path, "$TEST_ENV_NUMBER"], 1, 4, {})
+        expect(result[:stdout].chomp).to eq '2'
+        expect(result[:exit_status]).to eq 0
+      end
+    end
+
     describe "rspec seed" do
       it "includes seed when provided" do
         run_with_file("puts 'Run options: --seed 555'") do |path|


### PR DESCRIPTION
verified with https://github.com/uyuni-project/uyuni
`rake parallel:sanity_check`