### PR TITLE
Fix ParallelTests::Cucumber::FailuresLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Fixed
+- Fix Cucumber failures logger when a runner doesn't have any failed examples
 
 ## 5.0.0 - 2025-03-01
 

--- a/lib/parallel_tests/cucumber/failures_logger.rb
+++ b/lib/parallel_tests/cucumber/failures_logger.rb
@@ -20,7 +20,7 @@ module ParallelTests
 
         # Add our own handler
         config.on_event :test_run_finished do
-          return if @failures.empty?
+          next if @failures.empty?
 
           lock_output do
             @failures.each do |file, lines|

--- a/spec/parallel_tests/cucumber/failure_logger_spec.rb
+++ b/spec/parallel_tests/cucumber/failure_logger_spec.rb
@@ -10,6 +10,7 @@ describe ParallelTests::Cucumber::FailuresLogger do
 
   let(:logger1) { ParallelTests::Cucumber::FailuresLogger.new(config) }
   let(:logger2) { ParallelTests::Cucumber::FailuresLogger.new(config) }
+  let(:logger3) { ParallelTests::Cucumber::FailuresLogger.new(config) }
 
   it "should produce a list of failing scenarios" do
     feature1 = double('feature', file: "feature/one.feature")
@@ -17,6 +18,7 @@ describe ParallelTests::Cucumber::FailuresLogger do
 
     logger1.instance_variable_set("@failures", { feature1.file => [1, 3] })
     logger2.instance_variable_set("@failures", { feature2.file => [2, 4] })
+    logger3.instance_variable_set("@failures", {})
 
     config.event_bus.broadcast(Cucumber::Events::TestRunFinished.new)
     parallel_cucumber_failures.rewind


### PR DESCRIPTION
Currently, using the ParallelTests::Cucumber::FailuresLogger throws a LocalJumpError when the run doesn't have any failed examples. 

## Checklist
- [X] Feature branch is up-to-date with `master` (if not - rebase it).
- [X] Added tests.
- [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] ~Update Readme.md when cli options are changed~