### PR TITLE
Fix undefined method `tags' for nil:NilClass (NoMethodError)

### DIFF
--- a/lib/parallel_tests/cucumber/scenarios.rb
+++ b/lib/parallel_tests/cucumber/scenarios.rb
@@ -48,6 +48,12 @@ module ParallelTests
             document = ::CukeModeler::FeatureFile.new(path)
             feature = document.feature
 
+            # Check if feature is not nil before proceeding
+            if feature.nil?
+              warn "No feature found in #{path}. Skipping file."
+              next
+            end
+            
             # We make an attempt to parse the gherkin document, this could be failed if the document is not well formatted
             feature_tags = feature.tags.map(&:name)
 


### PR DESCRIPTION
Fix for 

/3.2.0/gems/parallel_tests-4.4.0/lib/parallel_tests/cucumber/scenarios.rb:52:in `block in split_into_scenarios': undefined method `tags' for nil:NilClass (NoMethodError)

            feature_tags = feature.tags.map

Thank you for your contribution!

## Checklist
- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
