### PR TITLE
Upgrade RuboCop and fix some offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,6 +78,9 @@ Layout/LineLength:
   Enabled: false
   Max: 120
 
+Style/RedundantConstantBase:
+  Enabled: false
+
 Style/RegexpLiteral:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,4 @@ gem 'cucumber', "~> 4.0"
 gem 'cuke_modeler', '~> 3.6'
 gem 'spinach', '~> 0.12'
 gem 'rake'
-gem 'rubocop', '~> 1.28.0' # lock minor so we do not get accidental violations, also need to drop ruby 2.5 support to upgrade further
-gem 'rubocop-ast', '~> 1.17.0' # also need to drop ruby 2.5 support to remove this line
+gem 'rubocop', '~> 1.51.0' # lock minor so we do not get accidental violations

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,15 +53,18 @@ GEM
       cucumber-gherkin (< 23.0)
     diff-lcs (1.3)
     ffi (1.15.5)
+    ffi (1.15.5-java)
     ffi (1.15.5-x64-mingw32)
     gherkin-ruby (0.3.2)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    json (2.6.3)
+    json (2.6.3-java)
     middleware (0.1.0)
     minitest (5.5.1)
     multi_test (0.1.2)
-    parallel (1.22.1)
-    parser (3.1.2.1)
+    parallel (1.23.0)
+    parser (3.2.2.1)
       ast (~> 2.4.1)
     power_assert (2.0.1)
     protobuf-cucumber (3.10.8)
@@ -71,7 +74,7 @@ GEM
       thread_safe
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.5.0)
+    regexp_parser (2.8.0)
     rexml (3.2.5)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
@@ -86,18 +89,19 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
-    rubocop (1.28.2)
+    rubocop (1.51.0)
+      json (~> 2.3)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.17.0, < 2.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.17.0)
-      parser (>= 3.1.1.0)
-    ruby-progressbar (1.11.0)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.28.1)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
     spinach (0.12.0)
       colorize
       gherkin-ruby (>= 0.3.2)
@@ -107,12 +111,14 @@ GEM
       power_assert
     thor (1.2.1)
     thread_safe (0.3.6)
+    thread_safe (0.3.6-java)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.2.0)
+    unicode-display_width (2.4.2)
     zeitwerk (2.5.4)
 
 PLATFORMS
+  java
   ruby
   x64-mingw32
 
@@ -124,8 +130,7 @@ DEPENDENCIES
   parallel_tests!
   rake
   rspec (~> 3.3)
-  rubocop (~> 1.28.0)
-  rubocop-ast (~> 1.17.0)
+  rubocop (~> 1.51.0)
   spinach (~> 0.12)
   test-unit
 

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -258,7 +258,7 @@ module ParallelTests
           "--suffix [PATTERN]",
           <<~TEXT.rstrip.split("\n").join("\n#{newline_padding}")
             override built in test file pattern (should match suffix):
-            '_spec\.rb$' - matches rspec files
+            '_spec.rb$' - matches rspec files
             '_(test|spec).rb$' - matches test or spec files
           TEXT
         ) { |pattern| options[:suffix] = /#{pattern}/ }

--- a/lib/parallel_tests/rspec/runtime_logger.rb
+++ b/lib/parallel_tests/rspec/runtime_logger.rb
@@ -38,7 +38,7 @@ class ParallelTests::RSpec::RuntimeLogger < ParallelTests::RSpec::LoggerBase
     lock_output do
       @example_times.each do |file, time|
         relative_path = file.sub(%r{^#{Regexp.escape Dir.pwd}/}, '').sub(%r{^\./}, "")
-        @output.puts "#{relative_path}:#{time > 0 ? time : 0}"
+        @output.puts "#{relative_path}:#{[time, 0].max}"
       end
     end
     @output.flush

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -147,12 +147,12 @@ describe ParallelTests::Test::Runner do
 
         isolated, *groups = result
         expect(isolated).to eq(["aaa"])
-        actual = groups.map(&:to_set).to_set
+        actual = groups.to_set(&:to_set)
 
         # both eee and ccs are the same size, so either can be in either group
         valid_combinations = [
-          [["bbb", "eee"], ["ccc", "ddd"]].map(&:to_set).to_set,
-          [["bbb", "ccc"], ["eee", "ddd"]].map(&:to_set).to_set
+          [["bbb", "eee"], ["ccc", "ddd"]].to_set(&:to_set),
+          [["bbb", "ccc"], ["eee", "ddd"]].to_set(&:to_set)
         ]
 
         expect(valid_combinations).to include(actual)
@@ -169,12 +169,12 @@ describe ParallelTests::Test::Runner do
         isolated_1, isolated_2, *groups = result
         expect(isolated_1).to eq(["aaa2"])
         expect(isolated_2).to eq(["aaa1", "aaa3"])
-        actual = groups.map(&:to_set).to_set
+        actual = groups.to_set(&:to_set)
 
         # both eee and ccs are the same size, so either can be in either group
         valid_combinations = [
-          [["bbb", "eee"], ["ccc", "ddd"]].map(&:to_set).to_set,
-          [["bbb", "ccc"], ["eee", "ddd"]].map(&:to_set).to_set
+          [["bbb", "eee"], ["ccc", "ddd"]].to_set(&:to_set),
+          [["bbb", "ccc"], ["eee", "ddd"]].to_set(&:to_set)
         ]
 
         expect(valid_combinations).to include(actual)
@@ -191,12 +191,12 @@ describe ParallelTests::Test::Runner do
         specify_groups_1, specify_groups_2, *groups = result
         expect(specify_groups_1).to eq(["aaa2", "aaa1"])
         expect(specify_groups_2).to eq(["bbb"])
-        actual = groups.map(&:to_set).to_set
+        actual = groups.to_set(&:to_set)
 
         # both eee and ccs are the same size, so either can be in either group
         valid_combinations = [
-          [["aaa3", "ccc"], ["ddd", "eee"]].map(&:to_set).to_set,
-          [["aaa3", "eee"], ["ddd", "ccc"]].map(&:to_set).to_set
+          [["aaa3", "ccc"], ["ddd", "eee"]].to_set(&:to_set),
+          [["aaa3", "eee"], ["ddd", "ccc"]].to_set(&:to_set)
         ]
 
         expect(valid_combinations).to include(actual)


### PR DESCRIPTION
Ruby 2.5 compatibility is no longer a concern, so we can now upgrade to the very latest version.

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
