### PR TITLE
Prioritize PARALLEL_RAILS_ENV over the standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,9 @@ only add here if you are working on a PR
 
 ### Breaking Changes
 
-- `test` is not a hardcoded environment for rake tasks
-
 ### Added
 
-- Rake tasks will prioritize the `PARALLEL_RAILS_ENV` value over the standard `RAILS_ENV`, so setups where `RAILS_ENV` changes during the process will keep the `PARALLEL_RAILS_ENV` value (see https://github.com/grosser/parallel_tests/pull/776)
+- Rake tasks will prioritize the `PARALLEL_RAILS_ENV` value over the default `test` environment
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ only add here if you are working on a PR
 
 ### Breaking Changes
 
+- `test` is not a hardcoded environment for rake tasks
+
 ### Added
+
+- Rake tasks will prioritize the `PARALLEL_RAILS_ENV` value over the standard `RAILS_ENV`, so setups where `RAILS_ENV` changes during the process will keep the `PARALLEL_RAILS_ENV` value
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ only add here if you are working on a PR
 
 ### Added
 
-- Rake tasks will prioritize the `PARALLEL_RAILS_ENV` value over the standard `RAILS_ENV`, so setups where `RAILS_ENV` changes during the process will keep the `PARALLEL_RAILS_ENV` value
+- Rake tasks will prioritize the `PARALLEL_RAILS_ENV` value over the standard `RAILS_ENV`, so setups where `RAILS_ENV` changes during the process will keep the `PARALLEL_RAILS_ENV` value (see https://github.com/grosser/parallel_tests/pull/776)
 
 ### Fixed
 

--- a/Readme.md
+++ b/Readme.md
@@ -360,6 +360,7 @@ TIPS
  - Debug errors that only happen with multiple files using `--verbose` and [cleanser](https://github.com/grosser/cleanser)
  - `export PARALLEL_TEST_PROCESSORS=13` to override default processor count
  - `export PARALLEL_TEST_MULTIPLY_PROCESSES=.5` to override default processor multiplier
+ - `export PARALLEL_RAILS_ENV=environment_name` to override default `RAILS_ENV`
  - Shell alias: `alias prspec='parallel_rspec -m 2 --'`
  - [Spring] Add the [spring-commands-parallel-tests](https://github.com/DocSpring/spring-commands-parallel-tests) gem to your `Gemfile` to get `parallel_tests` working with Spring.
  - `--first-is-1` will make the first environment be `1`, so you can test while running your full suite.<br/>

--- a/Readme.md
+++ b/Readme.md
@@ -360,7 +360,7 @@ TIPS
  - Debug errors that only happen with multiple files using `--verbose` and [cleanser](https://github.com/grosser/cleanser)
  - `export PARALLEL_TEST_PROCESSORS=13` to override default processor count
  - `export PARALLEL_TEST_MULTIPLY_PROCESSES=.5` to override default processor multiplier
- - `export PARALLEL_RAILS_ENV=environment_name` to override default `RAILS_ENV`
+ - `export PARALLEL_RAILS_ENV=environment_name` to override the default `test` environment
  - Shell alias: `alias prspec='parallel_rspec -m 2 --'`
  - [Spring] Add the [spring-commands-parallel-tests](https://github.com/DocSpring/spring-commands-parallel-tests) gem to your `Gemfile` to get `parallel_tests` working with Spring.
  - `--first-is-1` will make the first environment be `1`, so you can test while running your full suite.<br/>

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -6,7 +6,7 @@ module ParallelTests
   module Tasks
     class << self
       def rails_env
-        'test'
+        ENV['PARALLEL_RAILS_ENV'] || ENV['RAILS_ENV'] || 'test'
       end
 
       def load_lib

--- a/lib/parallel_tests/tasks.rb
+++ b/lib/parallel_tests/tasks.rb
@@ -6,7 +6,7 @@ module ParallelTests
   module Tasks
     class << self
       def rails_env
-        ENV['PARALLEL_RAILS_ENV'] || ENV['RAILS_ENV'] || 'test'
+        ENV['PARALLEL_RAILS_ENV'] || 'test'
       end
 
       def load_lib

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -42,13 +42,19 @@ describe ParallelTests::Tasks do
   end
 
   describe ".rails_env" do
-    it "should be test" do
+    it "should be test when nothing was set" do
       expect(ParallelTests::Tasks.rails_env).to eq("test")
     end
 
-    it "should disregard whatever was set" do
+    it "should be whatever was set" do
       ENV["RAILS_ENV"] = "foo"
-      expect(ParallelTests::Tasks.rails_env).to eq("test")
+      expect(ParallelTests::Tasks.rails_env).to eq("foo")
+    end
+
+    it "should prioritize the PARALLEL_RAILS_ENV value over the standard" do
+      ENV["RAILS_ENV"] = "foo"
+      ENV["PARALLEL_RAILS_ENV"] = "bar"
+      expect(ParallelTests::Tasks.rails_env).to eq("bar")
     end
   end
 

--- a/spec/parallel_tests/tasks_spec.rb
+++ b/spec/parallel_tests/tasks_spec.rb
@@ -46,13 +46,7 @@ describe ParallelTests::Tasks do
       expect(ParallelTests::Tasks.rails_env).to eq("test")
     end
 
-    it "should be whatever was set" do
-      ENV["RAILS_ENV"] = "foo"
-      expect(ParallelTests::Tasks.rails_env).to eq("foo")
-    end
-
     it "should prioritize the PARALLEL_RAILS_ENV value over the standard" do
-      ENV["RAILS_ENV"] = "foo"
       ENV["PARALLEL_RAILS_ENV"] = "bar"
       expect(ParallelTests::Tasks.rails_env).to eq("bar")
     end


### PR DESCRIPTION
Based on the debate on https://github.com/grosser/parallel_tests/issues/970, makes `ParallelTests::Tasks.rails_env` be more dynamic being able to run on different Rails environments. 

The change prioritizes the `PARALLEL_RAILS_ENV` value, if it isn't set, it defaults to `test`.

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [x] Update Readme.md when cli options are changed
