### PR TITLE
Fix output of ParallelTests::Cucumber::FailuresLogger (fixes #979)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Fix output of Cucumber failures logger. Previously, an event handler inherited from `Cucumber::Formatter::Rerun` would improperly join failures (e.g. `feature/one.feature:1feature/two.feature:1`). Now failures are separated with a single space.
+
 ## 4.9.0 - 2025-01-09
 
 ### Fixed

--- a/spec/parallel_tests/cucumber/failure_logger_spec.rb
+++ b/spec/parallel_tests/cucumber/failure_logger_spec.rb
@@ -2,44 +2,25 @@
 require 'spec_helper'
 require 'parallel_tests/gherkin/io'
 require 'parallel_tests/cucumber/failures_logger'
+require 'cucumber/configuration'
 
 describe ParallelTests::Cucumber::FailuresLogger do
-  before do
-    @output = OutputLogger.new([])
-    allow(@output).to receive(:write)
+  let(:parallel_cucumber_failures) { StringIO.new }
+  let(:config) { Cucumber::Configuration.new(out_stream: parallel_cucumber_failures) }
 
-    config = double('config', out_stream: @output, on_event: :test_run_finished)
+  let(:logger1) { ParallelTests::Cucumber::FailuresLogger.new(config) }
+  let(:logger2) { ParallelTests::Cucumber::FailuresLogger.new(config) }
 
-    @logger1 = ParallelTests::Cucumber::FailuresLogger.new(config)
-    @logger2 = ParallelTests::Cucumber::FailuresLogger.new(config)
-    @logger3 = ParallelTests::Cucumber::FailuresLogger.new(config)
+  it "should produce a list of failing scenarios" do
+    feature1 = double('feature', file: "feature/one.feature")
+    feature2 = double('feature', file: "feature/two.feature")
 
-    @feature1 = double('feature', file: "feature/path/to/feature1.feature")
-    @feature2 = double('feature', file: "feature/path/to/feature2.feature")
-    @feature3 = double('feature', file: "feature/path/to/feature3.feature")
+    logger1.instance_variable_set("@failures", { feature1.file => [1, 3] })
+    logger2.instance_variable_set("@failures", { feature2.file => [2, 4] })
 
-    @logger1.instance_variable_set("@failures", { @feature1.file => [1, 2, 3] })
-    @logger2.instance_variable_set("@failures", { @feature2.file => [2, 4, 6] })
-    @logger3.instance_variable_set("@failures", { @feature3.file => [3, 6, 9] })
-  end
+    config.event_bus.broadcast(Cucumber::Events::TestRunFinished.new)
+    parallel_cucumber_failures.rewind
 
-  it "should produce a list of lines for failing scenarios" do
-    @logger1.done
-    @logger2.done
-    @logger3.done
-
-    output_file_contents = @output.output.join("\n").concat("\n")
-
-    expect(output_file_contents).to eq <<~END
-      feature/path/to/feature1.feature:1\s
-      feature/path/to/feature1.feature:2\s
-      feature/path/to/feature1.feature:3\s
-      feature/path/to/feature2.feature:2\s
-      feature/path/to/feature2.feature:4\s
-      feature/path/to/feature2.feature:6\s
-      feature/path/to/feature3.feature:3\s
-      feature/path/to/feature3.feature:6\s
-      feature/path/to/feature3.feature:9\s
-    END
+    expect(parallel_cucumber_failures.read).to eq 'feature/one.feature:1 feature/one.feature:3 feature/two.feature:2 feature/two.feature:4 '
   end
 end


### PR DESCRIPTION
## Checklist
- [x] Feature branch is up-to-date with `master`.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
- [ ] ~Update Readme.md when cli options are changed~
