### PR TITLE
Update build status badges in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,7 @@
 # parallel_tests
 
 [![Gem Version](https://badge.fury.io/rb/parallel_tests.svg)](https://rubygems.org/gems/parallel_tests)
-[![Build Status](https://travis-ci.org/grosser/parallel_tests.svg)](https://travis-ci.org/grosser/parallel_tests/builds)
-[![Build status](https://github.com/grosser/parallel_tests/workflows/windows/badge.svg)](https://github.com/grosser/parallel_tests/actions?query=workflow%3Awindows)
+[![Build status](https://github.com/grosser/parallel_tests/workflows/test/badge.svg)](https://github.com/grosser/parallel_tests/actions?query=workflow%3Atest)
 
 Speedup Test::Unit + RSpec + Cucumber + Spinach by running parallel on multiple CPU cores.<br/>
 ParallelTests splits tests into even groups (by number of lines or runtime) and runs each group in a single process with its own database.


### PR DESCRIPTION
PR updates the build status badges in the README by:
* removing the travis one (since a job hasn't run there in 2 years)
* updates the GH badge to point at the `test` workflow over `windows`

My best guess is that the README was never updated to reflect the changes from #763.
