### PR TITLE
Correct options key passed to ParallelTests.determine_multiple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ only add here if you are working on a PR
 
 ### Fixed
 
+- The `--multiply-processes` option was being parsed into `options[:multiply-processes]` but was being referenced as `options[:multiply]` in the code 
+
 ## 5.3.0 - 2025-05-30
 
 ### Added

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -15,7 +15,7 @@ module ParallelTests
       ENV['DISABLE_SPRING'] ||= '1'
 
       num_processes = ParallelTests.determine_number_of_processes(options[:count])
-      num_processes = (num_processes * ParallelTests.determine_multiple(options[:multiply])).round
+      num_processes = (num_processes * ParallelTests.determine_multiple(options[:multiply_processes])).round
 
       options[:first_is_1] ||= first_is_1?
 


### PR DESCRIPTION
The `--multiply-processes` CLI option is being parsed into `options[:multiply-processes]` but the call to `determine_multiple` was looking for it in `options[:multiply]`.

I haven't added a test for this as it seemed overkill although happy to add one if you feel it's worth it?

Thank you for your contribution!

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [-] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [x] Update Readme.md when cli options are changed
