### PR TITLE
Handle signal-terminated processes in exit status

### DIFF
--- a/lib/parallel_tests/test/runner.rb
+++ b/lib/parallel_tests/test/runner.rb
@@ -110,7 +110,16 @@ module ParallelTests
             capture_output(io, env, options)
           end
           ParallelTests.pids.delete(pid) if pid
-          exitstatus = $?.exitstatus
+
+          status = $?
+          exitstatus = if status.exitstatus
+            status.exitstatus
+          elsif status.termsig
+            status.termsig + 128
+          else
+            1
+          end
+
           seed = output[/seed (\d+)/, 1]
 
           output = "#{Shellwords.shelljoin(cmd)}\n#{output}" if report_process_command?(options) && options[:serialize_stdout]

--- a/spec/parallel_tests/test/runner_spec.rb
+++ b/spec/parallel_tests/test/runner_spec.rb
@@ -564,6 +564,13 @@ describe ParallelTests::Test::Runner do
       end
     end
 
+    it "returns exit status 128 + signal number when terminated by signal", unless: Gem.win_platform? do
+      run_with_file("Process.kill('KILL', Process.pid)") do |path|
+        result = call(["ruby", path], 1, 4, {})
+        expect(result[:exit_status]).to eq 128 + 9 # SIGKILL = 9
+      end
+    end
+
     it "prints each stream to the correct stream" do
       skip "open3"
       _out, err = run_with_file("puts 123 ; $stderr.puts 345 ; exit 5") do |path|


### PR DESCRIPTION
## Problem

When a child process is terminated by a Unix signal (e.g., SIGKILL, SIGTERM), `$?.exitstatus` returns `nil` while `$?.termsig` contains the signal number. This causes downstream code to fail when comparing or aggregating exit statuses.

### Affected code paths

The following code in `cli.rb` breaks when `exit_status` is `nil`:

1. **`cli.rb:102`** - `--highest-exit-status` option:
```ruby
test_results.map { |data| data.fetch(:exit_status) }.max
```

2. **`cli.rb:120`** - `--test-file-limit` option:
```ruby
result[:exit_status] = [res[:exit_status], result[:exit_status]].max
```

Both fail with `ArgumentError: comparison of Integer with nil failed` when a test process is killed by a signal.

## Solution

In `execute_command_and_capture_output`, ensure `exit_status` is always an integer:

- Use `$?.exitstatus` for normal process termination
- Use `$?.termsig + 128` for signal termination (following Unix shell convention)
- Fall back to `1` as a defensive default

The 128 + signal convention is standard in Unix shells (e.g., bash returns 137 for SIGKILL, 143 for SIGTERM).

## Changes

- `lib/parallel_tests/test/runner.rb`: Handle nil exitstatus from signal-terminated processes
- `spec/parallel_tests/test/runner_spec.rb`: Add spec for signal termination behavior