### PR TITLE
Fix duplicate raise code

### DIFF
--- a/lib/parallel_tests/grouper.rb
+++ b/lib/parallel_tests/grouper.rb
@@ -27,10 +27,6 @@ module ParallelTests
         isolate_count = isolate_count(options)
 
         if isolate_count >= num_groups
-          raise 'Number of isolated processes must be less than total the number of processes'
-        end
-
-        if isolate_count >= num_groups
           raise 'Number of isolated processes must be >= total number of processes'
         end
 

--- a/spec/parallel_tests/grouper_spec.rb
+++ b/spec/parallel_tests/grouper_spec.rb
@@ -72,7 +72,7 @@ describe ParallelTests::Grouper do
       expect do
         call(3, single_process: [/1/], isolate_count: 3)
       end.to raise_error(
-        "Number of isolated processes must be less than total the number of processes"
+        "Number of isolated processes must be >= total number of processes"
       )
     end
 


### PR DESCRIPTION
We found the duplicate `raise` codes.
Looking at the git history, the last modification to these codes was this PR https://github.com/grosser/parallel_tests/pull/804 .
Therefore, we decided it would be better to use the second `raise` code and remove the first `raise` code.

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
