### PR TITLE
Prepend env in command output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Breaking Changes
+- The `--verbose-process-command` and `--verbose-rerun-command` are combined into `--verbose-command`. See [#884](https://github.com/grosser/parallel_tests/pull/884).
 
 ### Added
 

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -131,12 +131,12 @@ module ParallelTests
       failing_sets = test_results.reject { |r| r[:exit_status] == 0 }
       return if failing_sets.none?
 
-      if options[:verbose] || options[:verbose_rerun_command]
+      if options[:verbose] || options[:verbose_command]
         puts "\n\nTests have failed for a parallel_test group. Use the following command to run the group again:\n\n"
         failing_sets.each do |failing_set|
           command = failing_set[:command]
           command = @runner.command_with_seed(command, failing_set[:seed]) if failing_set[:seed]
-          puts Shellwords.shelljoin(command)
+          @runner.print_command(command, failing_set[:env] || {})
         end
       end
     end
@@ -261,8 +261,7 @@ module ParallelTests
         opts.on("--first-is-1", "Use \"1\" as TEST_ENV_NUMBER to not reuse the default test environment") { options[:first_is_1] = true }
         opts.on("--fail-fast", "Stop all groups when one group fails (best used with --test-options '--fail-fast' if supported") { options[:fail_fast] = true }
         opts.on("--verbose", "Print debug output") { options[:verbose] = true }
-        opts.on("--verbose-process-command", "Displays only the command that will be executed by each process") { options[:verbose_process_command] = true }
-        opts.on("--verbose-rerun-command", "When there are failures, displays the command executed by each process that failed") { options[:verbose_rerun_command] = true }
+        opts.on("--verbose-command", "Displays the command that will be executed by each process and when there are failures displays the command executed by each process that failed") { options[:verbose_command] = true }
         opts.on("--quiet", "Print only tests output") { options[:quiet] = true }
         opts.on("-v", "--version", "Show Version") do
           puts ParallelTests::VERSION

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -97,9 +97,14 @@ module ParallelTests
           # being able to run with for example `-output foo-$TEST_ENV_NUMBER` worked originally and is convenient
           cmd.map! { |c| c.gsub("$TEST_ENV_NUMBER", number).gsub("${TEST_ENV_NUMBER}", number) }
 
-          puts Shellwords.shelljoin(cmd) if report_process_command?(options) && !options[:serialize_stdout]
+          print_command(cmd, env) if report_process_command?(options) && !options[:serialize_stdout]
 
           execute_command_and_capture_output(env, cmd, options)
+        end
+
+        def print_command(command, env)
+          env_str = ['TEST_ENV_NUMBER', 'PARALLEL_TEST_GROUPS'].map { |e| "#{e}=#{env[e]}" }.join(' ')
+          puts [env_str, Shellwords.shelljoin(command)].compact.join(' ')
         end
 
         def execute_command_and_capture_output(env, cmd, options)
@@ -119,7 +124,7 @@ module ParallelTests
 
           output = "#{Shellwords.shelljoin(cmd)}\n#{output}" if report_process_command?(options) && options[:serialize_stdout]
 
-          { stdout: output, exit_status: exitstatus, command: cmd, seed: seed }
+          { env: env, stdout: output, exit_status: exitstatus, command: cmd, seed: seed }
         end
 
         def find_results(test_output)
@@ -286,7 +291,7 @@ module ParallelTests
         end
 
         def report_process_command?(options)
-          options[:verbose] || options[:verbose_process_command]
+          options[:verbose] || options[:verbose_command]
         end
       end
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -66,8 +66,8 @@ describe 'CLI' do
     end
   end
 
-  let(:printed_commands) { /specs? per process\nbundle exec rspec/ }
-  let(:printed_rerun) { "run the group again:\n\nbundle exec rspec" }
+  let(:printed_commands) { /specs? per process\nTEST_ENV_NUMBER=(\d+)? PARALLEL_TEST_GROUPS=\d+ bundle exec rspec/ }
+  let(:printed_rerun) { /run the group again:\n\nTEST_ENV_NUMBER=(\d+)? PARALLEL_TEST_GROUPS=\d+ bundle exec rspec/ }
 
   context "running tests sequentially" do
     it "exits with 0 when each run is successful" do
@@ -231,28 +231,14 @@ describe 'CLI' do
     expect(result).to include('Took')
   end
 
-  it "shows command and rerun with --verbose" do
+  it "shows command and rerun with --verbose-command" do
     write 'spec/xxx_spec.rb', 'describe("it"){it("should"){puts "TEST1"}}'
     write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){expect(1).to eq(2)}}'
-    result = run_tests ["spec", "--verbose"], type: 'rspec', fail: true
+    result = run_tests ["spec", "--verbose-command"], type: 'rspec', fail: true
     expect(result).to match printed_commands
-    expect(result).to include printed_rerun
+    expect(result).to match printed_rerun
     expect(result).to include "bundle exec rspec spec/xxx_spec.rb"
     expect(result).to include "bundle exec rspec spec/xxx2_spec.rb"
-  end
-
-  it "shows only rerun with --verbose-rerun-command" do
-    write 'spec/xxx_spec.rb', 'describe("it"){it("should"){expect(1).to eq(2)}}'
-    result = run_tests ["spec", "--verbose-rerun-command"], type: 'rspec', fail: true
-    expect(result).to include printed_rerun
-    expect(result).to_not match printed_commands
-  end
-
-  it "shows only process with --verbose-process-command" do
-    write 'spec/xxx_spec.rb', 'describe("it"){it("should"){expect(1).to eq(2)}}'
-    result = run_tests ["spec", "--verbose-process-command"], type: 'rspec', fail: true
-    expect(result).to_not include printed_rerun
-    expect(result).to match printed_commands
   end
 
   it "fails when tests fail" do


### PR DESCRIPTION
This PR combines `--verbose-process-command` and `--verbose-rerun-command` into singel `--verbose-command`.
Also `TEST_ENV_NUMBER` and `PARALLEL_TEST_GROUPS` environment variables added to command output. Useful for debugging purposes.

**Before:**
```
1 process for 1 spec, ~ 1 spec per process
bundle exec rspec spec/xxx_spec.rb
```

**After:**
```
1 process for 1 spec, ~ 1 spec per process
TEST_ENV_NUMBER= PARALLEL_TEST_GROUPS=2 bundle exec rspec spec/xxx_spec.rb
```


## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [x] Update Readme.md when cli options are changed
