### PR TITLE
Remove compatibility with RSpec 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking Changes
 
+- Drop support for RSpec 2.
+
 ### Added
 
 ### Fixed

--- a/lib/parallel_tests/rspec/failures_logger.rb
+++ b/lib/parallel_tests/rspec/failures_logger.rb
@@ -3,22 +3,14 @@ require 'parallel_tests/rspec/logger_base'
 require 'parallel_tests/rspec/runner'
 
 class ParallelTests::RSpec::FailuresLogger < ParallelTests::RSpec::LoggerBase
-  if RSPEC_2
-    def dump_failures(*args); end
-  else
-    RSpec::Core::Formatters.register self, :dump_summary
-  end
+  RSpec::Core::Formatters.register(self, :dump_summary)
 
   def dump_summary(*args)
     lock_output do
-      if RSPEC_2
-        dump_commands_to_rerun_failed_examples
-      else
-        notification = args.first
-        unless notification.failed_examples.empty?
-          colorizer = ::RSpec::Core::Formatters::ConsoleCodes
-          output.puts notification.colorized_rerun_commands(colorizer)
-        end
+      notification = args.first
+      unless notification.failed_examples.empty?
+        colorizer = ::RSpec::Core::Formatters::ConsoleCodes
+        output.puts notification.colorized_rerun_commands(colorizer)
       end
     end
     @output.flush

--- a/lib/parallel_tests/rspec/logger_base.rb
+++ b/lib/parallel_tests/rspec/logger_base.rb
@@ -7,8 +7,6 @@ end
 require 'rspec/core/formatters/base_text_formatter'
 
 class ParallelTests::RSpec::LoggerBase < RSpec::Core::Formatters::BaseTextFormatter
-  RSPEC_2 = RSpec::Core::Version::STRING.start_with?('2')
-
   def initialize(*args)
     super
 

--- a/lib/parallel_tests/rspec/runtime_logger.rb
+++ b/lib/parallel_tests/rspec/runtime_logger.rb
@@ -9,7 +9,7 @@ class ParallelTests::RSpec::RuntimeLogger < ParallelTests::RSpec::LoggerBase
     @group_nesting = 0
   end
 
-  RSpec::Core::Formatters.register self, :example_group_started, :example_group_finished, :start_dump unless RSPEC_2
+  RSpec::Core::Formatters.register(self, :example_group_started, :example_group_finished, :start_dump)
 
   def example_group_started(example_group)
     @time = ParallelTests.now if @group_nesting == 0
@@ -20,8 +20,7 @@ class ParallelTests::RSpec::RuntimeLogger < ParallelTests::RSpec::LoggerBase
   def example_group_finished(notification)
     @group_nesting -= 1
     if @group_nesting == 0
-      path = (RSPEC_2 ? notification.file_path : notification.group.file_path)
-      @example_times[path] += ParallelTests.now - @time
+      @example_times[notification.group.file_path] += ParallelTests.now - @time
     end
     super if defined?(super)
   end

--- a/lib/parallel_tests/rspec/summary_logger.rb
+++ b/lib/parallel_tests/rspec/summary_logger.rb
@@ -2,7 +2,7 @@
 require 'parallel_tests/rspec/failures_logger'
 
 class ParallelTests::RSpec::SummaryLogger < ParallelTests::RSpec::LoggerBase
-  RSpec::Core::Formatters.register self, :dump_failures unless RSPEC_2
+  RSpec::Core::Formatters.register(self, :dump_failures)
 
   def dump_failures(*args)
     lock_output { super }

--- a/spec/parallel_tests/rspec/runtime_logger_spec.rb
+++ b/spec/parallel_tests/rspec/runtime_logger_spec.rb
@@ -19,7 +19,7 @@ describe ParallelTests::RSpec::RuntimeLogger do
       end
 
       example = double(file_path: "#{Dir.pwd}/spec/foo.rb")
-      example = double(group: example) unless ParallelTests::RSpec::RuntimeLogger::RSPEC_2
+      example = double(group: example)
 
       logger.example_group_started example
       logger.example_group_finished example


### PR DESCRIPTION
RSpec 3 was released 9 years ago. Most people will have upgraded by now 😅

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
