### PR TITLE
fix double int without breaking stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Avoid double sending int while also not breaking debugging [#891](https://github.com/grosser/parallel_tests/pull/891)
+
 ## 4.1.0 - 2023-01-14
 
 ### Fixed

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -108,11 +108,10 @@ module ParallelTests
         end
 
         def execute_command_and_capture_output(env, cmd, options)
-          pid = nil
-
-          popen_options = { pgroup: true }
+          popen_options = {} # do not add `pgroup: true`, it will break `binding.irb` inside the test
           popen_options[:err] = [:child, :out] if options[:combine_stderr]
 
+          pid = nil
           output = IO.popen(env, cmd, popen_options) do |io|
             pid = io.pid
             ParallelTests.pids.add(pid)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -667,7 +667,10 @@ describe 'CLI' do
     # Process.kill on Windows doesn't work as expected. It kills all process group instead of just one process.
     it "passes on int signal to child processes", unless: Gem.win_platform? do
       timeout = 2
-      write "spec/test_spec.rb", "sleep #{timeout}; describe { specify { 'Should not get here' }; specify { p 'Should not get here either'} }"
+      write(
+        "spec/test_spec.rb",
+        "sleep #{timeout}; describe { specify { p 'Should not get here' }; specify { p 'Should not get here either'} }"
+      )
       pid = nil
       Thread.new { sleep timeout - 0.5; Process.kill("INT", pid) }
       result = run_tests(["spec"], processes: 2, type: 'rspec', fail: true) { |io| pid = io.pid }


### PR DESCRIPTION
reproduction:
```
source "https://rubygems.org"

gem "parallel_tests", path: "~/Code/tools/parallel_tests"
gem "minitest"
gem "rspec"

# a_spec.rb
sleep 5; describe { specify { 'Should not get here' }; specify { p 'Should not get here either'} }

# a_test.rb
require "minitest/autorun"

describe "foo" do
  it "do" do
    # binding.irb
    puts "foo"
    sleep 10
  end
end

trap("SIGINT")  do
  puts "GOT INT A"
  $stdout.flush
end
```

- run test and Ctrl+c -> 1 GOT INT
- run test and uncomment `binding.irb` shell works
- run spec and interrupt -> does not run tests

issues:
integration test fails ... I think this is because it's not a cgroup so the signal does not reach all tests
so I expect this to also happen on CI which could mean tests hang forever
also tried with `(parallel_rspec test/a_spec.rb -n 2 &)` and then `kill -int` but also worked