### PR TITLE
Make sure no error is raised when a process is already terminated

### DIFF
--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -44,6 +44,8 @@ module ParallelTests
 
     def stop_all_processes
       pids.all.each { |pid| Process.kill(:INT, pid) }
+    rescue Errno::ESRCH
+      # Process already terminated, do nothing
     end
 
     # copied from http://github.com/carlhuda/bundler Bundler::SharedHelpers#find_gemfile

--- a/spec/parallel_tests_spec.rb
+++ b/spec/parallel_tests_spec.rb
@@ -194,6 +194,13 @@ describe ParallelTests do
         expect(ParallelTests.pids.count).to eq(0)
       end
     end
+
+    it "doesn't fail if the pid has already been killed", unless: Gem.win_platform? do
+      ParallelTests.with_pid_file do
+        ParallelTests.pids.add(1234)
+        expect { ParallelTests.stop_all_processes }.not_to raise_error
+      end
+    end
   end
 
   it "has a version" do


### PR DESCRIPTION
Hey! Sometime when using `parallel_rspec --fail-fast --test-options '--fail-fast'`, it can happen that the process is already gone before `stop_all_processes` has time to kill it. In this case `Errno::ESRCH` was raised. Rescuing the error ensures that the exits happen as expected for the parent process itself.

Fix errors like that:
```
bundler: failed to load command: parallel_rspec (/Users/louim/.asdf/installs/ruby/3.0.6/bin/parallel_rspec)
/Users/louim/.gem/ruby/3.0.0/gems/parallel_tests-4.2.1/lib/parallel_tests.rb:46:in `kill': No such process (Errno::ESRCH)
	from /Users/louim/.gem/ruby/3.0.0/gems/parallel_tests-4.2.1/lib/parallel_tests.rb:46:in `block in stop_all_processes'
	from /Users/louim/.gem/ruby/3.0.0/gems/parallel_tests-4.2.1/lib/parallel_tests.rb:46:in `each'
	from /Users/louim/.gem/ruby/3.0.0/gems/parallel_tests-4.2.1/lib/parallel_tests.rb:46:in `stop_all_processes'
	from /Users/louim/.gem/ruby/3.0.0/gems/parallel_tests-4.2.1/lib/parallel_tests/cli.rb:63:in `block (4 levels) in execute_in_parallel'
	from /Users/louim/.gem/ruby/3.0.0/gems/parallel-1.23.0/lib/parallel.rb:627:in `call_with_index'
	from /Users/louim/.gem/ruby/3.0.0/gems/parallel-1.23.0/lib/parallel.rb:418:in `block (2 levels) in work_in_threads'
	from /Users/louim/.gem/ruby/3.0.0/gems/parallel-1.23.0/lib/parallel.rb:637:in `with_instrumentation'
	from /Users/louim/.gem/ruby/3.0.0/gems/parallel-1.23.0/lib/parallel.rb:417:in `block in work_in_threads'
	from /Users/louim/.gem/ruby/3.0.0/gems/parallel-1.23.0/lib/parallel.rb:219:in `block (4 levels) in in_threads'
```

Wasn't sure a changelog entry was required. Let me know if you'd like one.

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
