### PR TITLE
Check for tty with tty? instead of comparing pgid

### DIFF
--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -44,9 +44,15 @@ module ParallelTests
       #
       # The ParallelTests::Pids `synchronize` method can't be called directly from a trap,
       # using Thread workaround https://github.com/ddollar/foreman/issues/332
-      Thread.new do
-        if Gem.win_platform? || ((child_pid = ParallelTests.pids.all.first) && Process.getpgid(child_pid) != Process.pid)
-          ParallelTests.stop_all_processes
+      unless ENV['PARALLEL_TEST_INTERRUPT_MODE'] == 'never'
+        Thread.new do
+          should_interrupt = ENV['PARALLEL_TEST_INTERRUPT_MODE'] == 'always'
+          should_interrupt ||= Gem.win_platform?
+          should_interrupt ||= ((child_pid = ParallelTests.pids.all.first) && Process.getpgid(child_pid) != Process.pid)
+
+          if should_interrupt
+            ParallelTests.stop_all_processes
+          end
         end
       end
 


### PR DESCRIPTION
Hi, 

I think there's a problem with how the SIGINT forwarding works.  Checking `Process.getpgid(child_pid) != Process.pid` can be wrong in both directions:
- if executed through a task runner like `rake`, the check will pass and a second interrupt will send
  -  I put together [a small repro here](https://github.com/timreinke/actions-test)
- worse (for me at least 😄) - if the tests are executed outside a tty, it's possible for the check to fail and the signal swallowed.  

In my case, I want to perform cleanup (release selenium grid handles) when a github workflow is cancelled. If I define my step as:
```
# use exec so signals are forwarded
run: exec bundle exec parallel_cucumber ...
```

Then the `parallel_test` is group leader and `Process.getpgid(child_pid) == Process.pid`, so the signal is swallowed.

One workaround is:
```
run: |
   handle_signal() {
     kill -INT $child_pid
   }
   trap handle_signal SIGINT
   bundle exec parallel_cucumber .. &
   child_pid=$?
```

Now the runner shell remains the group leader and the check passes -- it's kind of a bother though :).  There's [a lot of discussion](https://github.com/orgs/community/discussions/26311#discussioncomment-6247156) about how github could do better, but here we are.

This changes the check to use `tty?` - which itself can be wrong (redirects in shell or command runners).   This feels like the sort of thing where someone will always be unhappy, unfortunately.  Could add an envvar as an escape hatch?

## Checklist
- [X] Feature branch is up-to-date with `master` (if not - rebase it).
- [X] Added tests.
  - Reusing existing SIGINT test for detached processes
  - Maybe the [PTY repro](https://github.com/timreinke/actions-test) could be adopted to test the tty case? Not sure if you'd want something like that in here
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
   - It might?
- [X] ~Update Readme.md when cli options are changed~
