### PR TITLE
Allow TEST_ENV_NUMBER to support duplicate file groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Fixed
+- The `--allow-attributes` flag now runs duplicate tests in different groups
 
 ## 4.6.0 - 2024-03-25
 

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -82,8 +82,7 @@ module ParallelTests
 
         report_number_of_tests(groups) unless options[:quiet]
         test_results = execute_in_parallel(groups, groups.size, options) do |group, index|
-          test_env_number = options[:first_is_1] ? index + 1 : index
-          run_tests(group, test_env_number, num_processes, options)
+          run_tests(group, index, num_processes, options)
         end
         report_results(test_results, options) unless options[:quiet]
       end

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -394,9 +394,9 @@ describe ParallelTests::CLI do
 
       it "calls run_tests with --first-is-1" do
         options = common_options.merge(count: processes, first_is_1: true)
+        expect(subject).to receive(:run_tests).once.with(['foo'], 0, processes, options).and_return(results)
         expect(subject).to receive(:run_tests).once.with(['foo'], 1, processes, options).and_return(results)
-        expect(subject).to receive(:run_tests).once.with(['foo'], 2, processes, options).and_return(results)
-        expect(subject).to receive(:run_tests).once.with(['bar'], 3, processes, options).and_return(results)
+        expect(subject).to receive(:run_tests).once.with(['bar'], 2, processes, options).and_return(results)
         subject.run(['test', '-n', processes.to_s, '--first-is-1', '--allow-duplicates', '-t', 'my_test_runner'])
       end
     end

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -319,6 +319,7 @@ describe ParallelTests::CLI do
       before do
         allow(subject).to receive(:puts)
         expect(subject).to receive(:load_runner).with("my_test_runner").and_return(ParallelTests::MyTestRunner::Runner)
+        allow(ParallelTests::MyTestRunner::Runner).to receive(:test_file_name).and_return("test")
         expect(ParallelTests::MyTestRunner::Runner).to receive(:tests_in_groups).and_return(
           [
             ['aaa', 'bbb'],
@@ -363,53 +364,41 @@ describe ParallelTests::CLI do
 
     context 'when --allow-duplicates' do
       let(:results) { { stdout: "", exit_status: 0 } }
+      let(:processes) { 2 }
       let(:common_options) do
         { files: ['test'], allow_duplicates: true, first_is_1: false }
       end
       before do
         allow(subject).to receive(:puts)
-        expect(subject).to receive(:load_runner).with('my_test_runner').and_return(ParallelTests::MyTestRunner::Runner)
+        expect(subject).to receive(:load_runner).with("my_test_runner").and_return(ParallelTests::MyTestRunner::Runner)
+        allow(ParallelTests::MyTestRunner::Runner).to receive(:test_file_name).and_return("test")
         expect(subject).to receive(:report_results).and_return(nil)
       end
 
-      it "calls run_tests multiples times when same file is passed" do
-        options = common_options.merge(count: 4, only_group: [3, 4], group_by: :filesize)
-        expect(subject).to receive(:run_tests).once.with(['test'], 0, 1, options).and_return(results)
-        expect(subject).to receive(:run_tests).once.with(['foo'], 1, 1, options).and_return(results)
-        subject.run(['test', '-n', '4', '--allow-duplicates', '--only-group', '3,4', '-t', 'my_test_runner'])
+      before do
+        expect(ParallelTests::MyTestRunner::Runner).to receive(:tests_in_groups).and_return(
+          [
+            ['foo'],
+            ['foo'],
+            ['bar']
+          ]
+        )
       end
 
-      it "calls run_tests multiples times when same file is passed" do
-        options = common_options.merge(count: 2)
-        expect(subject).to receive(:run_tests).once.with(['foo'], 3, 2, options).and_return(results)
-        expect(subject).to receive(:run_tests).once.with(['test'], 2, 2, options).and_return(results)
-        expect(subject).to receive(:run_tests).once.with(['test'], 1, 2, options).and_return(results)
-        expect(subject).to receive(:run_tests).once.with(['test'], 0, 2, options).and_return(results)
-        subject.run(['test', '-n', '2', '--allow-duplicates', '-t', 'my_test_runner'])
+      it "calls run_tests with --only-group" do
+        options = common_options.merge(count: processes, only_group: [2, 3], group_by: :filesize)
+        expect(subject).to receive(:run_tests).once.with(['foo'], 0, 1, options).and_return(results)
+        expect(subject).to receive(:run_tests).once.with(['bar'], 1, 1, options).and_return(results)
+        subject.run(['test', '-n', processes.to_s, '--allow-duplicates', '--only-group', '2,3', '-t', 'my_test_runner'])
       end
 
-      it "also calls run_tests multiples times when same file is passed" do
-        options = common_options.merge(count: 4)
-        expect(subject).to receive(:run_tests).once.with(['foo'], 3, 4, options).and_return(results)
-        expect(subject).to receive(:run_tests).once.with(['test'], 2, 4, options).and_return(results)
-        expect(subject).to receive(:run_tests).once.with(['test'], 1, 4, options).and_return(results)
-        expect(subject).to receive(:run_tests).once.with(['test'], 0, 4, options).and_return(results)
-        subject.run(['test', '-n', '4', '--allow-duplicates', '-t', 'my_test_runner'])
+      it "calls run_tests with --first-is-1" do
+        options = common_options.merge(count: processes, first_is_1: true)
+        expect(subject).to receive(:run_tests).once.with(['foo'], 1, processes, options).and_return(results)
+        expect(subject).to receive(:run_tests).once.with(['foo'], 2, processes, options).and_return(results)
+        expect(subject).to receive(:run_tests).once.with(['bar'], 3, processes, options).and_return(results)
+        subject.run(['test', '-n', processes.to_s, '--first-is-1', '--allow-duplicates', '-t', 'my_test_runner'])
       end
-
-      it "also calls run_tests multiples times when same file is passed" do
-        options = common_options.merge(count: 4, first_is_1: true)
-        expect(subject).to receive(:run_tests).once.with(['foo'], 4, 4, options).and_return(results)
-        expect(subject).to receive(:run_tests).once.with(['test'], 3, 4, options).and_return(results)
-        expect(subject).to receive(:run_tests).once.with(['test'], 2, 4, options).and_return(results)
-        expect(subject).to receive(:run_tests).once.with(['test'], 1, 4, options).and_return(results)
-        subject.run(['test', '-n', '4', '--first-is-1', '--allow-duplicates', '-t', 'my_test_runner'])
-      end
-
-      #   # expect(subject).to receive(:run_tests).twice.and_return(results)
-      #   # expect(subject).to receive(:run_tests).twice.and_return(results)
-      #   subject.run(['test', '-n', '3', '--allow-duplicates', '--only-group', '1,2,3', '-t', 'my_test_runner'])
-      # end
     end
   end
 
@@ -442,20 +431,6 @@ end
 module ParallelTests
   module MyTestRunner
     class Runner
-      class << self
-        def test_file_name
-          "test"
-        end
-
-        def tests_in_groups(_tests, _num_groups, _options = {})
-          [
-            ['test'],
-            ['test'],
-            ['test'],
-            ['foo']
-          ]
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
This is a follow up to #940 

After that PR was merged, I was writing a little helper script that basically let me do `<script> <file>` and it would basically duplicate that file name `sysctl -n hw.ncpu`, and then run parallel_rspec w/ the `--allow-duplicates` flag.

What I discovered was that the `TEST_ENV_NUMBER` was set to the same value for each file. I traced the root behavior back to the small change I made in this PR

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [x] Update Readme.md when cli options are changed
