### PR TITLE
handle term signal same as int signal

### DIFF
--- a/lib/parallel_tests.rb
+++ b/lib/parallel_tests.rb
@@ -56,8 +56,8 @@ module ParallelTests
       ENV.fetch('PARALLEL_PID_FILE')
     end
 
-    def stop_all_processes
-      pids.all.each { |pid| Process.kill(:INT, pid) }
+    def stop_all_processes(signal)
+      pids.all.each { |pid| Process.kill(signal, pid) }
     rescue Errno::ESRCH, Errno::EPERM
       # Process already terminated, do nothing
     end


### PR DESCRIPTION
Thank you for your contribution!

## Checklist
- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed

**Motivation:**

AWS Spot instances in EKS notify processes regarding termination by sending **TERM** signal to PID 1 of container.

It would be nice to implement proper signal propagation by pushing the signal down the script hierarchy (by trapping in each script and **kill -$signal $children_pids ; wait $children_pids** all the way down)

Managed to implement it but had to trap **TERM** sent by **AWS**, then send **INT** signal to **parallel_test** process and then **TERM** to child processes

Simplified process tree: 
```
bash run_parallel_rspec.sh # receives TERM from AWS EKS
    \_ bundle exec parallel_test -n 2 -e parallel_rspec.sh # receives INT from  run_parallel_rspec.sh trap, waits for childs
        \_ parallel_rspec.sh # receives TERM, waits for childs
            \_ bundle exec rake "knapsack_pro:queue:rspec" .... # receives TERM, propagates to children 
                 \_ ruby /bin/rake knapsack_pro:queue:rspec_go .... # receives TERM, wraps up
        \_ parallel_rspec.sh
            \_ bundle exec rake "knapsack_pro:queue:rspec" ....
                 \_ ruby /bin/rake knapsack_pro:queue:rspec_go ....
```

Maybe it would make sense to handle **SIGINT** same way as **SIGTERM** is handled - would avoid to translate to SIGINT when notifying **bundle exec parallel_test** process

NB. Copy pasted same test as for **SIGINT** (replaced with **SIGTERM**) but it fails - help welcome :) 
