### PR TITLE
Use cgroups aware processor count by default

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     parallel_tests (4.7.1)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       parallel
 
 GEM
@@ -17,7 +18,7 @@ GEM
     builder (3.2.4)
     bump (0.10.0)
     colorize (1.1.0)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.3.3)
     cucumber (4.1.0)
       builder (~> 3.2, >= 3.2.3)
       cucumber-core (~> 7.1, >= 7.1.0)

--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -2,6 +2,7 @@
 require "parallel"
 require "parallel_tests/railtie" if defined? Rails::Railtie
 require "rbconfig"
+require "concurrent-ruby"
 
 module ParallelTests
   WINDOWS = (RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
@@ -17,7 +18,7 @@ module ParallelTests
       [
         count,
         ENV["PARALLEL_TEST_PROCESSORS"],
-        Parallel.processor_count
+        Concurrent.available_processor_count
       ].detect { |c| !c.to_s.strip.empty? }.to_i
     end
 

--- a/parallel_tests.gemspec
+++ b/parallel_tests.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new name, ParallelTests::VERSION do |s|
   s.license = "MIT"
   s.executables = ["parallel_spinach", "parallel_cucumber", "parallel_rspec", "parallel_test"]
   s.add_runtime_dependency "parallel"
+  s.add_runtime_dependency "concurrent-ruby", "~> 1.0", ">= 1.3.1"
   s.required_ruby_version = '>= 3.0.0'
 end

--- a/spec/parallel_tests_spec.rb
+++ b/spec/parallel_tests_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 describe ParallelTests do
   describe ".determine_number_of_processes" do
     before do
-      allow(Parallel).to receive(:processor_count).and_return 20
+      allow(Concurrent).to receive(:available_processor_count).and_return 20
     end
 
     def call(count)


### PR DESCRIPTION
## Changes

In containerized environments, a number of CPU cores isn't the same as the available CPUs. In this case, we need to consider cgroups.

`concurrent-ruby` now has the method to get that since v1.3.1. I think it's better to use this for setting more container environment friendly default value.
Ref: https://github.com/ruby-concurrency/concurrent-ruby/pull/1038

Thank you for your contribution!

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
