### PR TITLE
Update runner.rb - A suggested fix for 'The command line is too long.' in Windows when the number of tests are huge

### DIFF
--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -146,7 +146,6 @@ module ParallelTests
               combined_result[:stdout] = combined_result[:stdout].to_s + res[:stdout].to_s
               combined_result[:exit_status] = combined_result[:exit_status] + res[:exit_status] # just add
               combined_result[:command] = combined_result[:command] | res[:command]
-              combined_result[:seed] = res[:seed]
             end
           end
 

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -133,7 +133,7 @@ module ParallelTests
           print_command(cmd, env) if report_process_command?(options) && !options[:serialize_stdout]
 
           result = []
-          process_in_batches(cmd, 8191, options[:files].first).each do |subcmd|
+          result = process_in_batches(cmd, 8191, options[:files].first).map do |subcmd|
             result << execute_command_and_capture_output(env, subcmd, options)
           end
 

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -143,7 +143,6 @@ module ParallelTests
             if combined_result.empty?
               combined_result = res
             else
-              combined_result[:env] = res[:env]
               combined_result[:stdout] = combined_result[:stdout].to_s + res[:stdout].to_s
               combined_result[:exit_status] = combined_result[:exit_status] + res[:exit_status] # just add
               combined_result[:command] = combined_result[:command] | res[:command]


### PR DESCRIPTION
A suggested fix for 'The command line is too long.' in Windows when the number of tests are huge

Thank you for your contribution!

## Checklist
- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
