### PR TITLE
Avoid double sending of SIGINT to subprocesses

### DIFF
--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -110,7 +110,7 @@ module ParallelTests
         def execute_command_and_capture_output(env, cmd, options)
           pid = nil
 
-          popen_options = {}
+          popen_options = { pgroup: true }
           popen_options[:err] = [:child, :out] if options[:combine_stderr]
 
           output = IO.popen(env, cmd, popen_options) do |io|


### PR DESCRIPTION
This addresses an issue when manually interrupting the test suite via Ctrl+C in the shell. In particular we've noticed that this can sometimes leave orphaned web browser processes from our selenium feature specs, which then cause various problems until manually terminated.

Tracing the problem I found that it's caused by subprocesses receiving SIGINT twice thus preventing the graceful shutdown that would normally happen. The fix prevents the shell from sending a SIGINT directly to the subprocesses leaving only one SIGINT from the interrupt handler in the `CLI` class.