### PR TITLE
Fix: test-options with tag counting wrong file entries

### DIFF
--- a/lib/parallel_tests/rspec/runner.rb
+++ b/lib/parallel_tests/rspec/runner.rb
@@ -55,11 +55,13 @@ module ParallelTests
             *test_options,
             *tests.map { |t| File.directory?(t) ? t : t.gsub(/:\d+$/, "") },
           ]
-          execute_command_and_capture_output(
-            (options[:env] || {}),
-            command,
-            options.merge(combine_stderr: false) # combine stderr breaks output parsing
-          )
+          ParallelTests.with_pid_file do
+            execute_command_and_capture_output(
+              (options[:env] || {}),
+              command,
+              options.merge(combine_stderr: false) # combine stderr breaks output parsing
+            )
+          end
 
           require "parallel_tests/rspec/runtime_json_formatter"
           RuntimeJsonFormatter.new(File.read(tmpfile.path)).example_files

--- a/lib/parallel_tests/rspec/runtime_json_formatter.rb
+++ b/lib/parallel_tests/rspec/runtime_json_formatter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "json"
+
+module ParallelTests
+  module RSpec
+    class RuntimeJsonFormatter
+      def initialize(json_output)
+        @data = JSON.parse(json_output)
+      rescue JSON::ParserError
+        @data = { "examples" => [] }
+      end
+
+      def example_files
+        @data["examples"].map { |e| e["file_path"] }.uniq
+      end
+    end
+  end
+end


### PR DESCRIPTION
Thank you for your contribution!

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
