### PR TITLE
Fix $TEST_ENV_NUMBER replacing code to not affect all processes

### DIFF
--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -95,7 +95,7 @@ module ParallelTests
           cmd = ["nice", *cmd] if options[:nice]
 
           # being able to run with for example `-output foo-$TEST_ENV_NUMBER` worked originally and is convenient
-          cmd.map! { |c| c.gsub("$TEST_ENV_NUMBER", number).gsub("${TEST_ENV_NUMBER}", number) }
+          cmd = cmd.map { |c| c.gsub("$TEST_ENV_NUMBER", number).gsub("${TEST_ENV_NUMBER}", number) }
 
           print_command(cmd, env) if report_process_command?(options) && !options[:serialize_stdout]
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -288,6 +288,11 @@ describe 'CLI' do
       expect(result.gsub('"', '').chars.sort).to eq(['0', '2', '3', '4'])
     end
 
+    it "can exec given commands with $TEST_ENV_NUMBER" do
+      result = run_tests ['-e', 'echo foo-$TEST_ENV_NUMBER'], processes: 4
+      expect(result.split(/\n+/).sort).to eq(['foo-', 'foo-2', 'foo-3', 'foo-4'])
+    end
+
     it "can exec given command non-parallel" do
       result = run_tests(
         ['-e', 'ruby -e "sleep(rand(10)/100.0); puts ENV[:TEST_ENV_NUMBER.to_s].inspect"'],


### PR DESCRIPTION
Hi. I was trying to create a small script running some custom tests in parallel where I need the TEST_ENV_NUMBER in an other ENV variable, so I naturally tried to reassing it, something like this:

```bash
parallel_test -n 3 --first-is-1 -e 'bash -c "export CI_NODE_TOTAL=3 && export CI_NODE_INDEX=$TEST_ENV_NUMBER && echo $CI_NODE_INDEX / $CI_NODE_TOTAL"'
```

However, it printed `1 / 3` for all processes instead of `1 / 3`, `2 / 3` and `3 / 3`. Then I found [this line](https://github.com/grosser/parallel_tests/blob/f70f2ee0624a318296732cbe149468174cfdd97e/lib/parallel_tests/test/runner.rb#L98) that replaces `$TEST_ENV_NUMBER` and `${TEST_ENV_NUMBER}` with the current number by modifying the original `cmd` array which affects all the other processes as there won't be `$TEST_ENV_NUMBER` substring in them anymore.

I added one spec that initially failed on the branch and got fixed by my change, I hope I found the right place for it.

Let me know if you need anything else :)

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
