### PR TITLE
Allow passing custom command lines as "PARALLEL_TESTS_EXECUTABLE"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Restore support for passing custom command lines as PARALLEL_TESTS_EXECUTABLE.
+
 ## 4.7.1 - 2024-04-25
 
 ### Added

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -158,7 +158,7 @@ module ParallelTests
 
         def executable
           if (executable = ENV['PARALLEL_TESTS_EXECUTABLE'])
-            [executable]
+            Shellwords.shellsplit(executable)
           else
             determine_executable
           end

--- a/parallel_tests.gemspec
+++ b/parallel_tests.gemspec
@@ -15,8 +15,6 @@ Gem::Specification.new name, ParallelTests::VERSION do |s|
     "wiki_uri" => "https://github.com/grosser/#{name}/wiki"
   }
 
-
-
   s.files = Dir["{lib,bin}/**/*"] + ["Readme.md"]
   s.license = "MIT"
   s.executables = ["parallel_spinach", "parallel_cucumber", "parallel_rspec", "parallel_test"]

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -18,6 +18,12 @@ describe ParallelTests::Test::Runner do
         expect(a).to include("script/custom_rspec")
       end
       call(['xxx'], 1, 22, {})
+
+      ENV['PARALLEL_TESTS_EXECUTABLE'] = 'ruby -Icustom_option script/custom_rspec'
+      expect(ParallelTests::Test::Runner).to receive(:execute_command) do |a, _, _, _d|
+        expect(a).to include("ruby", "-Icustom_option", "script/custom_rspec")
+      end
+      call(['xxx'], 1, 22, {})
     end
 
     it "uses options" do


### PR DESCRIPTION
This used to work until 7fd751839ee588c5fc8382027a842cf49ad0605c. I think it was an oversight so this change adds the proper shellspliting so that it keeps working.

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
