### PR TITLE
enhancement: added exec-args option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Fixed
 
+## 5.3.0 - 2025-05-24
+
+### Added
+
+- The `--exec-args` option, which allows users to run shell commands in parallel with test files as arguments
+
 ## 5.2.0 - 2025-05-08
 
 - The `specify-groups` option supports reading from STDIN when set to `-`

--- a/Readme.md
+++ b/Readme.md
@@ -269,6 +269,9 @@ Options are:
                                      Only run the given group numbers.
                                      Changes `--group-by` default to 'filesize'.
     -e, --exec COMMAND               execute this code parallel and with ENV['TEST_ENV_NUMBER']
+        --exec-args COMMAND          execute this code parallel with test files as arguments, Ex.
+                                     $ parallel_tests --exec-args echo
+                                        echo spec/a_spec.rb spec/b_spec.rb
     -o, --test-options 'OPTIONS'     execute test commands with those options
     -t, --type TYPE                  test(default) / rspec / cucumber / spinach
         --suffix PATTERN             override built in test file pattern (should match suffix):

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -274,6 +274,12 @@ module ParallelTests
         ) { |groups| options[:only_group] = groups.map(&:to_i) }
 
         opts.on("-e", "--exec COMMAND", "execute this code parallel and with ENV['TEST_ENV_NUMBER']") { |arg| options[:execute] = Shellwords.shellsplit(arg) }
+        opts.on("--exec-args COMMAND",           <<~TEXT.rstrip.split("\n").join("\n#{newline_padding}")
+          execute this code parallel with test files as arguments, Ex.
+          $ parallel_tests --exec-args echo
+            echo spec/a_spec.rb spec/b_spec.rb#{' '}
+        TEXT
+        ) { |arg| options[:execute_args] = Shellwords.shellsplit(arg) }
         opts.on("-o", "--test-options 'OPTIONS'", "execute test commands with those options") { |arg| options[:test_options] = Shellwords.shellsplit(arg) }
         opts.on("-t", "--type TYPE", "test(default) / rspec / cucumber / spinach") do |type|
           @runner = load_runner(type)

--- a/lib/parallel_tests/gherkin/runner.rb
+++ b/lib/parallel_tests/gherkin/runner.rb
@@ -18,11 +18,7 @@ module ParallelTests
           options[:env] ||= {}
           options[:env] = options[:env].merge({ 'AUTOTEST' => '1' }) if $stdout.tty?
 
-          cmd = executable
-          cmd += runtime_logging if File.directory?(File.dirname(runtime_log))
-          cmd += combined_scenarios
-          cmd += cucumber_opts(options[:test_options])
-          execute_command(cmd, process_number, num_processes, options)
+          execute_command(get_cmd(combined_scenarios, options), process_number, num_processes, options)
         end
 
         def test_file_name
@@ -39,6 +35,15 @@ module ParallelTests
 
         def line_is_result?(line)
           line =~ /^\d+ (steps?|scenarios?)/
+        end
+
+        def build_cmd(file_list, options)
+          cmd = [
+            *executable,
+            *(runtime_logging if File.directory?(File.dirname(runtime_log))),
+            *file_list,
+            *cucumber_opts(options[:test_options])
+          ]
         end
 
         # cucumber has 2 result lines per test run, that cannot be added

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -6,8 +6,7 @@ module ParallelTests
     class Runner < ParallelTests::Test::Runner
       class << self
         def run_tests(test_files, process_number, num_processes, options)
-          cmd = [*executable, *options[:test_options], *color, *spec_opts, *test_files]
-          execute_command(cmd, process_number, num_processes, options)
+          execute_command(get_cmd(test_files, options), process_number, num_processes, options)
         end
 
         def determine_executable
@@ -40,6 +39,10 @@ module ParallelTests
 
         def line_is_result?(line)
           line =~ /\d+ examples?, \d+ failures?/
+        end
+
+        def build_cmd(file_list, options)
+          [*executable, *options[:test_options], *color, *spec_opts, *file_list]
         end
 
         # remove old seed and add new seed

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -28,15 +28,7 @@ module ParallelTests
 
         def run_tests(test_files, process_number, num_processes, options)
           require_list = test_files.map { |file| file.gsub(" ", "\\ ") }.join(" ")
-          cmd = [
-            *executable,
-            '-Itest',
-            '-e',
-            "%w[#{require_list}].each { |f| require %{./\#{f}} }",
-            '--',
-            *options[:test_options]
-          ]
-          execute_command(cmd, process_number, num_processes, options)
+          execute_command(get_cmd(require_list, options), process_number, num_processes, options)
         end
 
         # ignores other commands runner noise
@@ -166,6 +158,25 @@ module ParallelTests
 
         def determine_executable
           ["ruby"]
+        end
+
+        def get_cmd(file_list, options = {})
+          if options[:execute_args]
+            [*options[:execute_args], *file_list]
+          else
+            build_cmd(file_list, options)
+          end
+        end
+
+        def build_cmd(file_list, options = {})
+          [
+            *executable,
+            '-Itest',
+            '-e',
+            "%w[#{file_list}].each { |f| require %{./\#{f}} }",
+            '--',
+            *options[:test_options]
+          ]
         end
 
         def sum_up_results(results)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -335,6 +335,27 @@ describe 'CLI' do
       expect(result).not_to match(/2.*0.*2/m)
     end
 
+    it "runs command in parallel with files as arguments" do
+      write 'spec/xxx_spec.rb', 'describe("it"){it("should"){puts "TEST1"}}'
+      write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){puts "TEST2"}}'
+
+      result = run_tests "spec", type: 'rspec', add: ["--exec-args", "echo"]
+
+      expect(result).to include_exactly_times('spec/xxx_spec.rb', 1)
+      expect(result).to include_exactly_times('spec/xxx2_spec.rb', 1)
+    end
+
+    it "runs two commands in parallel with files as arguments" do
+      write 'spec/xxx_spec.rb', 'describe("it"){it("should"){puts "TEST1"}}'
+      write 'spec/xxx2_spec.rb', 'describe("it"){it("should"){puts "TEST2"}}'
+
+      result = run_tests "spec", type: 'rspec', add: ["--exec-args", "echo 'hello world' && rspec"]
+
+      expect(result).to include_exactly_times('hello world', 2)
+      expect(result).to include_exactly_times('TEST1', 1)
+      expect(result).to include_exactly_times('TEST2', 1)
+    end
+
     it "exists with success if all sub-processes returned success" do
       expect(system(*executable, '-e', 'cat /dev/null', '-n', '4')).to eq(true)
     end

--- a/spec/parallel_tests/cli_spec.rb
+++ b/spec/parallel_tests/cli_spec.rb
@@ -26,6 +26,10 @@ describe ParallelTests::CLI do
       expect(call(["--exec", "echo"])).to eq(execute: ["echo"])
     end
 
+    it "parses execute arguments" do
+      expect(call(["test", "--exec-args", "echo"])).to eq(defaults.merge(execute_args: ["echo"]))
+    end
+
     it "parses excludes pattern" do
       expect(call(["test", "--exclude-pattern", "spec/"])).to eq(defaults.merge(exclude_pattern: /spec\//))
     end


### PR DESCRIPTION
Thank you for your contribution!

## Checklist
- [X] Feature branch is up-to-date with `master` (if not - rebase it).
- [X] Added tests.
- [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [X] Update Readme.md when cli options are changed

Addresses #1007

Added `--exec-args` option, allowing users to run shell commands prior to running the tests in each process.

For example, running `bundle exec parallel_rspec ./spec/parallel_tests/ --exec-args "echo 'hello world'" -n 2 --verbose` will result in

> 2 processes for 17 specs, ~ 8 specs per process
> TEST_ENV_NUMBER= PARALLEL_TEST_GROUPS=2 echo hello\ world \&\& bundle exec rspec --color --tty spec/parallel_tests/gherkin/listener_spec.rb spec/parallel_tests/grouper_spec.rb spec/parallel_tests/rspec/failures_logger_spec.rb spec/parallel_tests/rspec/logger_base_spec.rb spec/parallel_tests/rspec/verbose_logger_spec.rb spec/parallel_tests/tasks_spec.rb spec/parallel_tests/test/runner_spec.rb spec/parallel_tests/test/runtime_logger_spec.rb
> TEST_ENV_NUMBER=2 PARALLEL_TEST_GROUPS=2 echo hello\ world \&\& bundle exec rspec --color --tty spec/parallel_tests/cli_spec.rb spec/parallel_tests/cucumber/failure_logger_spec.rb spec/parallel_tests/cucumber/runner_spec.rb spec/parallel_tests/cucumber/scenarios_spec.rb spec/parallel_tests/pids_spec.rb spec/parallel_tests/rspec/runner_spec.rb spec/parallel_tests/rspec/runtime_logger_spec.rb spec/parallel_tests/rspec/summary_logger_spec.rb spec/parallel_tests/spinach/runner_spec.rb