### PR TITLE
cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,15 @@
 
 ## Unreleased
 
+only add here if you are working on a PR
+
 ### Breaking Changes
 
 ### Added
 
-### Fixed
-
-## 5.3.0 - 2025-05-24
-
-### Added
-
 - The `--exec-args` option, which allows users to run shell commands in parallel with test files as arguments
+
+### Fixed
 
 ## 5.2.0 - 2025-05-08
 

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -273,11 +273,11 @@ module ParallelTests
           TEXT
         ) { |groups| options[:only_group] = groups.map(&:to_i) }
 
-        opts.on("-e", "--exec COMMAND", "execute this code parallel and with ENV['TEST_ENV_NUMBER']") { |arg| options[:execute] = Shellwords.shellsplit(arg) }
+        opts.on("-e", "--exec COMMAND", "execute COMMAND in parallel and with ENV['TEST_ENV_NUMBER']") { |arg| options[:execute] = Shellwords.shellsplit(arg) }
         opts.on("--exec-args COMMAND",           <<~TEXT.rstrip.split("\n").join("\n#{newline_padding}")
-          execute this code parallel with test files as arguments, Ex.
+          execute COMMAND in parallel with test files as arguments, for example:
           $ parallel_tests --exec-args echo
-            echo spec/a_spec.rb spec/b_spec.rb#{' '}
+            echo spec/a_spec.rb spec/b_spec.rb
         TEXT
         ) { |arg| options[:execute_args] = Shellwords.shellsplit(arg) }
         opts.on("-o", "--test-options 'OPTIONS'", "execute test commands with those options") { |arg| options[:test_options] = Shellwords.shellsplit(arg) }

--- a/lib/parallel_tests/gherkin/runner.rb
+++ b/lib/parallel_tests/gherkin/runner.rb
@@ -18,7 +18,7 @@ module ParallelTests
           options[:env] ||= {}
           options[:env] = options[:env].merge({ 'AUTOTEST' => '1' }) if $stdout.tty?
 
-          execute_command(get_cmd(combined_scenarios, options), process_number, num_processes, options)
+          execute_command(build_command(combined_scenarios, options), process_number, num_processes, options)
         end
 
         def test_file_name
@@ -37,8 +37,8 @@ module ParallelTests
           line =~ /^\d+ (steps?|scenarios?)/
         end
 
-        def build_cmd(file_list, options)
-          cmd = [
+        def build_test_command(file_list, options)
+          [
             *executable,
             *(runtime_logging if File.directory?(File.dirname(runtime_log))),
             *file_list,

--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -6,7 +6,7 @@ module ParallelTests
     class Runner < ParallelTests::Test::Runner
       class << self
         def run_tests(test_files, process_number, num_processes, options)
-          execute_command(get_cmd(test_files, options), process_number, num_processes, options)
+          execute_command(build_command(test_files, options), process_number, num_processes, options)
         end
 
         def determine_executable
@@ -41,7 +41,7 @@ module ParallelTests
           line =~ /\d+ examples?, \d+ failures?/
         end
 
-        def build_cmd(file_list, options)
+        def build_test_command(file_list, options)
           [*executable, *options[:test_options], *color, *spec_opts, *file_list]
         end
 

--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -28,7 +28,7 @@ module ParallelTests
 
         def run_tests(test_files, process_number, num_processes, options)
           require_list = test_files.map { |file| file.gsub(" ", "\\ ") }.join(" ")
-          execute_command(get_cmd(require_list, options), process_number, num_processes, options)
+          execute_command(build_command(require_list, options), process_number, num_processes, options)
         end
 
         # ignores other commands runner noise
@@ -160,20 +160,21 @@ module ParallelTests
           ["ruby"]
         end
 
-        def get_cmd(file_list, options = {})
+        def build_command(file_list, options)
           if options[:execute_args]
-            [*options[:execute_args], *file_list]
+            options[:execute_args] + file_list
           else
-            build_cmd(file_list, options)
+            build_test_command(file_list, options)
           end
         end
 
-        def build_cmd(file_list, options = {})
+        # load all test files, to be overwritten by other runners
+        def build_test_command(file_list, options)
           [
             *executable,
-            '-Itest',
+            '-Itest', # adding ./test directory to the load path for compatibility to common setups
             '-e',
-            "%w[#{file_list}].each { |f| require %{./\#{f}} }",
+            "%w[#{file_list}].each { |f| require %{./\#{f}} }", # using %w to keep things readable
             '--',
             *options[:test_options]
           ]


### PR DESCRIPTION
I though https://github.com/grosser/parallel_tests/pull/1008 was green and I just wanted to rename a few things ... but turns out the test is broken 🤦 

@andr3i-f  I think we need to remove the shellsplit if we want the `a && b <files>` usecase to work, that is why you added the feature right ?