### PR TITLE
Support also feature files used by RSpec turnip gem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Support for RSpec turnip feature files.
+
 ## 4.2.2 - 2023-09-05
 
 ### Breaking Changes

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -33,8 +33,10 @@ module ParallelTests
           "spec"
         end
 
+        # used to find all _spec.rb files
+        # supports also feature files used by rspec turnip extension
         def test_suffix
-          /_spec\.rb$/
+          /(_spec\.rb|\.feature)$/
         end
 
         def line_is_result?(line)

--- a/spec/parallel_tests/rspec/runner_spec.rb
+++ b/spec/parallel_tests/rspec/runner_spec.rb
@@ -119,6 +119,12 @@ describe ParallelTests::RSpec::Runner do
       ParallelTests::RSpec::Runner.send(:find_tests, *args)
     end
 
+    it "finds turnip feature files" do
+      with_files(['a/test.feature']) do |root|
+        expect(call(["#{root}/"])).to eq(["#{root}/a/test.feature"])
+      end
+    end
+
     it "doesn't find backup files with the same name as test files" do
       with_files(['a/x_spec.rb', 'a/x_spec.rb.bak']) do |root|
         expect(call(["#{root}/"])).to eq(["#{root}/a/x_spec.rb"])


### PR DESCRIPTION
fixes https://github.com/grosser/parallel_tests/issues/271

:information_source: tested in real project as well

**before**

```
bin/parallel_rspec spec/acceptance/              
0 processes for 0 specs, ~ 0 specs per process 
```

**after**

```
bin/parallel_rspec spec/acceptance/                                                                                                             
1 process for 40 specs, ~ 40 specs per process
...
```