### PR TITLE
Add support for multiple DBs in Rails >= 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 ### Added
+- Support for running tasks against individual databases in a multi-database setup with Rails >= 6.1 ([#930](https://github.com/grosser/parallel_tests/pull/930))
 
 ## 4.4.0 - 2023-12-24
 

--- a/Readme.md
+++ b/Readme.md
@@ -32,18 +32,21 @@ test:
 
 ### Create additional database(s)
     rake parallel:create
+    rake parallel:create:secondary (create only `secondary` database if using multiple databases)
 
 ### Copy development schema (repeat after migrations)
     rake parallel:prepare
 
 ### Run migrations in additional database(s) (repeat after migrations)
     rake parallel:migrate
+    rake parallel:migrate:secondary (migrate only `secondary` database if using multiple databases)
 
 ### Setup environment from scratch (create db and loads schema, useful for CI)
     rake parallel:setup
 
 ### Drop all test databases
     rake parallel:drop
+    rake parallel:drop:secondary (drop only `secondary` database if using multiple databases)
 
 ### Run!
     rake parallel:test          # Minitest

--- a/Readme.md
+++ b/Readme.md
@@ -32,21 +32,28 @@ test:
 
 ### Create additional database(s)
     rake parallel:create
-    rake parallel:create:secondary (create only `secondary` database if using multiple databases)
+
+### (Multi-DB) Create individual database
+    rake parallel:create:<database>
+    rake parallel:create:secondary
 
 ### Copy development schema (repeat after migrations)
     rake parallel:prepare
 
 ### Run migrations in additional database(s) (repeat after migrations)
     rake parallel:migrate
-    rake parallel:migrate:secondary (migrate only `secondary` database if using multiple databases)
+
+### (Multi-DB) Run migrations in individual database
+    rake parallel:migrate:<database>
 
 ### Setup environment from scratch (create db and loads schema, useful for CI)
     rake parallel:setup
 
 ### Drop all test databases
     rake parallel:drop
-    rake parallel:drop:secondary (drop only `secondary` database if using multiple databases)
+
+### (Multi-DB) Drop individual test database
+    rake parallel:drop:<database>
 
 ### Run!
     rake parallel:test          # Minitest

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -135,10 +135,10 @@ module ParallelTests
       end
 
       def for_each_database(&block)
-        return unless defined?(ActiveRecord)
-
         # Use nil to represent all databases
         block&.call(nil)
+
+        return unless defined?(ActiveRecord)
 
         ActiveRecord::Tasks::DatabaseTasks.for_each(configured_databases) do |name|
           block&.call(name)

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -166,8 +166,13 @@ namespace :parallel do
   ParallelTests::Tasks.for_each_database do |name|
     task_name = 'create'
     task_name += ":#{name}" if name
+    description = if name
+                    "Create test #{name} database via db:#{task_name} --> parallel:#{task_name}[num_cpus]"
+                  else
+                    "Create test databases via db:#{task_name} --> parallel:#{task_name}[num_cpus]"
+                  end
 
-    desc "Create test #{name} #{'database'.pluralize(name.present? ? 1 : 2)} via db:#{task_name} --> parallel:#{task_name}[num_cpus]".squish
+    desc description
     task task_name.to_sym, :count do |_, args|
       ParallelTests::Tasks.run_in_parallel(
         [$0, "db:#{task_name}", "RAILS_ENV=#{ParallelTests::Tasks.rails_env}"],
@@ -179,8 +184,13 @@ namespace :parallel do
   ParallelTests::Tasks.for_each_database do |name|
     task_name = 'drop'
     task_name += ":#{name}" if name
+    description = if name
+                    "Drop test #{name} database via db:#{task_name} --> parallel:#{task_name}[num_cpus]"
+                  else
+                    "Drop test databases via db:#{task_name} --> parallel:#{task_name}[num_cpus]"
+                  end
 
-    desc "Drop test #{name} #{'database'.pluralize(name.present? ? 1 : 2)} via db:#{task_name} --> parallel:#{task_name}[num_cpus]".squish
+    desc description
     task task_name.to_sym, :count do |_, args|
       ParallelTests::Tasks.run_in_parallel(
         [
@@ -221,8 +231,13 @@ namespace :parallel do
   ParallelTests::Tasks.for_each_database do |name|
     task_name = 'migrate'
     task_name += ":#{name}" if name
+    description = if name
+                    "Update test #{name} database via db:#{task_name} --> parallel:#{task_name}[num_cpus]"
+                  else
+                    "Update test databases via db:#{task_name} --> parallel:#{task_name}[num_cpus]"
+                  end
 
-    desc "Update test #{name} #{'database'.pluralize(name.present? ? 1 : 2)} via db:#{task_name} --> parallel:#{task_name}[num_cpus]".squish
+    desc description
     task task_name.to_sym, :count do |_, args|
       ParallelTests::Tasks.run_in_parallel(
         [$0, "db:#{task_name}", "RAILS_ENV=#{ParallelTests::Tasks.rails_env}"],
@@ -247,7 +262,13 @@ namespace :parallel do
     task_name = 'load_schema'
     task_name += ":#{name}" if name
 
-    desc "Load dumped schema for test #{name} #{'database'.pluralize(name.present? ? 1 : 2)} via #{rails_task} --> parallel:#{task_name}[num_cpus]".squish
+    description = if name
+                    "Load dumped schema for test #{name} database via #{rails_task} --> parallel:#{task_name}[num_cpus]"
+                  else
+                    "Load dumped schema for test databases via #{rails_task} --> parallel:#{task_name}[num_cpus]"
+                  end
+
+    desc description
     task task_name.to_sym, :count do |_, args|
       command = [
         $0,

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -134,11 +134,11 @@ module ParallelTests
         @@configured_databases ||= ActiveRecord::Tasks::DatabaseTasks.setup_initial_database_yaml
       end
 
-      def for_each_database
-        return unless configured_databases.present?
+      def for_each_database(&block)
+        return unless configured_databases.present? && block_given?
 
         ActiveRecord::Tasks::DatabaseTasks.for_each(configured_databases) do |name|
-          yield name
+          block.call(name)
         end
       end
 

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -135,6 +135,8 @@ module ParallelTests
       end
 
       def for_each_database(&block)
+        return unless defined?(ActiveRecord)
+
         # Use nil to represent all databases
         block&.call(nil)
 


### PR DESCRIPTION
Added support for performing `create`, `migrate`, `drop`, and `load_schema` on individual databases when using multiple databases in Rails >= 6.1

NOTE: Will add integration tests if desired by maintainer

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [x] Update Readme.md when cli options are changed
