### PR TITLE
CI: add Ruby 3.2 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false # run all tests so we see which gem/ruby combinations break
       matrix:
-        ruby: ['2.7', '3.0', '3.1', head, jruby-head]
+        ruby: ['2.7', '3.0', '3.1', '3.2', head, jruby-head]
         os: [ubuntu-latest, windows-latest]
         task: [spec]
         include:

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'minitest', '~> 5.5.0'
 gem 'rspec', '~> 3.3'
 gem 'cucumber', "~> 4.0"
 gem 'cuke_modeler', '~> 3.6'
-gem 'spinach', git: "https://github.com/grosser/spinach.git", branch: "grosser/json" # https://github.com/codegram/spinach/pull/229
+gem 'spinach', '~> 0.12'
 gem 'rake'
 gem 'rubocop', '~> 1.28.0' # lock minor so we do not get accidental violations, also need to drop ruby 2.5 support to upgrade further
 gem 'rubocop-ast', '~> 1.17.0' # also need to drop ruby 2.5 support to remove this line

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/grosser/spinach.git
-  revision: e4e08ffd6d0877d139d602f3f5ccba3c97d69a36
-  branch: grosser/json
-  specs:
-    spinach (0.11.0)
-      colorize
-      gherkin-ruby (>= 0.3.2)
-
 PATH
   remote: .
   specs:
@@ -107,6 +98,9 @@ GEM
     rubocop-ast (1.17.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
+    spinach (0.12.0)
+      colorize
+      gherkin-ruby (>= 0.3.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     test-unit (3.5.3)
@@ -132,7 +126,7 @@ DEPENDENCIES
   rspec (~> 3.3)
   rubocop (~> 1.28.0)
   rubocop-ast (~> 1.17.0)
-  spinach!
+  spinach (~> 0.12)
   test-unit
 
 BUNDLED WITH

--- a/spec/fixtures/rails70/Gemfile.lock
+++ b/spec/fixtures/rails70/Gemfile.lock
@@ -83,14 +83,14 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.3)
+    nokogiri (1.14.1)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.3-x64-mingw32)
+    nokogiri (1.14.1-x64-mingw32)
       racc (~> 1.4)
-    nokogiri (1.13.3-x86_64-darwin)
+    nokogiri (1.14.1-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.3-x86_64-linux)
+    nokogiri (1.14.1-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
     racc (1.6.0)


### PR DESCRIPTION

Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! Let's add it to the build matrix.