### PR TITLE
Allow setting process multiplier via ENV variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Allow processor multiplier (flag: `-m` or `--multiply-processes`) to be set via the environment variable `PARALLEL_TEST_MULTIPLE`
+
 ### Fixed
 
 ## 4.9.1 - 2025-02-19

--- a/Readme.md
+++ b/Readme.md
@@ -335,6 +335,7 @@ TIPS
    e.g. `config.cache_store = ..., namespace: "test_#{ENV['TEST_ENV_NUMBER']}"`
  - Debug errors that only happen with multiple files using `--verbose` and [cleanser](https://github.com/grosser/cleanser)
  - `export PARALLEL_TEST_PROCESSORS=13` to override default processor count
+ - `export PARALLEL_TEST_MULTIPLE=.5` to override default processor multiplier
  - Shell alias: `alias prspec='parallel_rspec -m 2 --'`
  - [Spring] Add the [spring-commands-parallel-tests](https://github.com/DocSpring/spring-commands-parallel-tests) gem to your `Gemfile` to get `parallel_tests` working with Spring.
  - `--first-is-1` will make the first environment be `1`, so you can test while running your full suite.<br/>

--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -6,6 +6,7 @@ require "rbconfig"
 module ParallelTests
   WINDOWS = (RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
   RUBY_BINARY = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])
+  DEFAULT_MULTIPLE = 1.0
 
   autoload :CLI, "parallel_tests/cli"
   autoload :VERSION, "parallel_tests/version"
@@ -19,6 +20,14 @@ module ParallelTests
         ENV["PARALLEL_TEST_PROCESSORS"],
         Parallel.processor_count
       ].detect { |c| !c.to_s.strip.empty? }.to_i
+    end
+
+    def determine_multiple(multiple)
+      [
+        multiple,
+        ENV["PARALLEL_TEST_MULTIPLE"],
+        DEFAULT_MULTIPLE,
+      ].detect { |c| !c.to_s.strip.empty? }.to_f
     end
 
     def with_pid_file

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -15,7 +15,7 @@ module ParallelTests
       ENV['DISABLE_SPRING'] ||= '1'
 
       num_processes = ParallelTests.determine_number_of_processes(options[:count])
-      num_processes *= (options[:multiply] || 1)
+      num_processes *= ParallelTests.determine_multiple(options[:multiply])
 
       options[:first_is_1] ||= first_is_1?
 

--- a/spec/parallel_tests_spec.rb
+++ b/spec/parallel_tests_spec.rb
@@ -34,6 +34,40 @@ describe ParallelTests do
     end
   end
 
+  describe ".determine_multiple" do
+    let(:default_multiple) { 1.0 }
+
+    before do
+      allow(Parallel).to receive(:multiple).and_return(default_multiple)
+    end
+
+    def call(multiple)
+      ParallelTests.determine_multiple(multiple)
+    end
+
+    it "uses the given multiple if set" do
+      expect(call('.5')).to eq(0.5)
+    end
+
+    it "uses the processor multiple from Parallel" do
+      expect(call(nil)).to eq(default_multiple)
+    end
+
+    it "uses the processor multiple from ENV before Parallel" do
+      ENV['PARALLEL_TEST_MULTIPLE'] = '0.75'
+      expect(call(nil)).to eq(0.75)
+    end
+
+    it "does not use blank multiple" do
+      expect(call('   ')).to eq(default_multiple)
+    end
+
+    it "does not use blank env" do
+      ENV['PARALLEL_TEST_MULTIPLE'] = '   '
+      expect(call(nil)).to eq(default_multiple)
+    end
+  end
+
   describe ".bundler_enabled?" do
     before do
       allow(Object).to receive(:const_defined?).with(:Bundler).and_return false


### PR DESCRIPTION
Currently the CLI accepts `-m` or `--multiply-processes` with a `COUNT` value which is a multiple applied to the number of parallel process to be spun up.

This commit adds the aditional abiity to modify `COUNT` by specifing `PARALLEL_TEST_MULTIPLE` which will be parsed into a float.

Thank you for your contribution!

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [x] Update Readme.md when cli options are changed
